### PR TITLE
Convert two examples to use __enter__

### DIFF
--- a/06_gpu/stable_diffusion_slackbot.py
+++ b/06_gpu/stable_diffusion_slackbot.py
@@ -70,6 +70,7 @@ volume = modal.SharedVolume().persist("stable-diff-model-vol")
 
 CACHE_PATH = "/root/model_cache"
 
+
 class StableDiffusion:
     def __enter__(self):
         from diffusers import StableDiffusionPipeline

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -42,7 +42,7 @@ CACHE_PATH = "/root/model_cache"
 # decorator, we set up a Modal [Function](/docs/reference/modal.Function) that uses GPUs,
 # has a [`SharedVolume`](/docs/guide/shared-volumes) mount, runs on a [custom container image](/docs/guide/custom-container),
 # and automatically [retries](/docs/guide/retries#function-retries) failures up to 3 times.
-# In order for the model to be loaded only once per container, we put the model in a class and use a custom `__enter__`
+# In order for the model to be loaded only once per container, we put the model in a class and use a custom `__enter__`.
 
 
 class Model:

--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -48,7 +48,7 @@ web_app = fastapi.FastAPI()
 @web_app.post("/parse")
 async def parse(request: fastapi.Request):
     # Use aio_lookup since we're in an async context.
-    parse_receipt = modal.lookup("doc_ocr_jobs", "parse_receipt")
+    parse_receipt = modal.lookup("doc_ocr_jobs", "Model.parse_receipt")
 
     form = await request.form()
     receipt = await form["receipt"].read()


### PR DESCRIPTION
By putting a method on a class and defining an `__enter__` method, you can provide container-specific initialization code:

```python
class Model:
    def __enter__(self):
        self.model = pickle.load(open("model.pickle"))

    @stub.function
    def predict(self, x):
        return self.model.predict(x)
```