### PR TITLE
Fix a11y warning on video element

### DIFF
--- a/03_scaling_out/youtube_face_detection.py
+++ b/03_scaling_out/youtube_face_detection.py
@@ -17,7 +17,12 @@
 #
 # ## The result
 #
-# <center><video controls><source src="./youtube_face_detection.mp4" type="video/mp4"></video></center>
+# <center>
+# <video controls>
+# <source src="./youtube_face_detection.mp4" type="video/mp4">
+# <track kind="captions" />
+# </video>
+# </center>
 #
 # If you watched this, we succeeded
 # [rickrolling](https://en.wikipedia.org/wiki/Rickrolling)


### PR DESCRIPTION
In the future we could develop our own `<video>` component, but for now this clears the warnings.