### PR TITLE
batch-inference: handle rare flakes in model load

### DIFF
--- a/misc/batch_inference_using_huggingface.py
+++ b/misc/batch_inference_using_huggingface.py
@@ -49,7 +49,7 @@ class SentimentAnalysis:
             model="distilbert-base-uncased-finetuned-sst-2-english"
         )
 
-    @stub.function(cpu=8)
+    @stub.function(cpu=8, retries=3)
     def predict(self, phrase: str):
         pred = self.sentiment_pipeline(phrase, truncation=True, max_length=512, top_k=2)
         # pred will look like: [{'label': 'NEGATIVE', 'score': 0.99}, {'label': 'POSITIVE', 'score': 0.01}]


### PR DESCRIPTION
Should prevent this error failing a synthetic monitoring run again:

```
│                                                                              │
│   196 │   │   sys.argv[0] = mod_spec.origin                                  │
│ ❱ 197 │   return _run_code(code, main_globals, None,                         │
│   198 │   │   │   │   │    "__main__", mod_spec)                             │
│                                                                              │
│ /var/lang/lib/python3.9/runpy.py:87 in _run_code                             │
│                                                                              │
│    86 │   │   │   │   │      __spec__ = mod_spec)                            │
│ ❱  87 │   exec(code, run_globals)                                            │
│    88 │   return run_globals                                                 │
│                                                                              │
│ /tmp/examples/misc/batch_inference_using_huggingface.py:128 in <module>      │
│                                                                              │
│   127 │   │   print("Running batch prediction...")                           │
│ ❱ 128 │   │   predictions = list(predictor.predict.map(reviews))             │
│   129                                                                        │
│                                                                              │
│ /var/task/synchronicity/synchronizer.py:268 in _run_generator_sync           │
│                                                                              │
│       ...Remote call to Modal Function (ta-a6kFpq8v6D0YS6NzB3pOKG)...        │
│                                                                              │
│ /root/misc/batch_inference_using_huggingface.py:48 in __enter__              │
│                                                                              │
│ ❱ 48 self.sentiment_pipeline = pipeline(                                     │
│                                                                              │
│                                                                              │
│ /usr/local/lib/python3.9/site-packages/transformers/pipelines/__init__.py:70 │
│ 2 in pipeline                                                                │
│                                                                              │
│ ❱ 702 framework, model = infer_framework_load_model(                         │
│                                                                              │
│                                                                              │
│ /usr/local/lib/python3.9/site-packages/transformers/pipelines/base.py:266 in │
│ infer_framework_load_model                                                   │
│                                                                              │
│ ❱ 266 raise ValueError(f"Could not load model {model} with any of the follow │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
ValueError: Could not load model distilbert-base-uncased-finetuned-sst-2-english
with any of the following classes: (<class 
'transformers.models.auto.modeling_auto.AutoModelForSequenceClassification'>, 
<class 
'transformers.models.distilbert.modeling_distilbert.DistilBertForSequenceClassif
ication'>).
```

From a reasonably thorough reading of `huggingface` source, there's not simple way to catch a specific load fail or otherwise make this more robust without retrying the whole function. 🤷 