### PR TITLE
blender_video: Retry to address GPU flakes

### DIFF
--- a/06_gpu/blender_video.py
+++ b/06_gpu/blender_video.py
@@ -99,7 +99,7 @@ if stub.is_inside():
 # Note the `gpu=True` argument which tells Modal to use GPU workers.
 
 
-@stub.function(gpu=True)
+@stub.function(gpu=True, retries=2)
 def render_frame(i):
     print(f"Using frame {i}")
 


### PR DESCRIPTION
Other GPU examples are fine, but the `blender_video` has had 4 recent failures with:

```
Fra:33 Mem:823.52M (Peak 823.57M) | Time:00:01.55 | Mem:0.00M, Peak:0.00M | Scene | Initializing
Error: Failed to create CUDA context (Not permitted)
Invalid value in cuCtxDestroy(cuContext) (device_cuda_impl.cpp:252)
Error: Failed to create CUDA context (Not permitted)
```

Adding minimal retries as a first resort.