### PR TITLE
fix: Handle get_prices() returning no prices

### DIFF
--- a/03_scaling_out/fetch_stock_prices.py
+++ b/03_scaling_out/fetch_stock_prices.py
@@ -95,8 +95,8 @@ def run():
     # Get data
     tickers = list(get_stocks())
     data = list(get_prices.map(tickers))
-    first_date = min(min(prices.keys() for symbol, prices in data))
-    last_date = max(max(prices.keys() for symbol, prices in data))
+    first_date = min((min(prices.keys()) for symbol, prices in data if prices))
+    last_date = max((max(prices.keys()) for symbol, prices in data if prices))
 
     # Plot every symbol
     for symbol, prices in data:


### PR DESCRIPTION
Fixing a couple of things. 1.

```
│ /var/task/synchronicity/synchronizer.py:398 in proxy_method                  │
│                                                                              │
│       ...Remote call to Modal Function (ta-3PRVYyfo6BpIBmjtYGUs9U)...        │
│                                                                              │
│ /root/03_scaling_out/fetch_stock_prices.py:98 in run                         │
│                                                                              │
│ ❱ 98 first_date = min(min(prices.keys() for symbol, prices in data))         │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
ValueError: min() arg is an empty sequence
```

2. The `first_date` and `last_date` calcs were actually grabbing the min timestamp from the ticker with the shortest list of prices, not the ticker with the earliest price. Looking into it, this bug actually didn't seem to matter because all tickers have the same date range.