### PR TITLE
fix: Use an EFS (NFSv4) compatible locking mechanism on shared state mutations

### DIFF
--- a/misc/covid_datasette.py
+++ b/misc/covid_datasette.py
@@ -67,6 +67,7 @@ DB_PATH = pathlib.Path(CACHE_DIR, "covid-19.db")
 @stub.function(
     image=datasette_image,
     shared_volumes={CACHE_DIR: volume},
+    retries=2,
 )
 def download_dataset(cache=True):
     import git
@@ -76,7 +77,9 @@ def download_dataset(cache=True):
         print(f"Dataset already present and {cache=}. Skipping download.")
         return
     elif REPO_DIR.exists():
-        print("Acquiring lock before deleting dataset, which can be in use by other runs.")
+        print(
+            "Acquiring lock before deleting dataset, which may be in use by other runs."
+        )
         with Lock(LOCK_FILE, default_timeout=timedelta(hours=1)):
             shutil.rmtree(REPO_DIR)
         print("Cleaned dataset before re-downloading.")


### PR DESCRIPTION
More example robustness work. I realized why this error occasionally occurs:

```
Traceback (most recent call last):
  File "/pkg/modal/_container_entrypoint.py", line 248, in handle_input_exception
    yield
  File "/pkg/modal/_container_entrypoint.py", line 337, in call_function_sync
    res = fun(*args, **kwargs)
  File "/root/misc/covid_datasette.py", line 161, in prep_db
    for i, batch in enumerate(chunks(records, size=batch_size)):
  File "/root/misc/covid_datasette.py", line 140, in <lambda>
    return iter(lambda: tuple(itertools.islice(it, size)), ())
  File "/root/misc/covid_datasette.py", line 94, in load_daily_reports
    yield from load_report(filepath)
  File "/root/misc/covid_datasette.py", line 102, in load_report
    for row in csv.DictReader(fp):
  File "/usr/local/lib/python3.9/csv.py", line 111, in __next__
    row = next(self.reader)
OSError: [Errno 116] Stale file handle
```

This morning or early afternoon an example run coincided with a cron `refresh_db()` run, and the cron run removed the csv reports data while the example run was still using that data to populate the DB.