### PR TITLE
Eliminate 1-2 word transcript segments from UI

### DIFF
--- a/misc/whisper_pod_transcriber/api.py
+++ b/misc/whisper_pod_transcriber/api.py
@@ -11,6 +11,7 @@ from .main import (
     process_episode,
     search_podcast,
 )
+from .podcast import coalesce_short_transcript_segments
 
 web_app = FastAPI()
 
@@ -29,7 +30,7 @@ async def get_episode(podcast_id: str, episode_guid_hash: str):
     with open(transcription_path, "r") as f:
         data = json.load(f)
 
-    return dict(metadata=metadata, segments=data["segments"])
+    return dict(metadata=metadata, segments=coalesce_short_transcript_segments(data["segments"]))
 
 
 @web_app.get("/api/podcast/{podcast_id}")

--- a/misc/whisper_pod_transcriber/podcast.py
+++ b/misc/whisper_pod_transcriber/podcast.py
@@ -2,7 +2,9 @@ import dataclasses
 import os
 import pathlib
 import urllib.request
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple, Optional, TypedDict, Union
+
+Segment = TypedDict('Segment', {'text': str, 'start': float, "end": float})
 
 
 @dataclasses.dataclass
@@ -253,3 +255,32 @@ def store_original_audio(url: str, destination: pathlib.Path, overwrite: bool = 
     with open(destination, "wb") as f:
         f.write(podcast_download_result.data)
     print(f"Stored audio episode at {destination}.")
+
+
+def coalesce_short_transcript_segments(segments: list[Segment]) -> list[Segment]:
+    """
+    Some extracted transcript segments from openai/whisper are really short, like even just one word.
+    This function accepts a minimum segment length and combines short segments until the minimum is reached. 
+    """
+    minimum_transcript_len = 200  # About 2 sentences.
+    previous = None
+    long_enough_segments = []
+    for current in segments:
+        if previous is None:
+            previous = current
+        elif len(previous["text"]) < minimum_transcript_len:
+            previous = _merge_segments(left=previous, right=current)
+        else:
+            long_enough_segments.append(previous)
+            previous = current
+    if previous:
+        long_enough_segments.append(previous)
+    return long_enough_segments
+
+
+def _merge_segments(left: Segment, right: Segment) -> Segment:
+    return {
+        "text": left["text"] + " " + right["text"],
+        "start": left["start"],
+        "end": right["end"],
+    }


### PR DESCRIPTION
Merges short segments together at runtime, which is probably the right place to do it as this new function all strips out keys that are present in the original segment items.

See the before/after images below.

<details closed>
<summary><strong>Before</strong></summary>
<br>
<img width="964" alt="image" src="https://user-images.githubusercontent.com/12058921/196574648-1ff86a6b-69e7-42f4-ab9e-8406717f100f.png">
</details>

<details closed>
<summary><strong>After</strong></summary>
<br>
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/12058921/196574447-f2637616-88d5-47b3-add5-273e0c5bbad9.png">
</details>
