### PR TITLE
Refer to /apps instead of /deployments

### DIFF
--- a/04_secrets/db_to_sheet.py
+++ b/04_secrets/db_to_sheet.py
@@ -192,8 +192,8 @@ def db_to_sheet():
         print(f"{weather}: {count}")
 
 
-# This entire stub can now be deployed using `modal app deploy db_to_sheet.py`. The [deployments page](/deployments)
-# shows our cron job's execution history and logs.
+# This entire stub can now be deployed using `modal app deploy db_to_sheet.py`. The [apps page](/apps)
+# shows our cron job's execution history and lets you navigate to each invocation's logs.
 # Just to make it easy, we can also add a simple entrypoint so you can run it locally
 
 if __name__ == "__main__":

--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -98,5 +98,5 @@ if __name__ == "__main__":
 # If you run this script, it will search Hacker News ones. In order to deploy this
 # as a persistent cron job, you can run `modal app deploy hackernews_alerts.py`,
 
-# Once the job is deployed, visit the [deployments page](/deployments) page to see
+# Once the job is deployed, visit the [apps page](/apps) page to see
 # its execution history, logs and other stats.


### PR DESCRIPTION
To be merged when the reworked apps page is going live