### PR TITLE
whisper: Add top-left home button for easier app navigation

### DIFF
--- a/misc/whisper_pod_transcriber/whisper_frontend/src/components/HomeButton.tsx
+++ b/misc/whisper_pod_transcriber/whisper_frontend/src/components/HomeButton.tsx
@@ -1,0 +1,9 @@
+import { Link } from "react-router-dom";
+
+export default function HomeButton() {
+  return (
+    <button className="lg:fixed top-0 left-0 right-0 w-20 m-5 mb-0 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+        <Link to="/">Home</Link>
+    </button>
+  );
+}

--- a/misc/whisper_pod_transcriber/whisper_frontend/src/routes/episode.tsx
+++ b/misc/whisper_pod_transcriber/whisper_frontend/src/routes/episode.tsx
@@ -1,4 +1,5 @@
 import useSWR, { useSWRConfig } from "swr";
+import HomeButton from "../components/HomeButton";
 import Spinner from "../components/Spinner";
 import { Link } from "react-router-dom";
 import { useCallback, useState, useEffect } from "react";
@@ -218,6 +219,7 @@ export default function Podcast() {
 
   return (
     <div className="flex flex-col">
+      <HomeButton/>
       <div className="mx-auto max-w-4xl mt-4 py-8 rounded overflow-hidden shadow-lg">
         <div className="px-6 py-4">
           <Link

--- a/misc/whisper_pod_transcriber/whisper_frontend/src/routes/podcast.tsx
+++ b/misc/whisper_pod_transcriber/whisper_frontend/src/routes/podcast.tsx
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 import { useParams } from "react-router-dom";
 import { Link } from "react-router-dom";
+import HomeButton from "../components/HomeButton";
 import Spinner from "../components/Spinner";
 
 function Epsiode({
@@ -54,6 +55,7 @@ export default function Podcast() {
 
   return (
     <div>
+      <HomeButton />
       <div className="mx-auto max-w-4xl mt-4 py-8 rounded overflow-hidden shadow-lg">
         <div className="px-6 py-4">
           <div className="font-bold text-xl">{data.pod_metadata.title}</div>


### PR DESCRIPTION
Was finding it a bit annoying to navigate back to search after transcribing an episode.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/12058921/197363770-72af10f3-243c-40de-8df7-61f547accdd5.png">
