### PR TITLE
Use Python 3.9 in Github Actions, as we do locally.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
       - name: Install Modal client package and jupytext
         run: pip install modal-client jupytext
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      
+      - uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
 
       - name: Install black
         run: pip install black

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v3
       
       - uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
+        with:
+          python-version: "3.9"
 
       - name: Install black
         run: pip install black
@@ -26,6 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
       - name: Install flake8
         run: pip install flake8
 
@@ -37,6 +41,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
       - name: Install isort
         run: pip install isort
 
@@ -49,6 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
 
       - name: Install dev dependencies
         run: pip install pytest jupytext


### PR DESCRIPTION
The current Python version used does not support built-ins as type annotations, so [my deploy script is failing](https://github.com/modal-labs/modal-examples/actions/runs/3395370990/jobs/5645167212).