### PR TITLE
better debug on deploy fail

### DIFF
--- a/example_deploy.py
+++ b/example_deploy.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import re
 import shlex
 import subprocess
@@ -35,7 +34,6 @@ def deploy(
             shlex.split(deploy_command),
             cwd=module_with_stub.parent,
             capture_output=True,
-            env=dict({"TERM": "dumb", "NO_COLOR": "1"}, **os.environ),
         )
         if r.returncode != 0:
             print(f"⚠️ deployment failed: '{module_with_stub.name}'", file=sys.stderr)

--- a/example_deploy.py
+++ b/example_deploy.py
@@ -29,7 +29,9 @@ def deploy(
         print(f"🌵  dry-run: '{module_with_stub.name}' would have deployed")
     else:
         print(f"⛴ deploying: '{module_with_stub.name}' ...")
-        r = subprocess.run(shlex.split(deploy_command), cwd=module_with_stub.parent, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        r = subprocess.run(
+            shlex.split(deploy_command), cwd=module_with_stub.parent, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
         if r.returncode != 0:
             print(f"⚠️ deployment failed: '{module_with_stub.name}'", file=sys.stderr)
             print(r.stdout)

--- a/example_deploy.py
+++ b/example_deploy.py
@@ -10,8 +10,7 @@ from example_utils import get_examples, ExampleType
 
 
 class DeployError(NamedTuple):
-    stdout: str
-    stderr: str
+    logs: str
     code: int
 
 
@@ -30,10 +29,11 @@ def deploy(
         print(f"🌵  dry-run: '{module_with_stub.name}' would have deployed")
     else:
         print(f"⛴ deploying: '{module_with_stub.name}' ...")
-        r = subprocess.run(shlex.split(deploy_command), cwd=module_with_stub.parent, capture_output=True)
+        r = subprocess.run(shlex.split(deploy_command), cwd=module_with_stub.parent, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if r.returncode != 0:
             print(f"⚠️ deployment failed: '{module_with_stub.name}'", file=sys.stderr)
-            return DeployError(stdout=r.stdout, stderr=r.stderr, code=r.returncode)
+            print(r.stdout)
+            return DeployError(logs=r.stdout, code=r.returncode)
         else:
             print(f"✔️ deployed '{module_with_stub.name}")
     return None


### PR DESCRIPTION
Deployment is failing in Github Actions and I can't see why. Making this change to _actually_ log what happened in the deploy 😖.

The stderr output is quite ugly right now because there's no way (that I know of) to turn of the fancy `rich` tracebacks. Those get mangled in the subprocess.