### PR TITLE
Improve reliability of whisper demo

### DIFF
--- a/misc/whisper_pod_transcriber/api.py
+++ b/misc/whisper_pod_transcriber/api.py
@@ -1,4 +1,5 @@
 import json
+import urllib
 from typing import List
 
 from fastapi import FastAPI, Request
@@ -92,11 +93,23 @@ async def transcribe_job(podcast_id: str, episode_id: str):
 
 @web_app.get("/api/status/{call_id}")
 async def poll_status(call_id: str):
+    import modal.exception
     from modal._call_graph import InputInfo, InputStatus
     from modal.functions import FunctionCall
 
     function_call = FunctionCall.from_id(call_id)
     graph: List[InputInfo] = function_call.get_call_graph()
+
+    try:
+        res = function_call.get(timeout=0.1)
+    except TimeoutError:
+        pass
+    except modal.exception.RemoteError as exc:
+        if exc.args:
+            inner_exc = exc.args[0]
+            if "HTTPError 403" in inner_exc:
+                return dict(error="permission denied on podcast audio download")
+        return dict(error="unknown job processing error")
 
     try:
         map_root = graph[0].children[0].children[0]

--- a/misc/whisper_pod_transcriber/api.py
+++ b/misc/whisper_pod_transcriber/api.py
@@ -1,5 +1,4 @@
 import json
-import urllib
 from typing import List
 
 from fastapi import FastAPI, Request
@@ -101,7 +100,7 @@ async def poll_status(call_id: str):
     graph: List[InputInfo] = function_call.get_call_graph()
 
     try:
-        res = function_call.get(timeout=0.1)
+        function_call.get(timeout=0.1)
     except TimeoutError:
         pass
     except modal.exception.RemoteError as exc:

--- a/misc/whisper_pod_transcriber/podcast.py
+++ b/misc/whisper_pod_transcriber/podcast.py
@@ -50,7 +50,15 @@ class DownloadResult(NamedTuple):
 
 
 def download_podcast_file(url: str) -> DownloadResult:
-    with urllib.request.urlopen(url) as response:
+    req = urllib.request.Request(
+        url,
+        data=None,
+        # Set a user agent to avoid 403 response from some podcast audio servers.
+        headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
+        },
+    )
+    with urllib.request.urlopen(req) as response:
         return DownloadResult(
             data=response.read(),
             content_type=response.headers["content-type"],

--- a/misc/whisper_pod_transcriber/whisper_frontend/src/routes/episode.tsx
+++ b/misc/whisper_pod_transcriber/whisper_frontend/src/routes/episode.tsx
@@ -87,6 +87,15 @@ function Segment({ segment, metadata }: { segment: any; metadata: any }) {
   );
 }
 
+function ErrorCallout({msg}: {msg: string}) {
+  return (
+    <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+      <strong className="font-bold">Error: </strong>
+      <span className="block sm:inline">{msg}</span>
+    </div>
+  );
+}
+
 interface Status {
   done_segments: number;
   total_segments: number;
@@ -101,6 +110,7 @@ function TranscribeProgress({
   onFinished: () => void;
 }) {
   const [finished, setFinished] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
   const [status, setStatus] = useState<Status>();
   const [intervalId, setIntervalId] = useState<number>();
 
@@ -113,6 +123,11 @@ function TranscribeProgress({
     async function updateStatus() {
       const resp = await fetch(`/api/status/${callId}`);
       const body = await resp.json();
+      if (body.error) {
+        setError(body.error);
+        setFinished(true);
+      }
+
       setStatus(body);
       if (body.finished) {
         setFinished(true);
@@ -128,6 +143,8 @@ function TranscribeProgress({
   }, [finished]);
 
   let containerCount = status?.tasks ?? 0;
+
+  if (error) return <ErrorCallout msg={error} />;
 
   return (
     <div className="flex flex-col content-center">


### PR DESCRIPTION
* **Set a user agent**. Failing to download the audio with 403 is probably the most common error. I had someone message me about the demo not working and I'm betting this was the reason.
* **Handle errors in the UI**. Previously the UI would just get into a loop showing 0 containers running and never show the user that the transcription had failed. That's fixed now, and how it looks is shown below:

![new-error-handling](https://user-images.githubusercontent.com/12058921/200139335-8a43ca1a-3b72-4f68-940d-50853dbf90fe.png)

---

I don't offer a nice way for a user to proceed after getting an error, but this is good enough for now. 