### PR TITLE
whisper fixes: bad link and avoid race condition on podcast load

### DIFF
--- a/misc/whisper_pod_transcriber/api.py
+++ b/misc/whisper_pod_transcriber/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import List
 
@@ -36,12 +37,15 @@ async def get_episode(podcast_id: str, episode_guid_hash: str):
 @web_app.get("/api/podcast/{podcast_id}")
 async def get_podcast(podcast_id: str):
     pod_metadata_path = config.PODCAST_METADATA_DIR / podcast_id / "metadata.json"
-
+    previously_stored = True
     if not pod_metadata_path.exists():
+        previously_stored = False
+        # This runs a Modal function in a separate container in the cloud, so
+        # were exposed to a race condition with the NFS if we don't wait for the write
+        # to propogate.
         populate_podcast_metadata(podcast_id)
-    else:
-        # Refresh async.
-        populate_podcast_metadata.submit(podcast_id)
+        while not pod_metadata_path.exists():
+            await asyncio.sleep(20)
 
     with open(pod_metadata_path, "r") as f:
         pod_metadata = json.load(f)
@@ -58,6 +62,9 @@ async def get_podcast(podcast_id: str):
 
     episodes.sort(key=lambda ep: ep.get("publish_date"), reverse=True)
 
+    # Refresh possibly stale data asynchronously.
+    if previously_stored:
+        populate_podcast_metadata.submit(podcast_id)
     return dict(pod_metadata=pod_metadata, episodes=episodes)
 
 

--- a/misc/whisper_pod_transcriber/whisper_frontend/src/app.tsx
+++ b/misc/whisper_pod_transcriber/whisper_frontend/src/app.tsx
@@ -75,7 +75,7 @@ function Form({ onSubmit, searching }) {
         </p>  
         <p className="mb-1">
           <span>If you just want to see some transcripts, we ❤️ these tech podcasts: </span>
-          <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/972209"><em>On The Metal</em></a> and <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/972209"><em>CoRecursive</em></a>. 
+          <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/972209"><em>On The Metal</em></a> and <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/603405"><em>CoRecursive</em></a>. 
         </p>
       </div>
 

--- a/misc/whisper_pod_transcriber/whisper_frontend/src/routes/podcast.tsx
+++ b/misc/whisper_pod_transcriber/whisper_frontend/src/routes/podcast.tsx
@@ -2,7 +2,6 @@ import useSWR from "swr";
 import { useParams } from "react-router-dom";
 import { Link } from "react-router-dom";
 import HomeButton from "../components/HomeButton";
-import Footer from "../components/Footer";
 import Spinner from "../components/Spinner";
 
 function Episode({


### PR DESCRIPTION
* Fix a misdirecting link on front page
* Remove unused import
* Avoid race condition that was causing errors like `FileNotFoundError: [Errno 2] No such file or directory: '/cache/podcast_metadata/649594/metadata.json'` to show up as 500s in the client.