### PR TITLE
fix: expire in-progress transcription jobs

### DIFF
--- a/ml/whisper_pod_transcriber/api.py
+++ b/ml/whisper_pod_transcriber/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
-from typing import List
+import time
+from typing import List, NamedTuple
 
 from fastapi import FastAPI, Request
 
@@ -16,6 +17,14 @@ from .podcast import coalesce_short_transcript_segments
 
 logger = config.get_logger(__name__)
 web_app = FastAPI()
+
+# A transcription taking > 10 minutes should be exceedingly rare.
+MAX_JOB_AGE_SECS = 10 * 60
+
+
+class InProgressJob(NamedTuple):
+    call_id: str
+    start_time: int
 
 
 @web_app.get("/api/episode/{podcast_id}/{episode_guid_hash}")
@@ -85,15 +94,19 @@ async def podcasts_endpoint(request: Request):
 async def transcribe_job(podcast_id: str, episode_id: str):
     from modal import container_app
 
+    now = int(time.time())
     try:
-        existing_call_id = container_app.in_progress[episode_id]
-        logger.info(f"Found existing call ID {existing_call_id} for episode {episode_id}")
-        return {"call_id": existing_call_id}
+        inprogress_job = container_app.in_progress[episode_id]
+        # NB: runtime type check is to handle present of old `str` values that didn't expire.
+        if isinstance(inprogress_job, tuple) and (now - inprogress_job.start_time) < MAX_JOB_AGE_SECS:
+            existing_call_id = inprogress_job.call_id
+            logger.info(f"Found existing, unexpired call ID {existing_call_id} for episode {episode_id}")
+            return {"call_id": existing_call_id}
     except KeyError:
         pass
 
     call = process_episode.submit(podcast_id, episode_id)
-    container_app.in_progress[episode_id] = call.object_id
+    container_app.in_progress[episode_id] = InProgressJob(call_id=call.object_id, start_time=now)
 
     return {"call_id": call.object_id}
 

--- a/ml/whisper_pod_transcriber/main.py
+++ b/ml/whisper_pod_transcriber/main.py
@@ -402,7 +402,7 @@ def fetch_episodes(show_name: str, podcast_id: str, max_episodes=100):
             original_download_link=ep["audioUrl"],
         )
         for ep in episodes_raw
-        if "guid" in ep
+        if "guid" in ep and ep["guid"] is not None
     ]
     no_guid_count = len(episodes) - len(episodes_raw)
     logger.info(f"{no_guid_count} episodes had no GUID and couldn't be used.")


### PR DESCRIPTION
We use a `modal.Dict` to avoid running multiple transcription jobs for the same podcast and provide a nice user experience on hard-refresh of the browser. _But_, we never expire the `Dict` values, and in the worst case this causes the following error: 

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/12058921/203642067-f92d96c3-d141-4924-b351-e7b14c6450f2.png">

The input ID is presumably so old that its been deleted from DB. 