### PR TITLE
Add a minimal PyTorch GPU example

### DIFF
--- a/06_gpu/import_torch.py
+++ b/06_gpu/import_torch.py
@@ -1,0 +1,31 @@
+# # PyTorch with CUDA GPU support
+#
+# This example shows how you can use CUDA GPUs in Modal, with a minimal PyTorch
+# image. You can specify GPU requirements in the `stub.function` decorator.
+
+import time
+
+import modal
+
+stub = modal.Stub(
+    "example-import-torch",
+    image=modal.Image.debian_slim().pip_install(["torch"], "https://download.pytorch.org/whl/cu116"),
+)
+
+
+@stub.function(gpu=True)
+def gpu_function():
+    import subprocess
+    import torch
+
+    subprocess.run(["nvidia-smi"])
+    print("Torch version:", torch.__version__)
+    print("CUDA available:", torch.cuda.is_available())
+    print("CUDA device count:", torch.cuda.device_count())
+
+
+if __name__ == "__main__":
+    t0 = time.time()
+    with stub.run():
+        gpu_function()
+    print("Full time spent:", time.time() - t0)


### PR DESCRIPTION
I noticed that we didn't have a minimal GPU example, and all the examples in the `06_gpu` folder were more complex programs, so I added a simple one with just the boilerplate.

If someone just wants to quickly run something on a GPU, I can link them this. Perhaps we could link the code from the https://modal.com/docs/guide/gpu page too?