### PR TITLE
Optimized Stable Diffusion 1.5 example with CLI

### DIFF
--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -71,7 +71,7 @@ if stub.is_inside():
 # This is our Modal function. The function runs through the `StableDiffusionPipeline` pipeline.
 # It sends the PIL image back to our CLI where we save the resulting image in a local file.
 
-@stub.function(gpu=modal.gpu.A100())
+@stub.function(gpu=True)
 def _run_inference(prompt:str) -> str:
     with torch.inference_mode():
         with torch.autocast("cuda"):

--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -10,6 +10,7 @@
 
 # ## Basic setup
 import modal
+from pathlib import Path
 
 # All Modal programs need a [`Stub`](/docs/reference/modal.Stub) — an object that acts as a recipe for
 # the application. Let's give it a friendly name.
@@ -29,11 +30,12 @@ app = typer.Typer()
 # into the image. This is technique that allows you to load models much faster
 # by using our [high-performance blob storage file server](https://github.com/modal-labs/blobnet).
 
-image = modal.Image.debian_slim().apt_install(["curl"]).run_commands(
-    [
-    "pip install torch --extra-index-url https://download.pytorch.org/whl/cu117",
-    "pip install diffusers[torch] transformers ftfy accelerate"]
-).run_commands([
+image = modal.Image.conda().apt_install(["curl"]).run_commands([
+    "conda install xformers -c xformers/label/dev",
+    "conda install pytorch torchvision pytorch-cuda=11.7 -c pytorch -c nvidia",
+]).run_commands([
+    "pip install diffusers[torch] transformers ftfy accelerate"
+]).run_commands([
     "curl -L https://gist.github.com/luiscape/36a8cd29b8ed54cfbfcf56d51fe23cc0/raw/a6bf16996efe7c59114eea7944b0f99741d83d54/download_stable_diffusion_models.py | python"
 ], secrets=[modal.Secret.from_name("huggingface-secret")])
 stub.image = image
@@ -43,14 +45,18 @@ stub.image = image
 # Modal allows for you to create a global context that is valid only inside a
 # container. It is often useful to load models in this context because it can
 # make subsequent calls to the same predict method much faster given that they
-# no longer need to instantiate the model. We'll get substantial speedups
+# no longer need to instantiate the model. We'll get performance improvements
 # using this technique.
+#
+# We have also have applied a few model optimizations to make the model run
+# faster. On an A100, the model takes about 6.5s to load into memory, and then
+# 1.6s per generation on average. On a T4, it takes 13s to load and 3.7s per
+# generation. Other optimizations are also available [here](https://huggingface.co/docs/diffusers/optimization/fp16#memory-and-speed).
 
 if stub.is_inside():
     import torch
     import diffusers
 
-    # optimizations from https://huggingface.co/docs/diffusers/optimization/fp16#memory-and-speed
     torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
 
@@ -61,13 +67,13 @@ if stub.is_inside():
         cache_dir=cache_path)
     PIPE = diffusers.StableDiffusionPipeline.from_pretrained(
         cache_path, torch_dtype=torch.float16, scheduler=euler, cache_dir=cache_path).to("cuda")
-    # PIPE.enable_attention_slicing()
+    PIPE.enable_xformers_memory_efficient_attention()
 
 
 # This is our Modal function. The function runs through the `StableDiffusionPipeline` pipeline.
 # It sends the PIL image back to our CLI where we save the resulting image in a local file.
 
-@stub.function(gpu=modal.gpu.A100())
+@stub.function(gpu=True)
 def _run_inference(prompt:str, steps:int = 20) -> str:
     with torch.inference_mode():
         image = PIPE(prompt, num_inference_steps=steps, guidance_scale=7.0).images[0]
@@ -80,10 +86,15 @@ def _run_inference(prompt:str, steps:int = 20) -> str:
 @app.command()
 def entrypoint(prompt: str, samples:int = 10, steps:int = 20):
     typer.echo(f"prompt => {prompt}, steps => {steps}, samples => {samples}")
+
+    dir = Path("/tmp/stable-diffusion")
+    if not dir.exists():
+        dir.mkdir(exist_ok=True, parents=True)
+
     with stub.run():
         for i in range(samples):
             image = _run_inference(prompt, steps)
-            image.save(f"output_{i}.png")
+            image.save(dir / f"output_{i}.png")
 
 # And this is our entrypoint; where the CLI is invoked.
 

--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -78,11 +78,11 @@ def _run_inference(prompt:str, steps:int = 20) -> str:
 # This is the CLI command that we'll use to generate images.
 
 @app.command()
-def entrypoint(prompt: str, samples:int = 10):
-    typer.echo(f"prompt => {prompt}, samples => {samples}")
+def entrypoint(prompt: str, samples:int = 10, steps:int = 20):
+    typer.echo(f"prompt => {prompt}, steps => {steps}, samples => {samples}")
     with stub.run():
         for i in range(samples):
-            image = _run_inference(prompt)
+            image = _run_inference(prompt, steps)
             image.save(f"output_{i}.png")
 
 # And this is our entrypoint; where the CLI is invoked.

--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -1,0 +1,96 @@
+# ---
+# output-directory: "/tmp/stable-diffusion"
+# ---
+# # Stable Diffusion CLI
+#
+# This tutorial shows how you can create a CLI tool that runs GPU-intensive
+# work remotely but feels like you are running locally. We will be building
+# a tool that generates an image based on a prompt against Stable Diffusion
+# using the HuggingFace Hub and the `diffusers` library.
+
+# ## Basic setup
+import modal
+
+# All Modal programs need a [`Stub`](/docs/reference/modal.Stub) — an object that acts as a recipe for
+# the application. Let's give it a friendly name.
+
+stub = modal.Stub("stable-diffusion-cli")
+
+# We will be using `typer` to create our CLI interface.
+
+import typer
+
+app = typer.Typer()
+
+# ## Model dependencies
+#
+# Your model will be running remotely inside a container. We will be installing
+# all the model dependencies in the next step. We will also be "baking the model"
+# into the image. This is technique that allows you to load models much faster
+# by using our [high-performance blob storage file server](https://github.com/modal-labs/blobnet).
+
+model_cache_path = "/model_cache"
+image = modal.Image.debian_slim().run_commands(
+    [
+    "pip install torch --extra-index-url https://download.pytorch.org/whl/cu117",
+    "pip install diffusers[torch] transformers ftfy"]
+).run_commands([
+    f"""python -c 'import diffusers; import os; euler = diffusers.EulerAncestralDiscreteScheduler.from_config("runwayml/stable-diffusion-v1-5",subfolder="scheduler",use_auth_token=os.environ["HUGGINGFACE_TOKEN"], cache_dir="{model_cache_path}"); euler.save_config("{model_cache_path}")'""",
+    f"""python -c 'import diffusers; import os; import torch; pipe = diffusers.StableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5",use_auth_token=os.environ["HUGGINGFACE_TOKEN"],revision="fp16",torch_dtype=torch.float16,cache_dir="{model_cache_path}"); pipe.save_pretrained("{model_cache_path}")'"""
+], secrets=[modal.Secret.from_name("huggingface-secret")]).run_commands([
+    f"ls -lah {model_cache_path}"
+])
+stub.image = image
+
+# ## Global context
+#
+# Modal allows for you to create a global context that is valid only inside a
+# container. It is often useful to load models in this context because it can
+# make subsequent calls to the same predict method much faster given that they
+# no longer need to instantiate the model. We'll get substantial speedups
+# using this technique.
+
+if stub.is_inside():
+    import torch
+    import diffusers
+
+    # optimizations from https://huggingface.co/docs/diffusers/optimization/fp16#memory-and-speed
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    model_id = "/model_cache"
+    euler = diffusers.EulerAncestralDiscreteScheduler.from_config(
+        model_id,
+        subfolder="scheduler",
+        cache_dir=model_cache_path)
+    PIPE = diffusers.StableDiffusionPipeline.from_pretrained(
+        model_id, torch_dtype=torch.float16, scheduler=euler, cache_dir=model_cache_path).to("cuda")
+    PIPE.enable_attention_slicing()
+
+
+# This is our Modal function. The function runs through the `StableDiffusionPipeline` pipeline.
+# It sends the PIL image back to our CLI where we save the resulting image in a local file.
+
+@stub.function(gpu=modal.gpu.A100())
+def _run_inference(prompt:str) -> str:
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            image = PIPE(prompt, num_inference_steps=20, guidance_scale=7.0).images[0]
+
+    return image
+
+
+# This is the CLI command that we'll use to generate images.
+
+@app.command()
+def entrypoint(prompt: str, samples:int = 10):
+    typer.echo(f"prompt => {prompt}, samples => {samples}")
+    with stub.run():
+        for i in range(samples):
+            image = _run_inference(prompt)
+            image.save(f"output_{i}.png")
+
+# And this is our entrypoint; where the CLI is invoked.
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
This adds an optimized Stable Diffusion 1.5 tutorial to our docs. The breakdown is:

- **A100**: 6.5s to load model and 1.6s per generation
- **T4**: 13s to load model and 3.7s per generation

One of the key changes is to use the pre-trained `diffusers.EulerAncestralDiscreteScheduler`. It is fast and generates high quality images with fewer steps (20-30). Other optimizations such as tracing are available [here](https://huggingface.co/docs/diffusers/optimization/fp16#memory-and-speed), so it may be possible to make the generation step faster.