### PR TITLE
fix: turn off fn interactivity to fix app deploy github action

### DIFF
--- a/misc/dreambooth_app.py
+++ b/misc/dreambooth_app.py
@@ -178,7 +178,7 @@ def load_images(image_urls):
     },
     timeout=600,  # 10 minutes
     secrets=[modal.Secret.from_name("huggingface")],
-    interactive=True,
+    interactive=False,
 )
 def train(instance_example_urls, config=TrainConfig()):
     import subprocess


### PR DESCRIPTION
It appears in Github Actions we can't create `interactive=True` functions and deploy, because this call fails when setting up the terminal: `old_settings = termios.tcgetattr(fd)`. 

You don't really want to deploy functions in interactive mode, so I've just turned it off. We should also emit a warning, or just refuse to deploy.

The traceback is garbled in Github Actions because our client doesn't support plaintext output, but you can recover the pretty-printed traceback by copying the garbled output and then printing it: `print(garbled.decode())`. 

<details closed>
<summary><strong>Traceback</strong></summary>
<br>

```
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/modal/cli │
│ /app.py:89 in deploy                                                         │
│                                                                              │
│    86 │   if name is None:                                                   │
│    87 │   │   name = stub.name                                               │
│    88 │                                                                      │
│ ❱  89 │   res = stub.deploy(name=name)                                       │
│    90 │   if inspect.iscoroutine(res):                                       │
│    91 │   │   asyncio.run(res)                                               │
│    92                                                                        │
│                                                                              │
│ ╭───────────────────────── locals ─────────────────────────╮                 │
│ │ import_path = 'dreambooth_app.py'                        │                 │
│ │        name = 'example-dreambooth-app'                   │                 │
│ │        stub = <modal.stub.Stub object at 0x7fb82acca190> │                 │
│ │   stub_name = 'stub'                                     │                 │
│ │    stub_ref = 'dreambooth_app.py'                        │                 │
│ ╰──────────────────────────────────────────────────────────╯                 │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/synchroni │
│ city/synchronizer.py:412 in proxy_method                                     │
│                                                                              │
│   409 │   │   │   try:                                                       │
│   410 │   │   │   │   return method(instance, *args, **kwargs)               │
│   411 │   │   │   except UserCodeException as uc_exc:                        │
│ ❱ 412 │   │   │   │   raise uc_exc.exc from None                             │
│   413 │   │                                                                  │
│   414 │   │   return proxy_method                                            │
│   415                                                                        │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │         args = ()                                                        │ │
│ │     instance = <modal.stub._Stub object at 0x7fb82acca1c0>               │ │
│ │       kwargs = {'name': 'example-dreambooth-app'}                        │ │
│ │       method = <function _Stub.deploy at 0x7fb82b7e09d0>                 │ │
│ │         self = <modal_utils.async_utils.Synchronizer object at           │ │
│ │                0x7fb82cb4c5b0>                                           │ │
│ │ wrapped_self = <modal.stub.Stub object at 0x7fb82acca190>                │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/modal/stu │
│ b.py:430 in deploy                                                           │
│                                                                              │
│   427 │   │                                                                  │
│   428 │   │   # The `_run` method contains the logic for starting and runnin │
│   429 │   │   output_mgr = OutputManager(stdout, show_progress)              │
│ ❱ 430 │   │   async with self._run(                                          │
│   431 │   │   │   client, output_mgr, existing_app_id, last_log_entry_id, na │
│   432 │   │   ) as app:                                                      │
│   433 │   │   │   deploy_req = api_pb2.AppDeployRequest(                     │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │           app_req = namespace: DEPLOYMENT_NAMESPACE_ACCOUNT              │ │
│ │                     name: "example-dreambooth-app"                       │ │
│ │                     client_id: "cl-TY3cq2NQkROWr1Vybdouut"               │ │
│ │          app_resp = <class 'rich.pretty.Node'>.__repr__ returned empty   │ │
│ │                     string                                               │ │
│ │            client = <modal.client._Client object at 0x7fb829c5e7c0>      │ │
│ │   existing_app_id = None                                                 │ │
│ │ last_log_entry_id = ''                                                   │ │
│ │              name = 'example-dreambooth-app'                             │ │
│ │         namespace = 1                                                    │ │
│ │        output_mgr = <modal._output.OutputManager object at               │ │
│ │                     0x7fb829c72d00>                                      │ │
│ │              self = <modal.stub._Stub object at 0x7fb82acca1c0>          │ │
│ │     show_progress = None                                                 │ │
│ │            stdout = None                                                 │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/contextlib.py:181 in    │
│ __aenter__                                                                   │
│                                                                              │
│   178 │   │   # they are only needed for recreation, which is not possible a │
│   179 │   │   del self.args, self.kwds, self.func                            │
│   180 │   │   try:                                                           │
│ ❱ 181 │   │   │   return await self.gen.__anext__()                          │
│   182 │   │   except StopAsyncIteration:                                     │
│   183 │   │   │   raise RuntimeError("generator didn't yield") from None     │
│   184                                                                        │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │ self = <contextlib._AsyncGeneratorContextManager object at               │ │
│ │        0x7fb829c77490>                                                   │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/modal/stu │
│ b.py:249 in _run                                                             │
│                                                                              │
│   246 │   │   │   │                                                          │
│   247 │   │   │   │   if self._pty_input_stream:                             │
│   248 │   │   │   │   │   output_mgr._visible_progress = False               │
│ ❱ 249 │   │   │   │   │   async with write_stdin_to_pty_stream(app._pty_inpu │
│   250 │   │   │   │   │   │   yield app                                      │
│   251 │   │   │   │   │   output_mgr._visible_progress = True                │
│   252 │   │   │   │   else:                                                  │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │           aborted = False                                                │ │
│ │               app = <modal.app._App object at 0x7fb829c72c10>            │ │
│ │            app_id = 'ap-OSVVeZd9S8rjhdov2wfKvI'                          │ │
│ │          app_name = 'example-dreambooth-app'                             │ │
│ │            client = <modal.client._Client object at 0x7fb829c5e7c0>      │ │
│ │   create_progress = <rich.tree.Tree object at 0x7fb828bcdac0>            │ │
│ │            detach = False                                                │ │
│ │   existing_app_id = None                                                 │ │
│ │   initialized_msg = 'Initialized. [grey70]View app at                    │ │
│ │                     [underline]https://modal.com/apps/ap-OSVVeZd9S8'+33  │ │
│ │ last_log_entry_id = ''                                                   │ │
│ │         logs_loop = <Task cancelled name='Task-8'                        │ │
│ │                     coro=<OutputManager.get_logs_loop() done, defined at │ │
│ │                     /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.… │ │
│ │              mode = <StubRunMode.DEPLOY: 'deploy'>                       │ │
│ │              name = 'example-dreambooth-app'                             │ │
│ │               obj = <modal.functions._FunctionHandle object at           │ │
│ │                     0x7fb829c5eca0>                                      │ │
│ │        output_mgr = <modal._output.OutputManager object at               │ │
│ │                     0x7fb829c72d00>                                      │ │
│ │              self = <modal.stub._Stub object at 0x7fb82acca1c0>          │ │
│ │    status_spinner = <rich.spinner.Spinner object at 0x7fb828bcd3d0>      │ │
│ │               tag = 'fastapi_app'                                        │ │
│ │                tc = <modal_utils.async_utils.TaskContext object at       │ │
│ │                     0x7fb828bcd370>                                      │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/contextlib.py:181 in    │
│ __aenter__                                                                   │
│                                                                              │
│   178 │   │   # they are only needed for recreation, which is not possible a │
│   179 │   │   del self.args, self.kwds, self.func                            │
│   180 │   │   try:                                                           │
│ ❱ 181 │   │   │   return await self.gen.__anext__()                          │
│   182 │   │   except StopAsyncIteration:                                     │
│   183 │   │   │   raise RuntimeError("generator didn't yield") from None     │
│   184                                                                        │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │ self = <contextlib._AsyncGeneratorContextManager object at               │ │
│ │        0x7fb828bed850>                                                   │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/modal/_pt │
│ y.py:173 in write_stdin_to_pty_stream                                        │
│                                                                              │
│   170 │                                                                      │
│   171 │   async with TaskContext(grace=0.1) as tc:                           │
│   172 │   │   write_task = tc.create_task(_write())                          │
│ ❱ 173 │   │   with raw_terminal():                                           │
│   174 │   │   │   yield                                                      │
│   175 │   │   os.write(quit_pipe_write, b"\n")                               │
│   176 │   │   write_task.cancel()                                            │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │      _read_char = <function                                              │ │
│ │                   write_stdin_to_pty_stream.<locals>._read_char at       │ │
│ │                   0x7fb829c59160>                                        │ │
│ │          _write = <function write_stdin_to_pty_stream.<locals>._write at │ │
│ │                   0x7fb829c879d0>                                        │ │
│ │           queue = <modal.queue._QueueHandle object at 0x7fb828bcda30>    │ │
│ │  quit_pipe_read = 7                                                      │ │
│ │ quit_pipe_write = 8                                                      │ │
│ │              tc = <modal_utils.async_utils.TaskContext object at         │ │
│ │                   0x7fb828bcdf10>                                        │ │
│ │      write_task = <Task cancelled name='Task-22'                         │ │
│ │                   coro=<write_stdin_to_pty_stream.<locals>._write()      │ │
│ │                   done, defined at                                       │ │
│ │                   /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/… │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/contextlib.py:119 in    │
│ __enter__                                                                    │
│                                                                              │
│   116 │   │   # they are only needed for recreation, which is not possible a │
│   117 │   │   del self.args, self.kwds, self.func                            │
│   118 │   │   try:                                                           │
│ ❱ 119 │   │   │   return next(self.gen)                                      │
│   120 │   │   except StopIteration:                                          │
│   121 │   │   │   raise RuntimeError("generator didn't yield") from None     │
│   122                                                                        │
│                                                                              │
│ ╭─────────────────────────────── locals ────────────────────────────────╮    │
│ │ self = <contextlib._GeneratorContextManager object at 0x7fb828bcdf70> │    │
│ ╰───────────────────────────────────────────────────────────────────────╯    │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/modal/_pt │
│ y.py:52 in raw_terminal                                                      │
│                                                                              │
│    49 │   import tty                                                         │
│    50 │                                                                      │
│    51 │   fd = sys.stdin.fileno()                                            │
│ ❱  52 │   old_settings = termios.tcgetattr(fd)                               │
│    53 │                                                                      │
│    54 │   try:                                                               │
│    55 │   │   tty.setraw(fd, termios.TCSADRAIN)                              │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │      fd = 0                                                              │ │
│ │ termios = <module 'termios' from                                         │ │
│ │           '/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/lib-dyn… │ │
│ │     tty = <module 'tty' from                                             │ │
│ │           '/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/tty.py'> │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯
error: (25, 'Inappropriate ioctl for device')
```

</details>