### PR TITLE
removed superfluous arguments to from_pretrained

### DIFF
--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -100,11 +100,9 @@ class StableDiffusion:
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
 
-        euler = diffusers.EulerAncestralDiscreteScheduler.from_pretrained(
-            cache_path, subfolder="scheduler", cache_dir=cache_path
-        )
+        euler = diffusers.EulerAncestralDiscreteScheduler.from_pretrained(cache_path, subfolder="scheduler")
         self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(
-            cache_path, torch_dtype=torch.float16, scheduler=euler, cache_dir=cache_path
+            cache_path, torch_dtype=torch.float16, scheduler=euler
         ).to("cuda")
         self.pipe.enable_xformers_memory_efficient_attention()
 

--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -101,9 +101,7 @@ class StableDiffusion:
         torch.backends.cuda.matmul.allow_tf32 = True
 
         euler = diffusers.EulerAncestralDiscreteScheduler.from_pretrained(cache_path, subfolder="scheduler")
-        self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(
-            cache_path, torch_dtype=torch.float16, scheduler=euler
-        ).to("cuda")
+        self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(cache_path, scheduler=euler).to("cuda")
         self.pipe.enable_xformers_memory_efficient_attention()
 
     @stub.function(gpu=modal.gpu.A100())


### PR DESCRIPTION
* `cache_path` is provided twice, which seems unnecessary
* The floating point precision is already determined by the weights (running some benchmarks and removing this argument actually might even make it _faster_, although I'm not 100% sure)