### PR TITLE
txt-to-pokemon polish

### DIFF
--- a/ml/text-to-pokemon/config.py
+++ b/ml/text-to-pokemon/config.py
@@ -3,6 +3,8 @@ import pathlib
 CACHE_DIR = "/cache"
 # Where generated Pokémon images are stored, by hash of prompt.
 POKEMON_IMGS = pathlib.Path(CACHE_DIR, "generated_samples")
+# Where fully compose Pokémon card output images are stored, by hash of prompt.
+FINAL_IMGS = pathlib.Path(CACHE_DIR, "final_cards")
 # Location of web frontend assets.
 ASSETS_PATH = pathlib.Path(__file__).parent / "frontend" / "dist"
 # Card composite component images

--- a/ml/text-to-pokemon/config.py
+++ b/ml/text-to-pokemon/config.py
@@ -1,6 +1,7 @@
 import pathlib
 
 CACHE_DIR = "/cache"
+MODEL_CACHE = pathlib.Path(CACHE_DIR, "models")
 # Where generated Pokémon images are stored, by hash of prompt.
 POKEMON_IMGS = pathlib.Path(CACHE_DIR, "generated_samples")
 # Where fully compose Pokémon card output images are stored, by hash of prompt.

--- a/ml/text-to-pokemon/config.py
+++ b/ml/text-to-pokemon/config.py
@@ -10,6 +10,9 @@ FINAL_IMGS = pathlib.Path(CACHE_DIR, "final_cards")
 ASSETS_PATH = pathlib.Path(__file__).parent / "frontend" / "dist"
 # Card composite component images
 CARD_PART_IMGS = pathlib.Path(CACHE_DIR, "card_parts")
+# Sometimes the NSFW checker is confused by the Pokémon images.
+# You can disable it at your own risk.
+DISABLE_SAFETY = True
 
 
 POKEMON_CARDS = [

--- a/ml/text-to-pokemon/frontend/src/lib/components/Generator.svelte
+++ b/ml/text-to-pokemon/frontend/src/lib/components/Generator.svelte
@@ -9,8 +9,6 @@
   - Pokémon card generation display
 
 -->
-
-
 <script>
     import { prompts } from "../helpers/prefillPromptData";
     import PrefillPrompt from "./PrefillPrompt.svelte";
@@ -60,7 +58,7 @@
             clearInterval(poller);
         }
         poller = setInterval(doPoll(id), 2000);
-    }
+    };
 
     const doPoll = (id) => async () => {
         const resp = await fetch(`/api/status/${id}`);
@@ -74,13 +72,13 @@
             setTimeout(() => {
                 cards = body.cards;
                 loading = false;
-            }, 500)
- 
+            }, 500);
         }
     };
 
     const fetchPokemonCards = async () => {
         loading = true;
+        loadingComplete = false;
         const response = await self.fetch(`/api/create?prompt=${inputValue}`);
         if (response.ok) {
             const data = await response.json();
@@ -149,20 +147,24 @@
                 />
                 <!-- FILTERED LIST OF Prompts -->
                 {#if filteredPrompts?.length > 0}
-                <ul id="autocomplete-items-list">
-                    {#each filteredPrompts as prompt, i}
-                        <PrefillPrompt
-                            itemLabel={prompt}
-                            highlighted={i === hiLiteIndex}
-                            on:click={() => setInputVal(prompt)}
-                        />
-                    {/each}
-                </ul>
+                    <ul id="autocomplete-items-list">
+                        {#each filteredPrompts as prompt, i}
+                            <PrefillPrompt
+                                itemLabel={prompt}
+                                highlighted={i === hiLiteIndex}
+                                on:click={() => setInputVal(prompt)}
+                            />
+                        {/each}
+                    </ul>
                 {/if}
             </div>
 
             <div>
-                <button class="promptbutton shadow-lg" type="submit" disabled={loading}>
+                <button
+                    class="promptbutton shadow-lg"
+                    type="submit"
+                    disabled={loading}
+                >
                     <Pokeball />
                     <span>Create</span>
                 </button>
@@ -171,7 +173,7 @@
     </div>
 
     {#if loading}
-        <ProgressBar finished={loadingComplete}/>
+        <ProgressBar finished={loadingComplete} />
         <CardList>
             {#each Array(4) as _, i}
                 <Card

--- a/ml/text-to-pokemon/frontend/src/lib/helpers/prefillPromptData.js
+++ b/ml/text-to-pokemon/frontend/src/lib/helpers/prefillPromptData.js
@@ -9,20 +9,21 @@ export const prompts = [
     "A Happy Baby With A Rattle",
     "Banana in Pajamas",
     "Crab Made of Cheese",
-    "David Foster Wallace",
+    "Duck sized horse",
     "Elephant With Six Legs",
-    "Freezing Tree", // TODO: Needs edits/additions.
+    "Frodo Baggins",
     "Grandma's Cooking",
     "Homer Simpson",
+    "Horse sized duck",
     "IPhone 7 Device",
     "Joker Evil",
     "King Kong",
     "Kung Fu Panda",
     "Lima Monkey",
     "Marvin The Paranoid Robot",
-    "Modal Labs", // TODO: Needs edits/additions.
+    "Modal Lab Mad Scientist",
     "Nocturnal Animal",
-    "Old Buddhist Monk in Orange Robes", // A- prompt.
+    "Old Buddhist Monk in Orange Robes", // A+ prompt.
     "PDP-11 Computer",
     "Power Couple",
     "Question Mark With Eyes",

--- a/ml/text-to-pokemon/inpaint.py
+++ b/ml/text-to-pokemon/inpaint.py
@@ -1,16 +1,12 @@
 """
 Inpainting removes unwanted parts of an image. The module has
-inpainting functionality to remove the Pokémon name that appears on the 'base' card, 
+inpainting functionality to remove the Pokémon name that appears on the 'base' card,
 eg. Articuno, so that it can be replaced with a new, made up name for the model generated
 Pokémon character.
 
 This code is partly based on code from github.com/Sanster/lama-cleaner/.
 """
 import io
-import pathlib
-from typing import Optional
-
-from . import config
 
 import modal
 
@@ -36,6 +32,7 @@ cv_image = (
 # opencv document https://docs.opencv.org/4.6.0/d7/d8b/group__photo__inpaint.html#gga8002a65f5a3328fbf15df81b842d3c3ca05e763003a805e6c11c673a9f4ba7d07
 cv2_flag: str = "INPAINT_NS"
 cv2_radius: int = 4
+
 
 # From lama-cleaner
 def load_img(img_bytes, gray: bool = False):
@@ -69,29 +66,20 @@ def numpy_to_bytes(image_numpy, ext: str) -> bytes:
     return image_bytes
 
 
-def new_pokemon_name(card_image: Optional[bytes] = None, pokemon_name: str = "Randomon") -> bytes:
+def new_pokemon_name(card_image: bytes, pokemon_name: str = "Randomon") -> bytes:
     import cv2
-    from PIL import Image, ImageDraw, ImageFilter, ImageFont
+    from PIL import Image, ImageDraw, ImageFont
 
     # 1. Paint out the existing name.
 
     flag_map = {"INPAINT_NS": cv2.INPAINT_NS, "INPAINT_TELEA": cv2.INPAINT_TELEA}
-    # return new image bytes?
-    if not card_image:
-        test_img = "a5ada347c7c21bf34a4000544b62c51c1ed0b881b0664e320e4b50562a1c34c5/1.png"
-        test_img_path = config.FINAL_IMGS / test_img
-        image_bytes = test_img_path.read_bytes()
-    else:
-        image_bytes = card_image
-    img, alpha_channel = load_img(image_bytes)
+    img, alpha_channel = load_img(card_image)
 
     pokecard_name_top_left_crnr = (139, 43)
-    line_height = 40
     pokecard_name_size = (225, 45)  # (width, height)
 
     mask_im = Image.new("L", img.shape[:2][::-1], 0)
     draw = ImageDraw.Draw(mask_im)
-    edge_depth = 1
     (left, upper, right, lower) = (
         pokecard_name_top_left_crnr[0],
         pokecard_name_top_left_crnr[1],

--- a/ml/text-to-pokemon/inpaint.py
+++ b/ml/text-to-pokemon/inpaint.py
@@ -1,0 +1,158 @@
+"""
+Inpainting removes unwanted parts of an image. The module has
+inpainting functionality to remove the Pokémon name that appears on the 'base' card, 
+eg. Articuno, so that it can be replaced with a new, made up name for the model generated
+Pokémon character.
+
+This code is partly based on code from github.com/Sanster/lama-cleaner/.
+"""
+import io
+import pathlib
+
+from . import config
+from .main import stub, volume
+
+import modal
+
+cv_image = (
+    modal.Image.debian_slim()
+    .pip_install(
+        [
+            "opencv-python~=4.6.0.66",
+            "Pillow~=9.3.0",
+            "numpy~=1.23.5",
+        ]
+    )
+    .run_commands(
+        [
+            "apt-get update",
+            # Required to install libs such as libGL.so.1
+            "apt-get install ffmpeg libsm6 libxext6 --yes",
+        ]
+    )
+)
+
+# Configs for opencv inpainting
+# opencv document https://docs.opencv.org/4.6.0/d7/d8b/group__photo__inpaint.html#gga8002a65f5a3328fbf15df81b842d3c3ca05e763003a805e6c11c673a9f4ba7d07
+cv2_flag: str = "INPAINT_NS"
+cv2_radius: int = 4
+
+# From lama-cleaner
+def load_img(img_bytes, gray: bool = False):
+    import cv2
+    import numpy as np
+
+    alpha_channel = None
+    nparr = np.frombuffer(img_bytes, np.uint8)
+    if gray:
+        np_img = cv2.imdecode(nparr, cv2.IMREAD_GRAYSCALE)
+    else:
+        np_img = cv2.imdecode(nparr, cv2.IMREAD_UNCHANGED)
+        if len(np_img.shape) == 3 and np_img.shape[2] == 4:
+            alpha_channel = np_img[:, :, -1]
+            np_img = cv2.cvtColor(np_img, cv2.COLOR_BGRA2RGB)
+        else:
+            np_img = cv2.cvtColor(np_img, cv2.COLOR_BGR2RGB)
+
+    return np_img, alpha_channel
+
+
+def numpy_to_bytes(image_numpy, ext: str) -> bytes:
+    import cv2
+
+    data = cv2.imencode(
+        f".{ext}",
+        image_numpy,
+        [int(cv2.IMWRITE_JPEG_QUALITY), 100, int(cv2.IMWRITE_PNG_COMPRESSION), 0],
+    )[1]
+    image_bytes = data.tobytes()
+    return image_bytes
+
+
+@stub.function(
+    image=cv_image,
+    shared_volumes={config.CACHE_DIR: volume},
+    interactive=False,
+)
+def inpaint_new_pokemon_name(pokemon_name="Randomon") -> None:
+    import cv2
+    from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+    # 1. Paint out the existing name.
+
+    flag_map = {"INPAINT_NS": cv2.INPAINT_NS, "INPAINT_TELEA": cv2.INPAINT_TELEA}
+    # return new image bytes?
+    test_img = "a5ada347c7c21bf34a4000544b62c51c1ed0b881b0664e320e4b50562a1c34c5/1.png"
+    test_img_path = config.FINAL_IMGS / test_img
+    image_bytes = test_img_path.read_bytes()
+    img, alpha_channel = load_img(image_bytes)
+
+    pokecard_name_top_left_crnr = (139, 43)
+    line_height = 40
+    pokecard_name_size = (225, 45)  # (width, height)
+
+    mask_im = Image.new("L", img.shape[:2][::-1], 0)
+    draw = ImageDraw.Draw(mask_im)
+    edge_depth = 1
+    (left, upper, right, lower) = (
+        pokecard_name_top_left_crnr[0],
+        pokecard_name_top_left_crnr[1],
+        pokecard_name_top_left_crnr[0] + pokecard_name_size[0],
+        pokecard_name_top_left_crnr[1] + pokecard_name_size[1],
+    )
+    draw.rectangle((left, upper, right, lower), fill=255)
+    mask_im = mask_im.convert("L")
+    mask_bytesio = io.BytesIO()
+    mask_im.save(mask_bytesio, format="PNG")
+    mask_img_bytes = mask_bytesio.getvalue()
+    mask, _ = load_img(mask_img_bytes)
+
+    # return numpy_to_bytes(mask, "png")
+
+    assert img.shape[:2] == mask.shape[:2], "shapes of base image and mask must match"
+
+    # "No GPU is required, and for simple backgrounds, the results may even be better than AI models."
+    cur_res = cv2.inpaint(
+        img[:, :, ::-1],
+        mask[:, :, 0],  # Slicing ensures we get 1 channel not 3.
+        inpaintRadius=cv2_radius,
+        flags=flag_map[cv2_flag],
+    )
+
+    # 2. Insert the new name!
+
+    # make a blank image for the text, initialized to transparent text color
+    txt = Image.new("RGBA", cur_res.shape[:2][::-1], (255, 255, 255, 0))
+    # Dejavu is only font installed on Debian-slim images.
+    # TODO: Get the real Pokémon card font. (This Dejavu is pretty close though)
+    font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+    fnt = ImageFont.truetype(font_path, size=40)
+    fnt.fontmode = "L"  # antialiasing
+    # get a drawing context
+    d = ImageDraw.Draw(txt)
+
+    # draw text, full opacity
+    # -3 is done to put text at right line height position
+    text_position = (
+        pokecard_name_top_left_crnr[0],
+        pokecard_name_top_left_crnr[1] - 5,
+    )
+    # Note that the text is a *little* transparent. This looks closer to the original
+    # text. Full opacity is too flat.
+    d.text(text_position, pokemon_name, font=fnt, fill=(20, 20, 20, 230))
+
+    # https://stackoverflow.com/a/45646235/4885590
+    cur_res_correct_color = cv2.cvtColor(cur_res, cv2.COLOR_BGR2RGB)
+    cur_res_image = Image.fromarray(cur_res_correct_color).convert("RGBA")
+    out = Image.alpha_composite(cur_res_image, txt)
+
+    img_bytesio = io.BytesIO()
+    out.save(img_bytesio, format="PNG")
+    return img_bytesio.getvalue()
+
+
+if __name__ == "__main__":
+    with stub.run():
+        mask_bytes = inpaint_new_pokemon_name()
+        p = pathlib.Path("./temp.png")
+        p.write_bytes(mask_bytes)

--- a/ml/text-to-pokemon/main.py
+++ b/ml/text-to-pokemon/main.py
@@ -56,7 +56,18 @@ class Model:
         import torch
         from diffusers import StableDiffusionPipeline
 
-        pipe = StableDiffusionPipeline.from_pretrained("lambdalabs/sd-pokemon-diffusers", torch_dtype=torch.float16)
+        model_id = "lambdalabs/sd-pokemon-diffusers"
+        cache_dir = config.MODEL_CACHE / model_id
+        if cache_dir.exists:
+            local_files_only = True
+        else:
+            local_files_only = False
+        pipe = StableDiffusionPipeline.from_pretrained(
+            model_id,
+            torch_dtype=torch.float16,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+        )
         # Sometimes the NSFW checker is confused by the Pokémon images.
         # You can disable it at your own risk.
         disable_safety = True

--- a/ml/text-to-pokemon/main.py
+++ b/ml/text-to-pokemon/main.py
@@ -132,29 +132,6 @@ def fastapi_app():
     return web_app
 
 
-@stub.function
-def extract_colors(num=3) -> None:
-    import colorgram
-    import urllib.request
-
-    for card in config.POKEMON_CARDS:
-        print(f"Processing {card['name']}")
-        req = urllib.request.Request(
-            card["images"]["large"],
-            # Set a user agent to avoid 403 response from some podcast audio servers.
-            headers={
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
-            },
-        )
-        image_bytes = urllib.request.urlopen(req).read()
-        colors = colorgram.extract(io.BytesIO(image_bytes), num)
-        card["colors"] = [list(color.rgb) for color in colors]
-
-    import json
-
-    print(json.dumps(config.POKEMON_CARDS, indent=4))
-
-
 def composite_pokemon_card(base: bytes, character_img: bytes) -> bytes:
     """Constructs a new, unique Pokémon card image from existing and model-generated components."""
     from PIL import Image, ImageDraw, ImageFilter
@@ -279,20 +256,6 @@ def closest_pokecard_by_color(sample: bytes, cards):
 
 
 if __name__ == "__main__":
-    # composite_pokemon_card(
-    #     base=pathlib.Path("text-to-pokemon/bulbasaur.png"),
-    #     character_img=pathlib.Path("text-to-pokemon/abramon.png"),
-    # )
-
-    # with open(pathlib.Path("1668009013_3.png"), "rb") as f:
-    #     image_bytes = f.read()
-    # with stub.run():
-    #     closest = closest_pokecard_by_color(sample=image_bytes, cards=config.POKEMON_CARDS)
-    #     print(closest)
-
-    # with stub.run():
-    #     extract_colors()
-
     if len(sys.argv) == 1:
         print("No prompt provided so running webapp…")
         stub.serve()

--- a/ml/text-to-pokemon/utils.py
+++ b/ml/text-to-pokemon/utils.py
@@ -15,23 +15,41 @@ def reset_diskcache(dry_run=True) -> None:
     and you want create cache misses so the changes so up for users.
     """
     if config.POKEMON_IMGS.exists():
-        for i, filepath in enumerate(config.POKEMON_IMGS.glob("**/*")):
+        files = [f for f in config.POKEMON_IMGS.glob("**/*") if f.is_file()]
+        i = 0
+        for i, filepath in enumerate(files):
             if not dry_run:
                 filepath.unlink()
-        if dry_run:
+        if files and dry_run:
             print(f"dry-run: would have deleted {i+1} Pokémon character samples")
-        else:
+        elif files:
             print(f"deleted {i+1} Pokémon character samples")
+        else:
+            print("No Pokémon character samples to delete")
+
+        if not dry_run:
+            dirs = [f for f in config.POKEMON_IMGS.glob("**/*") if f.is_dir()]
+            for d in dirs:
+                d.rmdir()
 
     if config.FINAL_IMGS.exists():
-        for i, filepath in enumerate(config.FINAL_IMGS.glob("**/*")):
+        files = [f for f in config.FINAL_IMGS.glob("**/*") if f.is_file()]
+        i = 0
+        for i, filepath in enumerate(files):
             if not dry_run:
                 filepath.unlink()
 
-        if dry_run:
+        if files and dry_run:
             print(f"dry-run: would have deleted {i+1} Pokémon card images")
-        else:
+        elif files:
             print(f"deleted {i+1} Pokémon card images")
+        else:
+            print("No Pokémon character card images to delete")
+
+        if not dry_run:
+            dirs = [f for f in config.FINAL_IMGS.glob("**/*") if f.is_dir()]
+            for d in dirs:
+                d.rmdir()
 
 
 @stub.function
@@ -62,4 +80,4 @@ def extract_colors(num=3) -> None:
 
 if __name__ == "__main__":
     with stub.run():
-        reset_diskcache(dry_run=True)
+        reset_diskcache(dry_run=False)

--- a/ml/text-to-pokemon/utils.py
+++ b/ml/text-to-pokemon/utils.py
@@ -1,0 +1,32 @@
+import io
+import json
+import urllib.request
+
+from . import config
+from .main import stub
+
+
+@stub.function
+def extract_colors(num=3) -> None:
+    """
+    Extracts the colors for all Pokémon cards contained in `config` module
+    and updates the card config with color data.
+
+    Copy-paste this function's output back into the `config` module.
+    """
+    import colorgram
+
+    for card in config.POKEMON_CARDS:
+        print(f"Processing {card['name']}")
+        req = urllib.request.Request(
+            card["images"]["large"],
+            # Set a user agent to avoid 403 response from some podcast audio servers.
+            headers={
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
+            },
+        )
+        image_bytes = urllib.request.urlopen(req).read()
+        colors = colorgram.extract(io.BytesIO(image_bytes), num)
+        card["colors"] = [list(color.rgb) for color in colors]
+
+    print(json.dumps(config.POKEMON_CARDS, indent=4))

--- a/ml/text-to-pokemon/utils.py
+++ b/ml/text-to-pokemon/utils.py
@@ -1,9 +1,37 @@
 import io
 import json
 import urllib.request
+import shutil
 
 from . import config
-from .main import stub
+from .main import stub, volume
+
+
+@stub.function(shared_volumes={config.CACHE_DIR: volume})
+def reset_diskcache(dry_run=True) -> None:
+    """
+    Delete all Pokémon character samples and cards from disk cache.
+    Useful when a changes are made to character or card generation process
+    and you want create cache misses so the changes so up for users.
+    """
+    if config.POKEMON_IMGS.exists():
+        for i, filepath in enumerate(config.POKEMON_IMGS.glob("**/*")):
+            if not dry_run:
+                filepath.unlink()
+        if dry_run:
+            print(f"dry-run: would have deleted {i+1} Pokémon character samples")
+        else:
+            print(f"deleted {i+1} Pokémon character samples")
+
+    if config.FINAL_IMGS.exists():
+        for i, filepath in enumerate(config.FINAL_IMGS.glob("**/*")):
+            if not dry_run:
+                filepath.unlink()
+
+        if dry_run:
+            print(f"dry-run: would have deleted {i+1} Pokémon card images")
+        else:
+            print(f"deleted {i+1} Pokémon card images")
 
 
 @stub.function
@@ -30,3 +58,8 @@ def extract_colors(num=3) -> None:
         card["colors"] = [list(color.rgb) for color in colors]
 
     print(json.dumps(config.POKEMON_CARDS, indent=4))
+
+
+if __name__ == "__main__":
+    with stub.run():
+        reset_diskcache(dry_run=True)

--- a/ml/text-to-pokemon/utils.py
+++ b/ml/text-to-pokemon/utils.py
@@ -1,7 +1,6 @@
 import io
 import json
 import urllib.request
-import shutil
 
 from . import config
 from .main import stub, volume
@@ -66,7 +65,6 @@ def extract_colors(num=3) -> None:
         print(f"Processing {card['name']}")
         req = urllib.request.Request(
             card["images"]["large"],
-            # Set a user agent to avoid 403 response from some podcast audio servers.
             headers={
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
             },


### PR DESCRIPTION

<kbd>
<img width="1709" alt="image" src="https://user-images.githubusercontent.com/12058921/204852356-ea111fdc-fdbc-44eb-b0b4-302eeb99296b.png">
</kbd>


----

Pushing this example towards being 'showcase quality'.

* Fix progress bar 🐛 
* Better pre-filled prompts
* Cache final Pokémon card results, to avoid doing compositing every time on seen prompts
* New module `utils.py` for running operational tasks, such as purging the diskcache
* Replace the name on the Pokémon card ✨ (currently just hardcoded to Randomon)
* Pokémon card compositing is `.starmap`'d to parallelized. Will become more important as number of compositing steps increases.

**still todo**

* Better performance. It's still too slow, and could do with a 100% speedup. 
    * New prompt → 40-60s
    * Seen prompt → 5s
* Have some kind of function which maps prompts to Pokémon names. Can use simple mapping/transform rules, and fall back to random nonsense pseudo-Pokémon names if no rule is applicable.
    * Pre-fill prompts can have pre-fill names.
* Prompt input UI has some rough edges to sand
* Replace backgrounds of generated samples. They're too often just flat gray backgrounds, causing most generated outputs to have the silver base card. You can see in the above image that one of the duck-horses is clearly orange and green, but its gray/silver background causes it to get the silver base card. 
* Vary the `rarity` of the card results. More rare means more fancy CSS 
* Generally improve structure of card generation code. I'd like it to work more like a composition of transform functions