### PR TITLE
stable diffusion: provide a prompt for the synthetic monitor

### DIFF
--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -1,5 +1,6 @@
 # ---
 # output-directory: "/tmp/stable-diffusion"
+# args: ["a software engineer smoking a pumpkin pipe"]
 # ---
 # # Stable Diffusion CLI
 #


### PR DESCRIPTION
The monitors have been failing on this examples because nothing was provided.