### PR TITLE
Misc updates to basic grid search

### DIFF
--- a/03_scaling_out/basic_grid_search.py
+++ b/03_scaling_out/basic_grid_search.py
@@ -11,22 +11,6 @@ import modal
 
 stub = modal.Stub("example-basic-grid-search", image=modal.Image.debian_slim().pip_install(["scikit-learn"]))
 
-# ## Conditionally importing in the global scope
-#
-# The `image.inside()` function returns `False` when it runs locally, and `True` when it runs inside the
-# image in the cloud. This is needed so that we can run our script even if we don't have scikit-learn
-# installed locally.
-
-if stub.is_inside():
-    from sklearn.datasets import make_moons
-    from sklearn.neighbors import KNeighborsClassifier
-
-    X_train, y_train = make_moons(10000, noise=0.7, random_state=0)
-    X_test, y_test = make_moons(1000, noise=0.7, random_state=1)
-else:
-    print("Not importing scikit-learn")
-
-
 # ## The Modal function
 #
 # Next, define the function. Note that we use the custom image with scikit-learn in it.
@@ -35,6 +19,13 @@ else:
 
 @stub.function
 def fit_knn(k):
+    from sklearn.datasets import load_digits
+    from sklearn.model_selection import train_test_split
+    from sklearn.neighbors import KNeighborsClassifier
+
+    X, y = load_digits(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+
     clf = KNeighborsClassifier(k)
     clf.fit(X_train, y_train)
     score = float(clf.score(X_test, y_test))


### PR DESCRIPTION
I noticed the model fits so fast that it doesn't really need many containers.

* Use a larger datasets
* Remove the `is_inside` stuff

It now actually maxes out at 70+ containers (and the script still takes only a few seconds). Nice!