### PR TITLE
mypy check script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,6 +51,23 @@ jobs:
       - name: Check isort
         run: isort . -c -v --profile black
 
+  mypy:
+    name: MyPy
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install mypy
+        run: pip install mypy==0.950
+
+      - name: Run
+        run: python3 example_mypy.py
+
   pytest:
     name: Pytest
     runs-on: ubuntu-20.04

--- a/06_gpu/stable_diffusion_cli.py
+++ b/06_gpu/stable_diffusion_cli.py
@@ -108,7 +108,7 @@ class StableDiffusion:
         self.pipe.enable_xformers_memory_efficient_attention()
 
     @stub.function(gpu=modal.gpu.A100())
-    def run_inference(self, prompt: str, steps: int = 20) -> str:
+    def run_inference(self, prompt: str, steps: int = 20) -> bytes:
         import torch
 
         with torch.inference_mode():

--- a/07_webhooks/count_faces.py
+++ b/07_webhooks/count_faces.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     @app.post("/process")
     async def process(request: sanic.Request):
         input_file = request.files["file"][0]
-        async with app.run():
+        async with app.run():  # type: ignore
             num_faces = await count_faces(input_file.body)
 
         return sanic.json({"faces": num_faces})

--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -52,7 +52,7 @@ async def parse(request: fastapi.Request):
     parse_receipt = modal.lookup("example-doc-ocr-jobs", "parse_receipt")
 
     form = await request.form()
-    receipt = await form["receipt"].read()
+    receipt = await form["receipt"].read()  # type: ignore
     call = parse_receipt.submit(receipt)
     return {"call_id": call.object_id}
 
@@ -70,7 +70,7 @@ async def poll_results(call_id: str):
     try:
         result = function_call.get(timeout=0)
     except TimeoutError:
-        return fastapi.responses.JSONResponse(status_code=202)
+        return fastapi.responses.JSONResponse(content="", status_code=202)
 
     return result
 

--- a/10_integrations/duckdb_nyc_taxi.py
+++ b/10_integrations/duckdb_nyc_taxi.py
@@ -25,6 +25,7 @@
 
 import io
 import os
+from datetime import datetime
 
 import modal
 
@@ -77,7 +78,7 @@ def main():
 
     # Map over all inputs and combine the data
     inputs = [(year, month) for year in range(2018, 2023) for month in range(1, 13) if (year, month) <= (2022, 6)]
-    data = [[] for i in range(7)]  # Initialize a list for every weekday
+    data: list[list[tuple[datetime, int]]] = [[] for i in range(7)]  # Initialize a list for every weekday
     for r in get_data.starmap(inputs):
         for d, c in r:
             data[d.weekday()].append((d, c))

--- a/example_mypy.py
+++ b/example_mypy.py
@@ -1,0 +1,73 @@
+"""
+MyPy type-checking script.
+Unvalidated, incorrect type-hints are worse than no type-hints!
+"""
+import pathlib
+import subprocess
+import sys
+
+import mypy.api
+
+
+def fetch_git_repo_root() -> pathlib.Path:
+    return pathlib.Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("ascii").strip())
+
+
+def run_mypy(toplevel_pkg: str, config_file: pathlib.Path) -> list[str]:
+    args = [
+        toplevel_pkg,
+        "--no-incremental",
+        "--namespace-packages",
+        "--config-file",
+        str(config_file),
+    ]
+    result = mypy.api.run(args)
+    return result[0].splitlines()
+
+def extract_errors(output: list[str]) -> list[str]:
+    if len(output) > 0 and "success" in output[0].lower():
+        print(output[0], file=sys.stderr)
+        return []
+    return [l for l in output if "error" in l]
+
+def main() -> int:
+    repo_root = fetch_git_repo_root()
+    config_file = repo_root / "pyproject.toml"
+    errors = []
+
+    # Type-check scripts:
+    # (Only finds numbered folders up until '99_*')
+    topic_dirs = sorted([d for d in repo_root.iterdir() if d.name[:2].isdigit()])
+    for topic_dir in topic_dirs:
+        print(f"⌛️ running mypy on '{topic_dir.name}'", file=sys.stderr)
+        topic_errors = extract_errors(run_mypy(
+            toplevel_pkg=str(topic_dir),
+            config_file=config_file,
+        ))
+        if topic_errors:
+            print("\n".join(topic_errors))
+            errors.extend(topic_errors)
+
+    # Type-check packages:
+    # Getting mypy running successfully with a monorepo of heterogenous packaging structures
+    # is a bit fiddly, so we expect top-level packages to opt-in to type-checking by placing a
+    # `py.typed` file inside themselves. https://peps.python.org/pep-0561/
+    for py_typed in repo_root.glob("**/py.typed"):
+        toplevel_pkg = py_typed.parent
+        print(f"⌛️ running mypy on '{toplevel_pkg}'", file=sys.stderr)
+        package_errors = extract_errors(run_mypy(
+            toplevel_pkg=str(toplevel_pkg),
+            config_file=config_file,
+        ))
+        if package_errors:
+            print(f"found {len(package_errors)} errors in '{toplevel_pkg}'", file=sys.stderr)
+            print("\n".join(package_errors))
+            errors.extend(package_errors)
+
+    if errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/example_mypy.py
+++ b/example_mypy.py
@@ -24,11 +24,13 @@ def run_mypy(toplevel_pkg: str, config_file: pathlib.Path) -> list[str]:
     result = mypy.api.run(args)
     return result[0].splitlines()
 
+
 def extract_errors(output: list[str]) -> list[str]:
     if len(output) > 0 and "success" in output[0].lower():
         print(output[0], file=sys.stderr)
         return []
     return [l for l in output if "error" in l]
+
 
 def main() -> int:
     repo_root = fetch_git_repo_root()
@@ -40,10 +42,12 @@ def main() -> int:
     topic_dirs = sorted([d for d in repo_root.iterdir() if d.name[:2].isdigit()])
     for topic_dir in topic_dirs:
         print(f"⌛️ running mypy on '{topic_dir.name}'", file=sys.stderr)
-        topic_errors = extract_errors(run_mypy(
-            toplevel_pkg=str(topic_dir),
-            config_file=config_file,
-        ))
+        topic_errors = extract_errors(
+            run_mypy(
+                toplevel_pkg=str(topic_dir),
+                config_file=config_file,
+            )
+        )
         if topic_errors:
             print("\n".join(topic_errors))
             errors.extend(topic_errors)
@@ -55,10 +59,12 @@ def main() -> int:
     for py_typed in repo_root.glob("**/py.typed"):
         toplevel_pkg = py_typed.parent
         print(f"⌛️ running mypy on '{toplevel_pkg}'", file=sys.stderr)
-        package_errors = extract_errors(run_mypy(
-            toplevel_pkg=str(toplevel_pkg),
-            config_file=config_file,
-        ))
+        package_errors = extract_errors(
+            run_mypy(
+                toplevel_pkg=str(toplevel_pkg),
+                config_file=config_file,
+            )
+        )
         if package_errors:
             print(f"found {len(package_errors)} errors in '{toplevel_pkg}'", file=sys.stderr)
             print("\n".join(package_errors))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,13 @@ pythonpath = [
 
 [tool.black]
 line-length = 120
+
+[tool.mypy]
+ignore_missing_imports = true
+check_untyped_defs = true
+no_strict_optional = true
+
+# https://github.com/python/mypy/issues/10632
+[[tool.mypy.overrides]]
+module = "requests"
+ignore_missing_imports = true


### PR DESCRIPTION
Trying to pass the right combination of arguments and flags to get `mypy` working in a multi-project repo was too annoying, so knitting everything together in a Python script.

So far type-checking is only done on the 01-10 folders. I can't yet enable type-checking on the packages in misc, ml, and data because there are too many type issues. But can progressively fix those issues and then introduce `py.typed` marker files to opt-in packages to type-hint checking. 

**aside:** Why do we prefix the scripts with `example_`? Could we instead move scripts into a `scripts/` folder and remove the prefix?