### PR TITLE
Use io.BytesIO context manager in duckdb example

### DIFF
--- a/10_integrations/duckdb_nyc_taxi.py
+++ b/10_integrations/duckdb_nyc_taxi.py
@@ -101,9 +101,9 @@ def create_plot():
     pyplot.tight_layout()
 
     # Dump PNG and return
-    buf = io.BytesIO()
-    pyplot.savefig(buf, format="png", dpi=300)
-    return buf.getvalue()
+    with io.BytesIO() as buf:
+        pyplot.savefig(buf, format="png", dpi=300)
+        return buf.getvalue()
 
 
 # ## Entrypoint


### PR DESCRIPTION
Use io.BytesIO's context manager to close the buffer after using it.