### PR TITLE
need longer timeout on index() fn

### DIFF
--- a/ml/whisper_pod_transcriber/main.py
+++ b/ml/whisper_pod_transcriber/main.py
@@ -125,6 +125,7 @@ def search_podcast(name):
 @stub.function(
     image=search_image,
     shared_volumes={config.CACHE_DIR: volume},
+    timeout=(10 * 60),
 )
 def index():
     import dataclasses


### PR DESCRIPTION
Still getting failure emails because I set 10 min timeout on `refresh_index` but not the fn it calls, `index()`. 😖 