### PR TITLE
Remove smoke-test from import_sklearn

### DIFF
--- a/02_building_containers/import_sklearn.py
+++ b/02_building_containers/import_sklearn.py
@@ -1,6 +1,3 @@
-# ---
-# smoke-test: true
-# ---
 # # Install scikit-learn in a custom image
 #
 # This builds a custom image which installs the sklearn (scikit-learn) Python package in it.


### PR DESCRIPTION
We're not using the current iteration of smoke tests, so this removes the annotation.