### PR TITLE
Uses `safetensors` with `diffusers>=0.10`

### DIFF
--- a/06_gpu_and_ml/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion_cli.py
@@ -115,8 +115,6 @@ stub.image = image
 
 class StableDiffusion:
     def __enter__(self):
-        os.environ["SAFETENSORS_FAST_GPU"] = "1"
-
         import torch
         import diffusers
 

--- a/06_gpu_and_ml/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion_cli.py
@@ -69,13 +69,13 @@ def download_models():
     euler = diffusers.EulerAncestralDiscreteScheduler.from_pretrained(
         model_id, subfolder="scheduler", use_auth_token=hugging_face_token, cache_dir=cache_path
     )
-    euler.save_pretrained(cache_path)
+    euler.save_pretrained(cache_path, safe_serialization=True)
 
     # Downloads all other models.
     pipe = diffusers.StableDiffusionPipeline.from_pretrained(
         model_id, use_auth_token=hugging_face_token, revision="fp16", torch_dtype=torch.float16, cache_dir=cache_path
     )
-    pipe.save_pretrained(cache_path)
+    pipe.save_pretrained(cache_path, safe_serialization=True)
 
 
 image = (
@@ -86,7 +86,7 @@ image = (
             "conda install pytorch torchvision pytorch-cuda=11.7 -c pytorch -c nvidia",
         ]
     )
-    .run_commands(["pip install diffusers[torch] transformers ftfy accelerate"])
+    .run_commands(["pip install diffusers[torch]>=0.10 transformers ftfy accelerate safetensors"])
     .run_function(
         download_models,
         secrets=[modal.Secret.from_name("huggingface-secret")],
@@ -115,6 +115,8 @@ stub.image = image
 
 class StableDiffusion:
     def __enter__(self):
+        os.environ["SAFETENSORS_FAST_GPU"] = "1"
+
         import torch
         import diffusers
 


### PR DESCRIPTION
`diffusers` 0.10 integrated the Stable Diffusion pipeline with `safetensors`. I am adding that option here because it slightly reduces cold start speed (at best we gain ~1s). 

Measurements:

```
# Without safetensors
importing packages => 2.115561s
loading euler => 0.031964s
load pipe => 5.733712s
move_cuda => 3.039683s
total startup phase => 10.951955s
100%|██████████| 20/20 [00:04<00:00,  4.33it/s]
inference => 7.906272s
Sample 0 took 21.729s. Saving it to /tmp/stable-diffusion/output_0.png
100%|██████████| 20/20 [00:01<00:00, 18.41it/s]
inference => 1.219496s
Sample 1 took 1.770s. Saving it to /tmp/stable-diffusion/output_1.png

# With safetensors
importing packages => 2.155115s
loading euler => 0.031708s
load pipe => 1.429608s
move_cuda => 5.361170s
total startup phase => 9.005111s
100%|██████████| 20/20 [00:05<00:00,  3.95it/s]
inference => 8.725462s
Sample 0 took 20.573s. Saving it to /tmp/stable-diffusion/output_0.png
100%|██████████| 20/20 [00:01<00:00, 18.29it/s]
inference => 1.225201s
Sample 1 took 1.823s. Saving it to /tmp/stable-diffusion/output_1.png
```

Moving models to the GPU takes longer than without `safetensors` but the loading into CPU is much faster so it makes up for that slowness. Also, it seems that the way `safetensors` is implemented in `diffusers` [doesn't load tensors to the GPU directly but to the CPU first](https://github.com/huggingface/diffusers/blob/54796b7e43fb32f928afa168b776b7af68bb24c5/src/diffusers/modeling_utils.py#L98). The `safetensors` [GPU benchmarks](https://github.com/huggingface/safetensors/blob/ec48e3f894f1cc73827bc8ee9ff580d677e40dd0/docs/source/speed.mdx?plain=1#L66) suggest loading tensors directly to the GPU. I'll see if that helps at all. 
