### PR TITLE
Changes scheduler to use DPMSolver++

### DIFF
--- a/06_gpu_and_ml/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion_cli.py
@@ -125,7 +125,7 @@ class StableDiffusion:
         self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(cache_path, scheduler=scheduler).to("cuda")
         self.pipe.enable_xformers_memory_efficient_attention()
 
-    @stub.function(gpu=modal.gpu.A100())
+    @stub.function(gpu=modal.gpu.T4())
     def run_inference(self, prompt: str, steps: int = 20, batch_size: int = 4) -> list[bytes]:
         import torch
 
@@ -138,8 +138,7 @@ class StableDiffusion:
         for image in images:
             with io.BytesIO() as buf:
                 image.save(buf, format="PNG")
-                image_output.append(
-                    buf.getvalue())
+                image_output.append(buf.getvalue())
         return image_output
 
 
@@ -150,7 +149,7 @@ class StableDiffusion:
 
 
 @app.command()
-def entrypoint(prompt: str, samples: int = 5, steps: int = 20, batch_size:int = 1):
+def entrypoint(prompt: str, samples: int = 5, steps: int = 20, batch_size: int = 1):
     typer.echo(f"prompt => {prompt}, steps => {steps}, samples => {samples}, batch_size => {batch_size}")
 
     dir = Path("/tmp/stable-diffusion")

--- a/06_gpu_and_ml/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion_cli.py
@@ -64,9 +64,9 @@ def download_models():
 
     hugging_face_token = os.environ["HUGGINGFACE_TOKEN"]
 
-    # Download scheduler configuration. Experiment with different schedulers
-    # to identify one that works best for your use-case.
-    scheduler = diffusers.EulerAncestralDiscreteScheduler.from_pretrained(
+    # Download the DPMSolver scheduler configuration, currently the fastest
+    # scheduler implementation available.
+    scheduler = diffusers.DPMSolverSinglestepScheduler.from_pretrained(
         model_id, subfolder="scheduler", use_auth_token=hugging_face_token, cache_dir=cache_path
     )
     scheduler.save_pretrained(cache_path, safe_serialization=True)
@@ -121,7 +121,7 @@ class StableDiffusion:
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
 
-        scheduler = diffusers.EulerAncestralDiscreteScheduler.from_pretrained(cache_path, subfolder="scheduler")
+        scheduler = diffusers.DPMSolverSinglestepScheduler.from_pretrained(cache_path, subfolder="scheduler")
         self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(cache_path, scheduler=scheduler).to("cuda")
         self.pipe.enable_xformers_memory_efficient_attention()
 
@@ -149,8 +149,8 @@ class StableDiffusion:
 
 
 @app.command()
-def entrypoint(prompt: str, samples: int = 5, steps: int = 20, batch_size: int = 1):
-    typer.echo(f"prompt => {prompt}, steps => {steps}, samples => {samples}, batch_size => {batch_size}")
+def entrypoint(prompt: str, samples: int = 10, steps: int = 10):
+    typer.echo(f"prompt => {prompt}, steps => {steps}, samples => {samples}")
 
     dir = Path("/tmp/stable-diffusion")
     if not dir.exists():


### PR DESCRIPTION
Changing the example scheduler to use [DPMSolver++](https://huggingface.co/docs/diffusers/main/en/api/schedulers/multistep_dpm_solver) so we can generate images with 10 steps. With `batch_size=10` we can generate an image every 500ms on a A100. 

```shell
$ python 06_gpu_and_ml/stable_diffusion_cli.py "An 1600s oil painting of the New York City skyline" \
    --batch-size 10
Sample 4 took 4.805s (0.481s / image).
Saving it to /tmp/stable-diffusion/output_0_4.png
Saving it to /tmp/stable-diffusion/output_1_4.png
Saving it to /tmp/stable-diffusion/output_2_4.png
Saving it to /tmp/stable-diffusion/output_3_4.png
Saving it to /tmp/stable-diffusion/output_4_4.png
Saving it to /tmp/stable-diffusion/output_5_4.png
Saving it to /tmp/stable-diffusion/output_6_4.png
Saving it to /tmp/stable-diffusion/output_7_4.png
Saving it to /tmp/stable-diffusion/output_8_4.png
Saving it to /tmp/stable-diffusion/output_9_4.png
```

Example generation:

<img width="512" alt="image" src="https://user-images.githubusercontent.com/953118/208555488-225373a8-cb11-4f24-a262-f367a636c9bd.png">
