### PR TITLE
remove torch.backends.cudnn.benchmark

### DIFF
--- a/06_gpu_and_ml/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion_cli.py
@@ -118,7 +118,6 @@ class StableDiffusion:
         import diffusers
         import torch
 
-        torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
 
         scheduler = diffusers.DPMSolverMultistepScheduler.from_pretrained(


### PR DESCRIPTION
This takes cold start time from 21s to 15s with no impact on inference time