### PR TITLE
Minimal riffusion port

### DIFF
--- a/06_gpu_and_ml/riffusion_server.py
+++ b/06_gpu_and_ml/riffusion_server.py
@@ -38,30 +38,5 @@ def server():
     return app
 
 
-# web_image = (
-#     modal.Image.debian_slim()
-#     .apt_install(["git", "curl"])
-#     # Install npm
-#     .run_commands(
-#         [
-#             "curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash",
-#             ". $HOME/.nvm/nvm.sh && nvm install 16.14.2",
-#         ]
-#     )
-#     .run_commands(
-#         [
-#             f"git clone https://github.com/hmartiro/riffusion-app.git ~/riffusion-app",
-#             ". $HOME/.nvm/nvm.sh && cd ~/riffusion-app && npm install && next build && next export",
-#         ]
-#     )
-# )
-
-# @stub.wsgi(image=web_image)
-# def web_server():
-#     from riffusion.server import app
-
-#     return app
-
-
 if __name__ == "__main__":
     stub.serve()

--- a/06_gpu_and_ml/riffusion_server.py
+++ b/06_gpu_and_ml/riffusion_server.py
@@ -1,29 +1,63 @@
 import modal
 
-RIFFUSION_PATH = "/root/riffusion"
+RIFFUSION_PKG_PATH = "/root/riffusion"
 
-image = (
+inference_image = (
     modal.Image.debian_slim()
     .apt_install(["git"])
     .run_commands(
         [
-            f"git clone https://github.com/hmartiro/riffusion-inference {RIFFUSION_PATH}",
-            f"pip install -r {RIFFUSION_PATH}/requirements.txt",
+            f"git clone https://github.com/hmartiro/riffusion-inference {RIFFUSION_PKG_PATH}",
+            f"pip install -r {RIFFUSION_PKG_PATH}/requirements.txt",
         ]
     )
 )
 
-stub = modal.Stub("example-riffusion", image=image)
+stub = modal.Stub("example-riffusion")
 
 
-@stub.wsgi()
-def server():
-    import sys
+class Riffusion:
+    def __enter__(self):
+        print("loading")
+        import sys
 
-    sys.path.insert(0, RIFFUSION_PATH)
-    from riffusion.server import app
+        # HACK since riffusion is not a package, but we want to use it like one.
+        sys.path.insert(0, RIFFUSION_PKG_PATH)
+        from riffusion.server import load_model
 
-    return app
+        load_model()
+        print("loaded")
+
+    @stub.wsgi(image=inference_image)
+    def server(self):
+        from riffusion.server import app
+
+        return app
+
+
+# web_image = (
+#     modal.Image.debian_slim()
+#     .apt_install(["git", "curl"])
+#     # Install npm
+#     .run_commands(
+#         [
+#             "curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash",
+#             ". $HOME/.nvm/nvm.sh && nvm install 16.14.2",
+#         ]
+#     )
+#     .run_commands(
+#         [
+#             f"git clone https://github.com/hmartiro/riffusion-app.git ~/riffusion-app",
+#             ". $HOME/.nvm/nvm.sh && cd ~/riffusion-app && npm install && next build && next export",
+#         ]
+#     )
+# )
+
+# @stub.wsgi(image=web_image)
+# def web_server():
+#     from riffusion.server import app
+
+#     return app
 
 
 if __name__ == "__main__":

--- a/06_gpu_and_ml/riffusion_server.py
+++ b/06_gpu_and_ml/riffusion_server.py
@@ -1,0 +1,30 @@
+import modal
+
+RIFFUSION_PATH = "/root/riffusion"
+
+image = (
+    modal.Image.debian_slim()
+    .apt_install(["git"])
+    .run_commands(
+        [
+            f"git clone https://github.com/hmartiro/riffusion-inference {RIFFUSION_PATH}",
+            f"pip install -r {RIFFUSION_PATH}/requirements.txt",
+        ]
+    )
+)
+
+stub = modal.Stub("example-riffusion", image=image)
+
+
+@stub.wsgi()
+def server():
+    import sys
+
+    sys.path.insert(0, RIFFUSION_PATH)
+    from riffusion.server import app
+
+    return app
+
+
+if __name__ == "__main__":
+    stub.serve()


### PR DESCRIPTION
Just runs the inference server for riffusion, by pulling out their flask server and serving it as a Modal app. Sets up `SharedVolume` to cache model.

## Usage

For a given payload (`input.json`)
```json
{
  "alpha": 0.75,
  "num_inference_steps": 50,
  "seed_image_id": "og_beat",

  "start": {
    "prompt": "church bells on sunday",
    "seed": 42,
    "denoising": 0.75,
    "guidance": 7.0
  },

  "end": {
    "prompt": "jazz with piano",
    "seed": 123,
    "denoising": 0.75,
    "guidance": 7.0
  }
}
```

```bash
curl -X POST -H "Content-Type:application/json" -d @input.json https://aksh-at--example-riffusion-server-dev.modal.run/run_inference/
```