### PR TITLE
Fix open whisper example: Wrap installs in list

### DIFF
--- a/06_gpu_and_ml/whisper_pod_transcriber/main.py
+++ b/06_gpu_and_ml/whisper_pod_transcriber/main.py
@@ -18,7 +18,7 @@ volume = modal.SharedVolume().persist("dataset-cache-vol")
 
 app_image = (
     modal.Image.debian_slim()
-    .pip_install(
+    .pip_install([
         "https://github.com/openai/whisper/archive/9f70a352f9f8630ab3aa0d06af5cb9532bd8c21d.tar.gz",
         "dacite",
         "jiwer",
@@ -27,16 +27,16 @@ app_image = (
         "pandas",
         "loguru==0.6.0",
         "torchaudio==0.12.1",
-    )
-    .apt_install("ffmpeg")
-    .pip_install("ffmpeg-python")
+    ])
+    .apt_install(["ffmpeg"])
+    .pip_install(["ffmpeg-python"])
 )
-search_image = modal.Image.debian_slim().pip_install(
+search_image = modal.Image.debian_slim().pip_install([
     "scikit-learn~=0.24.2",
     "tqdm~=4.46.0",
     "numpy~=1.23.3",
     "dacite",
-)
+])
 
 stub = modal.Stub(
     "whisper-pod-transcriber",
@@ -210,7 +210,7 @@ def refresh_index():
 
 
 def split_silences(
-    path: str, min_segment_length: float = 30.0, min_silence_length: float = 1.0
+        path: str, min_segment_length: float = 30.0, min_silence_length: float = 1.0
 ) -> Iterator[Tuple[float, float]]:
     """Split audio file into contiguous chunks using the ffmpeg `silencedetect` filter.
     Yields tuples (start, end) of each chunk in seconds."""
@@ -266,10 +266,10 @@ def split_silences(
     cpu=2,
 )
 def transcribe_segment(
-    start: float,
-    end: float,
-    audio_filepath: pathlib.Path,
-    model: config.ModelSpec,
+        start: float,
+        end: float,
+        audio_filepath: pathlib.Path,
+        model: config.ModelSpec,
 ):
     import tempfile
     import time
@@ -309,9 +309,9 @@ def transcribe_segment(
     timeout=900,
 )
 def transcribe_episode(
-    audio_filepath: pathlib.Path,
-    result_path: pathlib.Path,
-    model: config.ModelSpec,
+        audio_filepath: pathlib.Path,
+        result_path: pathlib.Path,
+        model: config.ModelSpec,
 ):
     segment_gen = split_silences(str(audio_filepath))
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Modal Labs
+Copyright (c) 2023 Modal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

This PR will update the `main.py` in the `whisper_pod_transcriber` example such that the `pip_install` & `apt_install` commands are wrapped in strings.

Note: It's not immediately apparent why this fix was required, but it was the only step required for me to successfully run the `whisper_pod_transcriber` app once again.

## Other notes

- I am presently working on some other implementation of this app for a "sousveillance" project, but found `ffmpeg` to not be importable in my environment. I'm happy to share that repo with anyone wanting to collaborate. (basically it's the podcast example, but for a portable life-tracker ala [Rober Dam's blog on sousveillance](https://roberdam.com/en/wisper.html). 
- I hereby release this code under the terms of the MIT License.
  - I have updated the year to reflect this 😹 