### PR TITLE
fix: show warning when podcast result is non-EN. addresses #166

### DIFF
--- a/06_gpu_and_ml/whisper_pod_transcriber/main.py
+++ b/06_gpu_and_ml/whisper_pod_transcriber/main.py
@@ -113,6 +113,7 @@ def search_podcast(name):
             title=pod["title"],
             description=pod["description"],
             html_description=pod["htmlDescription"],
+            language=pod["language"],
             web_url=pod["webUrl"],
         )
         for pod in podcasts_raw
@@ -122,7 +123,7 @@ def search_podcast(name):
 @stub.function(
     image=search_image,
     shared_volumes={config.CACHE_DIR: volume},
-    timeout=(10 * 60),
+    timeout=(15 * 60),
 )
 def index():
     import dataclasses
@@ -202,7 +203,7 @@ def index():
 
 @stub.function(
     schedule=modal.Period(hours=4),
-    timeout=(10 * 60),
+    timeout=(15 * 60),
 )
 def refresh_index():
     logger.info(f"Running scheduled index refresh at {utc_now()}")

--- a/06_gpu_and_ml/whisper_pod_transcriber/podcast.py
+++ b/06_gpu_and_ml/whisper_pod_transcriber/podcast.py
@@ -44,6 +44,8 @@ class PodcastMetadata:
     html_description: str
     # Link to podcast on Podchaser website.
     web_url: str
+    # Used to detect non-English podcasts.
+    language: Optional[str] = None
 
 
 class DownloadResult(NamedTuple):
@@ -139,6 +141,7 @@ def search_podcast_name(gql, client, name, max_results=5) -> list[dict]:
                     id,
                     title,
                     description,
+                    language,
                     htmlDescription,
                     webUrl,
                 }}

--- a/06_gpu_and_ml/whisper_pod_transcriber/whisper_frontend/src/app.tsx
+++ b/06_gpu_and_ml/whisper_pod_transcriber/whisper_frontend/src/app.tsx
@@ -11,6 +11,15 @@ function truncate(str: string, n: number) {
   return str.length > n ? str.slice(0, n - 1) + "…" : str;
 }
 
+function NonEnglishLanguageWarning() {
+  return (
+    <div className="text-yellow-600">
+      <span className="mr-2" role="img" aria-label="warning sign">⚠️</span>
+      Detected non-English podcast. Transcription may be garbage, but amusing.
+    </div>
+  )
+}
+
 function PodcastCard({ podcast }) {
   return (
     <Link to={`/podcast/${podcast.id}`} className="px-6 py-1 group">
@@ -20,6 +29,8 @@ function PodcastCard({ podcast }) {
       <p className="text-gray-700 text-base py-4">
         {truncate(podcast.description, 200)}
       </p>
+      {podcast.language && !podcast.language.startsWith("en") ?
+        <NonEnglishLanguageWarning /> : null}
     </Link>
   );
 }
@@ -51,7 +62,7 @@ function Form({ onSubmit, searching }) {
   return (
     <form className="flex flex-col space-y-5 items-center">
       <div>
-        <a 
+        <a
           href="https://modal.com"
           target="_blank"
           rel="noopener noreferrer"
@@ -64,7 +75,7 @@ function Form({ onSubmit, searching }) {
       </div>
 
       <div className="mb-2 mt-0 text-xl text-center">
-          Transcribe <em>any</em> podcast episode in just 1-2 minutes!
+        Transcribe <em>any</em> podcast episode in just 1-2 minutes!
       </div>
 
       <div className="text-gray-700">
@@ -72,11 +83,11 @@ function Form({ onSubmit, searching }) {
           <strong>Enter a query below to search millions of podcasts. Click on a search result and then pick an episode to transcribe.</strong>
         </p>
         <p className="mb-1">
-          Try searching for 'ReactJS', 'data science', or 'software engineer career' podcasts. 
-        </p>  
+          Try searching for 'ReactJS', 'data science', or 'software engineer career' podcasts.
+        </p>
         <p className="mb-1">
           <span>If you just want to see some transcripts, we ❤️ these tech podcasts: </span>
-          <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/972209"><em>On The Metal</em></a> and <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/603405"><em>CoRecursive</em></a>. 
+          <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/972209"><em>On The Metal</em></a> and <a className="text-indigo-500 no-underline hover:underline" href="/#/podcast/603405"><em>CoRecursive</em></a>.
         </p>
       </div>
 


### PR DESCRIPTION
I'm not yet going to do the work to actually support non-English transcription, but in the meantime this at least makes some effort to let user know that non-English is not supported.

<kbd>
<img width="829" alt="image" src="https://user-images.githubusercontent.com/12058921/211223339-023861a9-e665-40bd-b76c-8e39badf4eee.png">
</kbd>

---

(Also increases timeout for indexing cron function)