### PR TITLE
Chore: fix typo in documentation

### DIFF
--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -89,7 +89,7 @@ def parse_receipt(image: bytes):
 # Python process and submit tasks to it:
 #
 # ```python
-# fn = modal.lookup("doc_ocr_jobs", "parse_receipt")
+# fn = modal.lookup("example-doc-ocr-jobs", "parse_receipt")
 # fn.spawn(my_image)
 # ```
 #


### PR DESCRIPTION
This PR updates small typo in `09_job_queues`