### PR TITLE
Text-to-Pokemon: share button

### DIFF
--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/App.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/App.svelte
@@ -91,11 +91,9 @@
 <Footer />
 
 <style>
-	@media screen and (max-width: 600px) {
-		main {
-			/* Need more space for footer badge on mobile. */
-			padding-bottom: 150px;
-		}
+	main {
+		/* Need more space for 'Built with Modal' footer badge. */
+		padding-bottom: 150px;
 	}
 
 	@media screen and (min-width: 600px) {

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/CopyToClipboard.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/CopyToClipboard.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import { createEventDispatcher } from "svelte";
+    export let text;
+
+    const dispatch = createEventDispatcher();
+    const copy = () => {
+        navigator.clipboard.writeText(text).then(
+            () => dispatch("copy", text),
+            (e) => dispatch("fail")
+        );
+    };
+</script>
+
+<slot {copy} />

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
@@ -230,7 +230,9 @@
         </CardList>
         <CopyToClipboard
             on:copy={() => alert("successfully copied!")}
-            text={"Hello from the component!"}
+            text={`${window.location.href}?share=${encodeURIComponent(
+                inputValue
+            )}`}
             let:copy
         >
             <div class="action">

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
@@ -16,6 +16,7 @@
     import Card from "./Card.svelte";
     import Pokeball from "./Pokeball.svelte";
     import CardList from "./CardList.svelte";
+    import CopyToClipboard from "./CopyToClipboard.svelte";
     import ProgressBar from "./ProgressBar.svelte";
 
     let filteredPrompts = [];
@@ -227,6 +228,17 @@
                 />
             {/each}
         </CardList>
+        <CopyToClipboard
+            on:copy={() => alert("successfully copied!")}
+            text={"Hello from the component!"}
+            let:copy
+        >
+            <div class="action">
+                <button id="copy-button" on:click={copy}>
+                    Share (Click to copy 📋)
+                </button>
+            </div>
+        </CopyToClipboard>
     {:else if error}
         <Callout type="error">
             <p>{error.message}</p>

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
@@ -235,7 +235,23 @@
         >
             <div class="action">
                 <button id="copy-button" on:click={copy}>
-                    Share (Click to copy 📋)
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#000000"
+                        stroke-width="3"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        ><g fill="none" fill-rule="evenodd"
+                            ><path
+                                d="M18 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8c0-1.1.9-2 2-2h5M15 3h6v6M10 14L20.2 3.8"
+                            /></g
+                        ></svg
+                    >
+                    <span>Share</span>
                 </button>
             </div>
         </CopyToClipboard>
@@ -337,6 +353,31 @@
     .promptbutton span {
         font-weight: 700;
         padding: 1em;
+    }
+
+    .action {
+        display: flex;
+        justify-content: center;
+    }
+
+    .action button {
+        background-color: white;
+        color: #222;
+        font-weight: bold;
+        padding: 1em 2em;
+        border-radius: 1em;
+        box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1),
+            0 1px 2px -1px rgb(0 0 0 / 0.1);
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .action button svg {
+        padding-right: 0.5em;
+    }
+
+    .action button:hover {
+        background-color: #999;
     }
 
     @media screen and (max-width: 600px) {

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Generator.svelte
@@ -10,6 +10,8 @@
 
 -->
 <script>
+    import { onMount } from "svelte";
+
     import { prompts } from "../helpers/prefillPromptData";
     import PrefillPrompt from "./PrefillPrompt.svelte";
     import Callout from "./Callout.svelte";
@@ -18,6 +20,9 @@
     import CardList from "./CardList.svelte";
     import CopyToClipboard from "./CopyToClipboard.svelte";
     import ProgressBar from "./ProgressBar.svelte";
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const sharedPrompt = urlParams.get("share");
 
     let filteredPrompts = [];
 
@@ -35,7 +40,16 @@
 
     // Handling the user's prompt input.
     let promptInput; // use with bind:this to focus element
-    let inputValue = "";
+    let inputValue = sharedPrompt || "";
+
+    onMount(async () => {
+        if (sharedPrompt) {
+            await handleSubmit(); // Immediately submit a shared prompt...
+        }
+        // ...and auto-scroll to view progress.
+        const scrollingElement = document.scrollingElement || document.body;
+        scrollingElement.scrollTop = scrollingElement.scrollHeight;
+    });
 
     $: if (!inputValue) {
         filteredPrompts = [];


### PR DESCRIPTION
Adds a share button below rendered cards to make it easier for users to show off their results. Intending for this feature to increase engagement when sharing the demo tomorrow.

If a `share` query param is present in the URL, the app immediately submits the param's prompt string and scrolls the cards into view. Shared prompts will typically be pre-rendered and cached, so results will be fast (~3-5s).

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/12058921/212447844-8523851d-1bd7-4912-8419-a244f7d01a12.png">

