### PR TITLE
Pins Python to 3.10 on Stable Diffusion example

### DIFF
--- a/06_gpu_and_ml/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion_cli.py
@@ -81,7 +81,7 @@ def download_models():
 
 
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.10")
     .pip_install(
         "accelerate",
         "diffusers[torch]>=0.10",


### PR DESCRIPTION
We likely need to do this for other examples as well. 