### PR TITLE
Fix blender python version issue

### DIFF
--- a/06_gpu_and_ml/blender_video.py
+++ b/06_gpu_and_ml/blender_video.py
@@ -49,7 +49,7 @@ dockerfile_commands = [
     f"RUN curl -L -o scene.blend -C - '{SCENE_FILENAME}'",
     f"RUN curl -L -o scene.mtl -C - '{MATERIALS_FILENAME}'",
 ]
-stub = modal.Stub("example-blender-video", image=modal.Image.debian_slim().dockerfile_commands(dockerfile_commands))
+stub = modal.Stub("example-blender-video", image=modal.Image.debian_slim(python_version="3.9").dockerfile_commands(dockerfile_commands))
 
 
 # ## Setting things up in the containers

--- a/06_gpu_and_ml/blender_video.py
+++ b/06_gpu_and_ml/blender_video.py
@@ -49,7 +49,10 @@ dockerfile_commands = [
     f"RUN curl -L -o scene.blend -C - '{SCENE_FILENAME}'",
     f"RUN curl -L -o scene.mtl -C - '{MATERIALS_FILENAME}'",
 ]
-stub = modal.Stub("example-blender-video", image=modal.Image.debian_slim(python_version="3.9").dockerfile_commands(dockerfile_commands))
+stub = modal.Stub(
+    "example-blender-video",
+    image=modal.Image.debian_slim(python_version="3.9").dockerfile_commands(dockerfile_commands),
+)
 
 
 # ## Setting things up in the containers


### PR DESCRIPTION
**Ref:** https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1674846317345789

Could reproduce this user's issue locally by using `python3.7` instead of `python3.9`, which is what the example expects.

This is still a bit dubious because the Modal execution can be running a different Python version to the user's local machine, but this at least makes the example code not break.