### PR TITLE
Allow example files to be gathered from grandchild dirs

### DIFF
--- a/example_test.py
+++ b/example_test.py
@@ -1,4 +1,5 @@
 import importlib
+import pathlib
 
 from example_utils import ExampleType, get_examples, render_example_md
 
@@ -7,6 +8,7 @@ def test_examples():
     for example in get_examples():
         if example.type == ExampleType.MODULE:
             assert not example.repo_filename.startswith("/")
+            assert pathlib.Path(example.repo_filename).exists()
 
             # If it's a module, try to import it
             importlib.import_module(example.module)


### PR DESCRIPTION
I think our example repo structure is straining under the limitation that all example files are only sourced one subdirectory deep. This PR extends the range of gathering to `1-2`. 

https://github.com/modal-labs/modal-examples/tree/main/06_gpu_and_ml is a good example of messiness that can be cleaned up. 

e.g  `06_gpu_and_ml/vision_model_training/assets` is `06_gpu_and_ml/vision_model_training.py` should be in one folder, but the latter couldn't be served in `docs/` if it was in a subdirectory. But also more generally, it'd be good if an example's code and its blog post image assets could be grouped into a subdirectory together.