### PR TITLE
provide a Conda-less Tensorflow GPU option in Tensorflow ex

### DIFF
--- a/06_gpu_and_ml/tensorflow_tutorial.py
+++ b/06_gpu_and_ml/tensorflow_tutorial.py
@@ -13,7 +13,7 @@
 # ## Setting up the dependencies
 #
 # Installing Tensorflow in Modal is quite straightforward.
-# If you want it to run on a GPU, you need the image to have CUDA libraries available
+# If you want it to run on a GPU, you need the container image to have CUDA libraries available
 # to the Tensorflow package. You can use Conda to install these libraries before `pip` installing `tensorflow`, or you
 # can use Tensorflow's official GPU base image which comes with the CUDA libraries and `tensorflow` already installed.
 


### PR DESCRIPTION
A TreeHacks hackathon team wanted to use Tensorflow and so grabbed this example code. Then, they unsurprisingly got stuck with some Conda problem when they tried to extend the image. 

Here I add a non-Conda 'Tensorflow with GPUs' image option.