### PR TITLE
Fix torchvision version error

### DIFF
--- a/06_gpu_and_ml/dreambooth_app.py
+++ b/06_gpu_and_ml/dreambooth_app.py
@@ -42,7 +42,7 @@ stub = modal.Stub(name="example-dreambooth-app")
 GIT_SHA = "ed616bd8a8740927770eebe017aedb6204c6105f"
 
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.10")
     .pip_install(
         "accelerate",
         "datasets",


### PR DESCRIPTION
Per this issue https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1674169099238619

The `dreambooth_app.py` error with the message 
```
ERROR: Could not find a version that satisfies the requirement torchvision (from versions: 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.2, 0.2.2.post2, 0.2.2.post3)
```

Adding python version contraint fixes that.