### PR TITLE
fix: 2 synmon serve cmd configs

### DIFF
--- a/06_gpu_and_ml/webcam.py
+++ b/06_gpu_and_ml/webcam.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "serve"]
+# cmd: ["modal", "serve", "06_gpu_and_ml/webcam.py"]
 # deploy: true
 # ---
 # # Machine learning model inference endpoint that uses the webcam

--- a/07_webhooks/badges.py
+++ b/07_webhooks/badges.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "serve"]
+# cmd: ["modal", "serve", "07_webhooks/badges.py"]
 # ---
 # # Serve a dynamic SVG badge
 


### PR DESCRIPTION
`modal serve` doesn't run anything, but returns `0` exit code, so it looked like these examples were successful. 

From a quick look I don't see a consensus on whether a command like `modal serve`, which returns help info, should return `0` or non-zero. I looked at `git`, `cargo`, `rustup`, and `gh` and found a mix. 