### PR TITLE
[MOD-1051] fix: set Content-Type on stream resp; commnt about curl --no-buffer

### DIFF
--- a/06_gpu_and_ml/whisper_streaming/main.py
+++ b/06_gpu_and_ml/whisper_streaming/main.py
@@ -182,9 +182,7 @@ async def stream_whisper(audio_data: bytes):
         # Must cooperatively yeild here otherwise `StreamingResponse` will not iteratively return stream parts.
         # see: https://github.com/python/asyncio/issues/284
         await asyncio.sleep(0.5)
-        # Addition of newline character is necessary for stream response structure.
-        # Remove it and streaming responses are buffered until the end.
-        yield result["text"] + "\n"
+        yield result["text"]
 
 
 @web_app.get("/")
@@ -193,7 +191,8 @@ async def transcribe(url: str):
     Usage:
 
     ```sh
-    curl https://modal-labs--example-whisper-streaming-web.modal.run/transcribe?url=https://www.youtube.com/watch?v=s_LncVnecLA" \
+    curl --no-buffer \
+        https://modal-labs--example-whisper-streaming-web.modal.run/transcribe?url=https://www.youtube.com/watch?v=s_LncVnecLA"
     ```
 
     This endpoint will stream back the Youtube's audio transcription as it makes progress.
@@ -214,7 +213,7 @@ async def transcribe(url: str):
         )
     print(f"streaming transcription of {url} audio to client...")
     return StreamingResponse(
-        stream_whisper(audio_data), media_type="text/plain"
+        stream_whisper(audio_data), media_type="text/event-stream"
     )
 
 

--- a/07_webhooks/streaming.py
+++ b/07_webhooks/streaming.py
@@ -12,18 +12,41 @@ stub = modal.Stub("example-fastapi-streaming")
 
 web_app = FastAPI()
 
+# This is 'faker' asynchronous generator function simulates
+# progressively returning data to the client. The `asyncio.sleep`
+# is not necessary, but makes it easier to see the iterative behavior
+# of the response.
+
 
 async def fake_video_streamer():
     for i in range(10):
-        yield f"frame {i}: some fake video bytes\n".encode()
+        yield f"frame {i}: hello world!".encode()
         await asyncio.sleep(1.0)
 
 
 @web_app.get("/")
 async def main():
-    return StreamingResponse(fake_video_streamer())
+    return StreamingResponse(
+        fake_video_streamer(), media_type="text/event-stream"
+    )
 
 
 @stub.asgi()
 def fastapi_app():
     return web_app
+
+
+# This is a very basic 'hello world' example of a webhook streaming response.
+#
+#
+# ```
+# modal server streaming.py
+# ```
+#
+# To try out the webhook, ensure that your client is not buffering the server response
+# until it gets newline (\n) characters. By default browsers and `curl` are buffering,
+# though modern browsers should respect the "text/event-stream" content type header being set.
+#
+# ```shell
+# curl --no-buffer https://modal-labs--example-fastapi-streaming-fastapi-app.modal.run
+# ````


### PR DESCRIPTION
The streaming examples now work properly with `curl` and in the browser _without_ having to include a trialing `\n` with each stream part.