### PR TITLE
fix deploy of text-to-pokemon

### DIFF
--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -174,7 +174,7 @@ def diskcached_text_to_pokemon(prompt: str) -> list[bytes]:
 
 
 @stub.asgi(
-    mounts=[modal.Mount.from_local_dir(remote_path="/assets")],
+    mounts=[modal.Mount.from_local_dir(local_path=config.ASSETS_PATH, remote_path="/assets")],
 )
 def fastapi_app():
     import fastapi.staticfiles


### PR DESCRIPTION
Addressing this: 

<img width="649" alt="image" src="https://user-images.githubusercontent.com/12058921/229835582-e40e9aa9-7da9-430e-ada3-80d5ea405937.png">
