### PR TITLE
Extend basic streaming example mod

### DIFF
--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -45,7 +45,8 @@ def sync_fake_video_streamer():
         time.sleep(1)
 
 
-@stub.webhook()
+@stub.function()
+@stub.web_endpoint()
 def hook():
     return StreamingResponse(
         iter(sync_fake_video_streamer.call()), media_type="text/event-stream"

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -13,7 +13,7 @@ stub = modal.Stub("example-fastapi-streaming")
 
 web_app = FastAPI()
 
-# This is 'faker' asynchronous generator function simulates
+# This is fake asynchronous generator function simulates
 # progressively returning data to the client. The `asyncio.sleep`
 # is not necessary, but makes it easier to see the iterative behavior
 # of the response.
@@ -38,7 +38,7 @@ def fastapi_app():
     return web_app
 
 
-@stub.function(is_generator=True)
+@stub.function()
 def sync_fake_video_streamer():
     for i in range(10):
         yield f"frame {i}: some data\n".encode()
@@ -48,6 +48,11 @@ def sync_fake_video_streamer():
 @stub.function()
 @stub.web_endpoint()
 def hook():
+    # `iter()` is used because `.call` returns an iterable object but not in Iterator,
+    # so the `StreamingResponse` can't call `next()` on it.
+    # `iter()` produces an Iterator from an iterable.
+    #
+    # See: https://docs.python.org/3/library/stdtypes.html#typeiter
     return StreamingResponse(
         iter(sync_fake_video_streamer.call()), media_type="text/event-stream"
     )

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -36,6 +36,7 @@ async def main():
 def fastapi_app():
     return web_app
 
+
 @stub.webhook()
 def hook():
     return StreamingResponse(

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -38,23 +38,17 @@ def fastapi_app():
     return web_app
 
 
-@stub.function
+@stub.function(is_generator=True)
 def sync_fake_video_streamer():
     for i in range(10):
         yield f"frame {i}: some data\n".encode()
         time.sleep(1)
 
-def wrapper():
-    # `sync_fake_video_streamer` is a Modal function, and can't be passed
-    # directly into FastAPI's `StreamingResponse` class, so we wrap it in
-    # a standard Python generator function.
-    for res in sync_fake_video_streamer.call():
-        yield res
 
 @stub.webhook()
 def hook():
     return StreamingResponse(
-        wrapper(), media_type="text/event-stream"
+        iter(sync_fake_video_streamer.call()), media_type="text/event-stream"
     )
 
 

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -3,6 +3,7 @@
 # deploy: true
 # ---
 import asyncio
+import time
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
@@ -37,10 +38,23 @@ def fastapi_app():
     return web_app
 
 
+@stub.function
+def sync_fake_video_streamer():
+    for i in range(10):
+        yield f"frame {i}: some data\n".encode()
+        time.sleep(1)
+
+def wrapper():
+    # `sync_fake_video_streamer` is a Modal function, and can't be passed
+    # directly into FastAPI's `StreamingResponse` class, so we wrap it in
+    # a standard Python generator function.
+    for res in sync_fake_video_streamer.call():
+        yield res
+
 @stub.webhook()
 def hook():
     return StreamingResponse(
-        fake_video_streamer(), media_type="text/event-stream"
+        wrapper(), media_type="text/event-stream"
     )
 
 

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -13,7 +13,7 @@ stub = modal.Stub("example-fastapi-streaming")
 
 web_app = FastAPI()
 
-# This is fake asynchronous generator function simulates
+# This asynchronous generator function simulates
 # progressively returning data to the client. The `asyncio.sleep`
 # is not necessary, but makes it easier to see the iterative behavior
 # of the response.

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -36,12 +36,18 @@ async def main():
 def fastapi_app():
     return web_app
 
+@stub.webhook()
+def hook():
+    return StreamingResponse(
+        fake_video_streamer(), media_type="text/event-stream"
+    )
+
 
 # This is a very basic 'hello world' example of a webhook streaming response.
 #
 #
 # ```
-# modal server streaming.py
+# modal serve streaming.py
 # ```
 #
 # To try out the webhook, ensure that your client is not buffering the server response
@@ -50,4 +56,5 @@ def fastapi_app():
 #
 # ```shell
 # curl --no-buffer https://modal-labs--example-fastapi-streaming-fastapi-app.modal.run
+# curl --no-buffer https://modal-labs--example-fastapi-streaming-hook.modal.run
 # ````


### PR DESCRIPTION
* Responding to https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1680620042163739.
* Iterable but an Iterator strikes again! https://twitter.com/jonobelotti_IO/status/1614106195866025985?s=20

cc @erikbern because this includes a `WarnIfGeneratorIsNotConsumer` gotcha: 

<img width="872" alt="image" src="https://user-images.githubusercontent.com/12058921/229873015-4a1c0147-62dc-4e74-bb31-6ca3182dbfbd.png">
