### PR TITLE
ChatGPT streaming example

### DIFF
--- a/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
+++ b/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
@@ -56,8 +56,8 @@ def stream_chat(prompt: str):
 #
 # We use the standard Python calling convention `stream_chat(...)` and not the
 # Modal-specific calling convention `stream_chat.call(...)`. The latter would still work,
-# but it would create a remote function invocation which would uncessarily involve `stream_chat`
-# running in a separate container and sending its results back to the caller over the network.
+# but it would create a remote function invocation which would unnecessarily involve `stream_chat`
+# running in a separate container, sending its results back to the caller over the network.
 
 
 @stub.function()
@@ -71,7 +71,7 @@ def web(prompt: str):
 # ## Try out the web endpoint
 #
 # Run this example with `modal serve chatgpt_streaming.py` and you'll see an ephemeral web endpoint
-# has started serving. Hit this endpoint with a prompt and see the ChatGPT response streaming back in
+# has started serving. Hit this endpoint with a prompt and watch the ChatGPT response streaming back in
 # your browser or terminal window.
 #
 # We've also already deployed this example and so you can try out our deployed web endpoint:

--- a/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
+++ b/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
@@ -1,10 +1,10 @@
 #
 # # Using the ChatGPT streaming API
-# 
-# This example shows how to stream from the ChatGPT API as the model is generating a completion, instead of 
+#
+# This example shows how to stream from the ChatGPT API as the model is generating a completion, instead of
 # waiting for the entire completion to finish. This provides a much better user experience, and is what you
 # get when playing with ChatGPT on [chat.openai.com](https://chat.openai.com/).
-# 
+#
 # You can try this out from the command line using the `modal` CLI, or serve the application and use the
 # included web endpoint.
 #
@@ -25,10 +25,11 @@ stub = modal.Stub(
 
 # This is all the code needed to stream answers back from ChatGPT.
 # Not much code to worry about!
-# 
+#
 # Because this Python function is decorated with `@stub.function`, it becomes
 # callable as a Modal remote function. But `stream_chat` can still be used as a
 # regular Python function, which becomes important below.
+
 
 @stub.function()
 def stream_chat(prompt: str):
@@ -36,15 +37,13 @@ def stream_chat(prompt: str):
 
     for chunk in openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
-        messages=[{
-            "role": "user",
-            "content": prompt
-        }],
+        messages=[{"role": "user", "content": prompt}],
         stream=True,
     ):
         content = chunk["choices"][0].get("delta", {}).get("content")
         if content is not None:
             yield content
+
 
 # ## Streaming web endpoint
 #
@@ -55,25 +54,28 @@ def stream_chat(prompt: str):
 # Notice that the `stream_chat` function is passed into the retuned streaming response.
 # This works because the function is a generator and is thus compatible with streaming.
 #
-# We use the standard Python calling convention `stream_chat(...)` and not the 
+# We use the standard Python calling convention `stream_chat(...)` and not the
 # Modal-specific calling convention `stream_chat.call(...)`. The latter would still work,
 # but it would create a remote function invocation which would uncessarily involve `stream_chat`
 # running in a separate container and sending its results back to the caller over the network.
+
 
 @stub.function()
 @stub.web_endpoint()
 def web(prompt: str):
     from fastapi.responses import StreamingResponse
+
     return StreamingResponse(stream_chat(prompt), media_type="text/html")
 
+
 # ## Try out the web endpoint
-# 
+#
 # Run this example with `modal serve chatgpt_streaming.py` and you'll see an ephemeral web endpoint
 # has started serving. Hit this endpoint with a prompt and see the ChatGPT response streaming back in
 # your browser or terminal window.
-# 
+#
 # We've also already deployed this example and so you can try out our deployed web endpoint:
-# 
+#
 # ```bash
 # curl --get \
 #   --data-urlencode "prompt=Generate a list of 20 great names for sentient cheesecakes that teach SQL" \
@@ -81,10 +83,13 @@ def web(prompt: str):
 # ```
 #
 # ## CLI interface
-# 
+#
 # Doing `modal run chatgpt_streaming.py --prompt="Generate a list of the world's most famous people"` also works, and uses the `local_entrypoint` defined below.
 
-default_prompt = "Generate a list of 20 great names for sentient cheesecakes that teach SQL"
+default_prompt = (
+    "Generate a list of 20 great names for sentient cheesecakes that teach SQL"
+)
+
 
 @stub.local_entrypoint()
 def main(prompt: str = default_prompt):

--- a/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
+++ b/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
@@ -1,3 +1,19 @@
+#
+# # Using the ChatGPT streaming API
+# 
+# This example shows how to stream from the ChatGPT API as the model is generating a completion, instead of 
+# waiting for the entire completion to finish. This provides a much better user experience, and is what you
+# get when playing with ChatGPT on [chat.openai.com](https://chat.openai.com/).
+# 
+# You can try this out from the command line using the `modal` CLI, or serve the application and use the
+# included web endpoint.
+#
+# ## Imports and Modal application configuration
+#
+# OpenAI's Python client library is the only package dependency we need. We also need an API key.
+# The former is specified in the Modal application's `image` definition, and the latter is attached to the app's
+# stub as a [`modal.Secret`](/docs/guide/secrets).
+
 import modal
 
 image = modal.Image.debian_slim().pip_install("openai")
@@ -7,10 +23,17 @@ stub = modal.Stub(
     secrets=[modal.Secret.from_name("openai-secret")],
 )
 
+# This is all the code needed to stream answers back from ChatGPT.
+# Not much code to worry about!
+# 
+# Because this Python function is decorated with `@stub.function`, it becomes
+# callable as a Modal remote function. But `stream_chat` can still be used as a
+# regular Python function, which becomes important below.
+
 @stub.function()
 def stream_chat(prompt: str):
     import openai
-    
+
     for chunk in openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=[{
@@ -23,9 +46,47 @@ def stream_chat(prompt: str):
         if content is not None:
             yield content
 
+# ## Streaming web endpoint
+#
+# These four lines are all that's needed to take that function above and serve it
+# over HTTP. It is a single function definition, annotated with decorators to make
+# it a Modal function that is [wrapped in a web serving capability](/docs/guide/webhooks).
+#
+# Notice that the `stream_chat` function is passed into the retuned streaming response.
+# This works because the function is a generator and is thus compatible with streaming.
+#
+# We use the standard Python calling convention `stream_chat(...)` and not the 
+# Modal-specific calling convention `stream_chat.call(...)`. The latter would still work,
+# but it would create a remote function invocation which would uncessarily involve `stream_chat`
+# running in a separate container and sending its results back to the caller over the network.
+
+@stub.function()
+@stub.web_endpoint()
+def web(prompt: str):
+    from fastapi.responses import StreamingResponse
+    return StreamingResponse(stream_chat(prompt), media_type="text/html")
+
+# ## Try out the web endpoint
+# 
+# Run this example with `modal serve chatgpt_streaming.py` and you'll see an ephemeral web endpoint
+# has started serving. Hit this endpoint with a prompt and see the ChatGPT response streaming back in
+# your browser or terminal window.
+# 
+# We've also already deployed this example and so you can try out our deployed web endpoint:
+# 
+# ```bash
+# curl --get \
+#   --data-urlencode "prompt=Generate a list of 20 great names for sentient cheesecakes that teach SQL" \
+#   https://modal-labs--example-chatgpt-stream-web.modal.run
+# ```
+#
+# ## CLI interface
+# 
+# Doing `modal run chatgpt_streaming.py --prompt="Generate a list of the world's most famous people"` also works, and uses the `local_entrypoint` defined below.
+
+default_prompt = "Generate a list of 20 great names for sentient cheesecakes that teach SQL"
 
 @stub.local_entrypoint()
-def main():
-    demo_prompt = "Generate a list of 20 great names for sentient cheesecakes that teach SQL"
-    for part in stream_chat.call(prompt=demo_prompt):
+def main(prompt: str = default_prompt):
+    for part in stream_chat.call(prompt=prompt):
         print(part, end="")

--- a/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
+++ b/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
@@ -47,9 +47,9 @@ def stream_chat(prompt: str):
 
 # ## Streaming web endpoint
 #
-# These four lines are all that's needed to take that function above and serve it
+# These four lines are all you need to take that function above and serve it
 # over HTTP. It is a single function definition, annotated with decorators to make
-# it a Modal function that is [wrapped in a web serving capability](/docs/guide/webhooks).
+# it a Modal function [with a web serving capability](/docs/guide/webhooks).
 #
 # Notice that the `stream_chat` function is passed into the retuned streaming response.
 # This works because the function is a generator and is thus compatible with streaming.

--- a/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
+++ b/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
@@ -1,0 +1,31 @@
+import modal
+
+image = modal.Image.debian_slim().pip_install("openai")
+stub = modal.Stub(
+    name="example-chatgpt-stream",
+    image=image,
+    secrets=[modal.Secret.from_name("openai-secret")],
+)
+
+@stub.function()
+def stream_chat(prompt: str):
+    import openai
+    
+    for chunk in openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{
+            "role": "user",
+            "content": prompt
+        }],
+        stream=True,
+    ):
+        content = chunk["choices"][0].get("delta", {}).get("content")
+        if content is not None:
+            yield content
+
+
+@stub.local_entrypoint()
+def main():
+    demo_prompt = "Generate a list of 20 great names for sentient cheesecakes that teach SQL"
+    for part in stream_chat.call(prompt=demo_prompt):
+        print(part, end="")


### PR DESCRIPTION
It's actually pretty cool how easy this is. 

---

I couldn't have a single Modal function because I got an error that a `@stub.web_endpoint` must return a streaming response while I needed the function to have a return type `Union[StreamingResponse, Iterable[str]]`. 

But being [able to call a Modal function as a standard Python function](https://github.com/modal-labs/modal-examples/compare/jonathon/chatgpt-streaming?expand=1#diff-6e8b58b0668dca39d184f38b455bcef5963f94f6854f40984242d41b293bcf01R67) came in handy so I still got nice code reuse :)

I'm going to link this example from our new streaming doc page (also just noticed a typo I need to fix 😖) — https://modal.com/docs/guide/streaming-endpoints.