### PR TITLE
make 'hello world' ex clear about local/remote execution

### DIFF
--- a/01_getting_started/hello_world.py
+++ b/01_getting_started/hello_world.py
@@ -46,15 +46,19 @@ def f(i):
 # Run `modal run hello_world.py` and the `@stub.local_entrypoint()` decorator will handle
 # starting the Modal app and then executing the wrapped function body.
 #
-# Inside the `main()` function body, we are calling the function `f` in two ways:
+# Inside the `main()` function body, we are calling the function `f` in three ways:
 #
-# 1. As a simple call `f.call(1000)`
-# 2. By mapping over the integers 0..19
+# 1  As a simple local call, `f(1000)`
+# 2. As a simple *remote* call `f.call(1000)`
+# 3. By mapping over the integers `0..19`
 
 
 @stub.local_entrypoint()
 def main():
-    # Call the function directly.
+    # Call the function locally.
+    print(f(1000))
+
+    # Call the function remotely.
     print(f.call(1000))
 
     # Parallel map.
@@ -67,7 +71,7 @@ def main():
 
 # ## What happens?
 #
-# When you call this, Modal will execute the function `f` **in the cloud,**
+# When you do `.call` on function `f`, Modal will execute `f` **in the cloud,**
 # not locally on your computer. It will take the code, put it inside a
 # container, run it, and stream all the output back to your local
 # computer.


### PR DESCRIPTION
Motivated by https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1681242971024609 I went looking for a place in our docs to add more about the `f()` vs `f.call()` distinction. 

> Aside: The log streaming was definitely more sluggish than it used to be. It used to be so snappy. 

cc @erikbern as this is a prominent example and you may have thoughts.