### PR TITLE
initial demo of stable lm

### DIFF
--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -20,7 +20,6 @@ def build_models():
     model_path = snapshot_download(
         "stabilityai/stablelm-tuned-alpha-7b",
         ignore_patterns=["*.md"],
-        revision="25071b093c15c0d1cb2b2876c6deb621b764fcf5",
     )
     m = AutoModelForCausalLM.from_pretrained(
         model_path,
@@ -42,11 +41,13 @@ image = (
     .conda_install(
         "cudatoolkit-dev=11.7",
         "pytorch-cuda=11.7",
-        channels=["nvidia", "pytorch"],
+        "rust=1.69.0",
+        channels=["nvidia", "pytorch", "conda-forge"],
     )
     .env(
         {
             "HF_HOME": "/root",
+            "HF_HUB_ENABLE_HF_TRANSFER": "1",
             "SAFETENSORS_FAST_GPU": "1",
             "BITSANDBYTES_NOWELCOME": "1",
             "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -98,6 +99,8 @@ class CompletionResponse(BaseModel):
 class StabilityLM:
     def __init__(self, model_url: str = "stabilityai/stablelm-tuned-alpha-7b"):
         self.model_url = model_url
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
     def __enter__(self):
         """

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -1,0 +1,152 @@
+import itertools
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional
+
+import torch
+from fastapi import Query
+from huggingface_hub import snapshot_download
+from pydantic import BaseModel, Field
+from rich import print
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    GenerationConfig,
+    StoppingCriteria,
+    StoppingCriteriaList,
+    pipeline,
+)
+
+import modal
+
+
+def fetch_models():
+    MODEL_PATH = snapshot_download("stabilityai/stablelm-tuned-alpha-7b", ignore_patterns=["*.md"], revision="25071b093c15c0d1cb2b2876c6deb621b764fcf5")
+
+
+def compile_models():
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    MODEL_PATH = snapshot_download("stabilityai/stablelm-tuned-alpha-7b", ignore_patterns=["*.md"], revision="25071b093c15c0d1cb2b2876c6deb621b764fcf5")
+    m = AutoModelForCausalLM.from_pretrained(MODEL_PATH, torch_dtype=torch.float16, local_files_only=True).cuda()
+    tok = AutoTokenizer.from_pretrained(MODEL_PATH, local_files_only=True)
+    m = torch.compile(m)
+    m.save_pretrained(MODEL_PATH, safe_serialization=True, max_shard_size="24GB")
+    tok.save_pretrained(MODEL_PATH)
+    [p.unlink() for p in Path(MODEL_PATH).rglob("*.bin")]
+
+
+image = (
+    modal.Image.conda()
+    .apt_install("git", "software-properties-common", "curl", "wget", "libopenblas-dev", "libblas-dev", "g++", "libboost-all-dev", "cmake", "ninja-build", "libpq-dev", "libatlas-base-dev", "gfortran", "libclblast-dev", "libprotobuf-dev", "protobuf-compiler")
+    .conda_install(
+        "cudatoolkit-dev=11.7",
+        "pytorch-cuda=11.7",
+        channels=["nvidia", "pytorch"],
+    )
+    .env({"HF_HOME": "/root", "SAFETENSORS_FAST_GPU": "1", "BITSANDBYTES_NOWELCOME": "1", "PIP_DISABLE_PIP_VERSION_CHECK": "1", "PIP_NO_CACHE_DIR": "1"})
+    .run_commands(
+        "pip install transformers==4.28.1 accelerate==0.18.0 safetensors==0.3.0 bitsandbytes==0.38.1 sentencepiece==0.1.98",
+        gpu="A10G"
+    )
+    .run_function(
+        fetch_models,
+        gpu=None,
+        timeout=3600,
+    )
+    .run_function(
+        compile_models,
+        gpu="A10G",
+        timeout=3600,
+    )
+)
+
+stub = modal.Stub(name="example-stability-lm", image=image)
+
+
+class StopOnTokens(StoppingCriteria):
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        stop_ids = [50278, 50279, 50277, 1, 0]
+        for stop_id in stop_ids:
+            if input_ids[0][-1] == stop_id:
+                return True
+        return False
+
+
+@stub.cls(gpu="A10G")
+class Alpha7B:
+    def __init__(self, model_url: str = "stabilityai/stablelm-tuned-alpha-7b"):
+        self.model_url = model_url
+
+    def __enter__(self):
+        """
+        Container-lifeycle method for model setup.
+        """
+        import accelerate
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        start = time.time()
+        tokenizer = AutoTokenizer.from_pretrained(self.model_url)
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_url,
+            torch_dtype=torch.float16,
+            device_map="auto",
+        )
+        print(f"Loaded model in {time.time() - start:.2f} seconds.")
+
+        if hasattr(model.config, "max_sequence_length"):
+            context_len = model.config.max_sequence_length
+        else:
+            context_len = 4096
+
+        self.context_len = context_len
+        self.generator = pipeline(
+            "text-generation",
+            model=model,
+            tokenizer=tokenizer,
+            torch_dtype=torch.float16,
+            device_map="auto",
+        )
+
+    @modal.method()
+    def generate(
+        self, text: str, temperature: float = 1.0, max_new_tokens: int = 1024
+    ):
+        text = format_prompt(text)
+        result = self.generator(
+            text,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+            num_return_sequences=1,
+            num_beams=1,
+            do_sample=True,
+            top_p=0.95,
+            top_k=1000,
+            stopping_criteria=StoppingCriteriaList([StopOnTokens()]),
+        )
+        return {"response": result[0]["generated_text"].replace(text, "")}
+
+
+def format_prompt(instruction):
+    return f"<|USER|>{instruction}<|ASSISTANT|>"
+
+
+@stub.function()
+@modal.web_endpoint(method="GET")
+def ask(prompt: str, temperature: float = 1.0, max_new_tokens: int = 512):
+    return Alpha7B().generate.call(
+        prompt, temperature=temperature, max_new_tokens=max_new_tokens
+    )
+
+
+@stub.local_entrypoint()
+def main():
+    q_style, q_end = "[bold bright_magenta]", "[/bold bright_magenta]"
+    instructions = [
+        "Generate a list of 20 great names for sentient cheesecakes that teach SQL.",
+        "How can I tell apart female and male red cardinals?",
+    ]
+    for q, a in zip(instructions, list(Alpha7B().generate.map(instructions))):
+        print(f"{q_style}{q}{q_end}\n{a['response']}\n\n")

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -129,7 +129,9 @@ class StabilityLM:
             do_sample=completion_request.do_sample,
             pad_token_id=self.generator.tokenizer.eos_token_id,
             eos_token_id=self.generator.tokenizer.convert_tokens_to_ids(
-                completion_request.stop
+                self.generator.tokenizer.tokenize(
+                    "".join(completion_request.stop)
+                )
             ),
         )
         return {"text": result[0]["generated_text"].replace(text, "")}

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -115,7 +115,9 @@ class StabilityLM:
             model=self.model_url,
             torch_dtype=torch.float16,
             device_map="auto",
+            model_kwargs={"local_files_only": True},
         )
+        self.generator.model = torch.compile(self.generator.model)
 
     @modal.method()
     def generate(self, completion_request: CompletionRequest):

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -1,13 +1,7 @@
-import itertools
-import os
-import re
-import sys
 import time
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional
 
 import torch
-from fastapi import Query
 from huggingface_hub import snapshot_download
 from pydantic import BaseModel, Field
 from rich import print
@@ -76,7 +70,7 @@ class StopOnTokens(StoppingCriteria):
 
 
 @stub.cls(gpu="A10G")
-class Alpha7B:
+class StabilityLM:
     def __init__(self, model_url: str = "stabilityai/stablelm-tuned-alpha-7b"):
         self.model_url = model_url
 
@@ -136,7 +130,7 @@ def format_prompt(instruction):
 @stub.function()
 @modal.web_endpoint(method="GET")
 def ask(prompt: str, temperature: float = 1.0, max_new_tokens: int = 512):
-    return Alpha7B().generate.call(
+    return StabilityLM().generate.call(
         prompt, temperature=temperature, max_new_tokens=max_new_tokens
     )
 
@@ -148,5 +142,5 @@ def main():
         "Generate a list of 20 great names for sentient cheesecakes that teach SQL.",
         "How can I tell apart female and male red cardinals?",
     ]
-    for q, a in zip(instructions, list(Alpha7B().generate.map(instructions))):
+    for q, a in zip(instructions, list(StabilityLM().generate.map(instructions))):
         print(f"{q_style}{q}{q_end}\n{a['response']}\n\n")

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -46,11 +46,6 @@ image = (
         gpu="A10G"
     )
     .run_function(
-        fetch_models,
-        gpu=None,
-        timeout=3600,
-    )
-    .run_function(
         compile_models,
         gpu="A10G",
         timeout=3600,

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -139,7 +139,7 @@ def ask(prompt: str, temperature: float = 1.0, max_new_tokens: int = 512):
 def main():
     q_style, q_end = "[bold bright_magenta]", "[/bold bright_magenta]"
     instructions = [
-        "Generate a list of 20 great names for sentient cheesecakes that teach SQL.",
+        "Generate a list of the 10 most beautiful cities in the world..",
         "How can I tell apart female and male red cardinals?",
     ]
     for q, a in zip(instructions, list(StabilityLM().generate.map(instructions))):

--- a/06_gpu_and_ml/stable_lm/requirements.txt
+++ b/06_gpu_and_ml/stable_lm/requirements.txt
@@ -4,3 +4,4 @@ accelerate~=0.18.0
 bitsandbytes~=0.38.1
 sentencepiece~=0.1.98
 hf-transfer~=0.1.3
+msgspec~=0.14.2

--- a/06_gpu_and_ml/stable_lm/requirements.txt
+++ b/06_gpu_and_ml/stable_lm/requirements.txt
@@ -1,0 +1,5 @@
+transformers~=4.28.1
+safetensors~=0.3.0
+accelerate~=0.18.0
+bitsandbytes~=0.38.1
+sentencepiece~=0.1.98

--- a/06_gpu_and_ml/stable_lm/requirements.txt
+++ b/06_gpu_and_ml/stable_lm/requirements.txt
@@ -3,3 +3,4 @@ safetensors~=0.3.0
 accelerate~=0.18.0
 bitsandbytes~=0.38.1
 sentencepiece~=0.1.98
+hf-transfer~=0.1.3


### PR DESCRIPTION
Initial demo of running zero-shot text generation with Stability AI's [stablelm-tuned-alpha-7b](https://huggingface.co/stabilityai/stablelm-tuned-alpha-7b). Converted model checkpoints to `safetensors` format and used `accelerate` to manage device mapping for faster container load times.

Inspired by Modal's [alpaca_lora](https://github.com/modal-labs/modal-examples/blob/e994cd6f8411232f49b9485aa8fdb0fc3114047c/06_gpu_and_ml/alpaca/alpaca_lora.py) example.
