### PR TITLE
Use 'device_auto' for hopefully faster StableDiffusion model load

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
@@ -144,10 +144,12 @@ class StableDiffusion:
             algorithm_type="dpmsolver++",
             solver_type="midpoint",
             denoise_final=True,  # important if steps are <= 10
+            low_cpu_mem_usage=True,
             device_map="auto",
         )
         self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(
             cache_path, scheduler=scheduler,
+            low_cpu_mem_usage=True,
             device_map="auto",
         )
         self.pipe.enable_xformers_memory_efficient_attention()

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
@@ -91,11 +91,11 @@ image = (
     Image.debian_slim(python_version="3.10")
     .pip_install(
         "accelerate",
-        "diffusers[torch]>=0.10",
+        "diffusers[torch]>=0.15.1",
         "ftfy",
         "torch",
         "torchvision",
-        "transformers",
+        "transformers~=4.25.1",
         "triton",
         "safetensors",
         "torch>=2.0",
@@ -135,21 +135,22 @@ class StableDiffusion:
 
         torch.backends.cuda.matmul.allow_tf32 = True
 
-        with torch.device("cuda"):
-            scheduler = diffusers.DPMSolverMultistepScheduler.from_pretrained(
-                cache_path,
-                subfolder="scheduler",
-                solver_order=2,
-                prediction_type="epsilon",
-                thresholding=False,
-                algorithm_type="dpmsolver++",
-                solver_type="midpoint",
-                denoise_final=True,  # important if steps are <= 10
-            )
-            self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(
-                cache_path, scheduler=scheduler
-            ).to("cuda")
-            self.pipe.enable_xformers_memory_efficient_attention()
+        scheduler = diffusers.DPMSolverMultistepScheduler.from_pretrained(
+            cache_path,
+            subfolder="scheduler",
+            solver_order=2,
+            prediction_type="epsilon",
+            thresholding=False,
+            algorithm_type="dpmsolver++",
+            solver_type="midpoint",
+            denoise_final=True,  # important if steps are <= 10
+            device_map="auto",
+        )
+        self.pipe = diffusers.StableDiffusionPipeline.from_pretrained(
+            cache_path, scheduler=scheduler,
+            device_map="auto",
+        )
+        self.pipe.enable_xformers_memory_efficient_attention()
 
     @method()
     def run_inference(


### PR DESCRIPTION
This is a direct followup to #279 

I don't think that previous optimization change worked, because it still required [`.to("cuda")`](https://github.com/modal-labs/modal-examples/pull/279/files#diff-71151f22f5be7655be13e817d5d2fcd21203d7274ae7db9accaf8fa5fba655baR150) to properly place the model on the GPU. The use of the context-manager wasn't causing the model load to bypass the CPU. 

If the context-manager worked, then `.to("cuda")` wouldn't be needed. See [Making model initialization faster](http://lernapparat.de/faster-model-init) for the best explanation of why that I saw. Basically, the `diffusers` and `transformers` models need to be updated to [conform to these requirements](https://pytorch.org/tutorials/prototype/skip_param_init.html#updating-modules-to-support-skipping-initialization) and if they don't then the context-manager doesn't optimize loading. 

These updates haven't yet been made, as far as I can see, and this isn't surprising because these developments are only 1-2 months old. But in future this context-manager technique may be the default way to automatically skip CPU initialization of pre-trained models. 

But there maybe still is an optimization available to us: https://huggingface.co/docs/transformers/main_classes/model#large-model-loading

> Moreover, you can directly place the model on different devices if it doesn’t fully fit in RAM (only works for inference for now). With `device_map="auto"`

> Using low_cpu_mem_usage=True will initialize the model on the meta device (requires Accelerate as an extra dep) and should speed up the initialization as a result. ... **source:** https://github.com/huggingface/transformers/issues/21913#issuecomment-1453482689

If this works, then it's still skipping the CPU and doing the optimization we seek. 



