### PR TITLE
Switch from flake8 to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E501,W503,E741,E266,E203,E402
-exclude =
-    .venv
-    __pycache__

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Black
         run: black --check .
 
-  flake8:
-    name: Flake8
+  ruff:
+    name: Ruff
     runs-on: ubuntu-20.04
 
     steps:
@@ -30,11 +30,11 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install flake8
-        run: pip install flake8
+      - name: Install ruff
+        run: pip install ruff
 
-      - name: Check flake8
-        run: flake8 .
+      - name: Check lint with Ruff
+        run: ruff check .
 
   isort:
     name: Isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,12 @@ no_strict_optional = true
 [[tool.mypy.overrides]]
 module = "requests"
 ignore_missing_imports = true
+
+[tool.ruff]
+# TODO: Add when available: "E266", "E203"
+ignore = ["E501","E741","E402"]
+exclude = [
+    ".venv",
+    "venv",
+    "__pycache__",
+]


### PR DESCRIPTION
We’ve already done this in the other repos, and I just ran flake8 over the repo and it’s sooo slow compared to ruff.

Part of proposed changes in **modal-examples repo tune-up** document.