### PR TITLE
Fixes parsing error

### DIFF
--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -314,7 +314,7 @@ def main():
         print(part, end="", flush=True)
 
 
-# ```
+# ```bash
 # curl $MODEL_APP_ENDPOINT \
 #   -H "Content-Type: application/json" \
 #   -d '{

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -313,7 +313,7 @@ def main():
     ):
         print(part, end="", flush=True)
 
-
+# ```
 # curl $MODEL_APP_ENDPOINT \
 #   -H "Content-Type: application/json" \
 #   -d '{
@@ -321,3 +321,4 @@ def main():
 #     "stream": true,
 #     "max_tokens": 64
 #   }'
+# ```

--- a/06_gpu_and_ml/stable_lm/main.py
+++ b/06_gpu_and_ml/stable_lm/main.py
@@ -313,6 +313,7 @@ def main():
     ):
         print(part, end="", flush=True)
 
+
 # ```
 # curl $MODEL_APP_ENDPOINT \
 #   -H "Content-Type: application/json" \


### PR DESCRIPTION
Fixes parsing error breaking our FE builds. We still need to write more notes on how to use this example, but restricting this addition to just fixing the code snippet to prevent a parsing error.