### PR TITLE
Notebooks examples

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,23 @@ jobs:
       - name: Run
         run: python3 internal/typecheck.py
 
+  nbconvert:
+    name: NbConvert
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install NbConvert
+        run: pip install jupyter nbconvert
+
+      - name: Check notebooks are cleaned
+        run: |
+          jupyter nbconvert --clear-output --inplace 11_notebooks/*.ipynb
+          git diff --quiet && git diff --cached --quiet || exit 1
+
   pytest:
     name: Pytest
     runs-on: ubuntu-20.04

--- a/11_notebooks/basic.ipynb
+++ b/11_notebooks/basic.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install modal-client\n",
+    "%pip install ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import modal\n",
+    "assert modal.__version__ > '0.49.0'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import modal\n",
+    "\n",
+    "stub = modal.Stub(name=\"example-basic-notebook\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Handling standard Python functions\n",
+    "\n",
+    "Standard Python functions can of course be defined in a notebook and used on their own or be called within Modal functions.\n",
+    "Below the `double` function is defined in pure-Python, and called once locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def double(x: int) -> int:\n",
+    "    return x + x\n",
+    "\n",
+    "double(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Handling Modal Functions\n",
+    "\n",
+    "If we wanted to run this trivial doubling function *in the cloud* we can write another function `double_with_modal` and decorate it with `@stub.function` to register\n",
+    "the function with the Modal stub.\n",
+    "\n",
+    "To demonstrate that Modal functions you define in the notebook can be called by _other_ Modal functions, there's another function, `quadruple`, which uses `double` and `double_with_modal`.\n",
+    "For numbers greater than 1 million, this function spins up containers that run in Modal, which is a _very_ inefficient way to multiply a number by four, but you can do it if you please!\n",
+    "\n",
+    "Be aware that all Modal functions are defined and run using `with stub.run()` in a single cell. Currently, putting all Modal functions in a single-cell is a limitation of the Modal client.\n",
+    "We aim to make notebook code organization more flexible in the future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@stub.function()\n",
+    "def double_with_modal(x: int) -> int:\n",
+    "    return x + x\n",
+    "\n",
+    "@stub.function()\n",
+    "def quadruple(x: int) -> int:\n",
+    "    if x <= 1_000_000:\n",
+    "        return double(x) + double(x)\n",
+    "    else:\n",
+    "        return double_with_modal.call(x) + double_with_modal.call(x)\n",
+    "\n",
+    "with stub.run():\n",
+    "    print(quadruple(100))\n",
+    "    print(quadruple.call(100))  # run remotely\n",
+    "    result = quadruple.call(10_000_000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate the result created above.\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.5 ('.venv': venv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "41aa4f5b72d46326b95133582f60c55f8bcca2a8619d8a82d21027f6cbc11af9"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Modal and run in our cloud, spawning serverless containers on demand.
 
 ## Examples
 
-* [**`01_getting_started/`**](/01_getting_started) through [**`10_integrations/`**](/10_integrations/) provide a guided tour through Modal's concepts and capabilities.
+* [**`01_getting_started/`**](/01_getting_started) through [**`11_integrations/`**](/11_notebooks/) provide a guided tour through Modal's concepts and capabilities.
 * [**`misc/`**](/misc) contains uncategorized, miscellaneous examples.
 
 ## License


### PR DESCRIPTION
Adds a new **11_notebooks** section with Jupyter Notebook related examples.

* Basic notebook example
* 'Jupyter inside Modal' example, requested here: https://modalbetatesters.slack.com/archives/C031Z7DBQFL/p1676872844882179?thread_ts=1676861135.011809&cid=C031Z7DBQFL
    * Takes Akshat's work from https://gist.github.com/aksh-at/0cc3f1d8840b70f42732de274c804dc7

Next job is to write a guide. Even though there's still one or two rough edges in the notebooks experience, it's worth documenting it for our users. A good notebooks experience is important for model training and fine-tuning, because the people that do that stuff tend to feel at home in notebooks. 