### PR TITLE
stable diffusion: torch 2.0.1+cu117

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
@@ -92,11 +92,11 @@ image = (
         "triton",
         "safetensors",
     )
-    .pip_install("xformers", pre=True)
     .pip_install(
-        "torch==1.12.1+cu116",
+        "torch==2.0.1+cu117",
         find_links="https://download.pytorch.org/whl/torch_stable.html",
     )
+    .pip_install("xformers", pre=True)
     .run_function(
         download_models,
         secrets=[Secret.from_name("huggingface-secret")],


### PR DESCRIPTION
Update stable diffusion example to use `torch` `2.x` as required by latest `xformers`.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
