### PR TITLE
Calling modal function from skopt minimize

### DIFF
--- a/06_gpu_and_ml/skopy_min.py
+++ b/06_gpu_and_ml/skopy_min.py
@@ -1,0 +1,34 @@
+from skopt.space import Real
+from skopt import gp_minimize
+from skopt.utils import use_named_args
+import modal
+
+
+image = modal.Image.debian_slim().pip_install("numpy", "scikit-optimize")
+stub = modal.Stub(image=image)
+
+
+# In this example we are minimizing a simple quadratic function
+# But this can easily be used to tune hyperparameters of a machine learning model
+@stub.function()
+def objective(x):
+    return (x - 5) ** 2
+
+
+# We'll create a space with our hyperparameter x
+space = [Real(-10, 10, name="x")]
+
+
+@use_named_args(space)
+def decorated_function(**hyperparams):
+    return objective.call(hyperparams["x"])
+
+
+def plot_callback(res):
+    print("Iteration {}".format(len(res.func_vals)))
+    print("Current minimum {}".format(res.fun))
+
+
+@stub.local_entrypoint()
+async def main():
+    res = gp_minimize(decorated_function, space, n_calls=15, callback=[plot_callback], random_state=42)


### PR DESCRIPTION
This is a simple example of how to call a modal function inside a [skopt minimize function](https://scikit-optimize.github.io/stable/modules/generated/skopt.gp_minimize.html#skopt.gp_minimize). This is useful for scaling hyperparameter tuning.

let me know if i need to do anything for the testing/formatting/dependencies!

### Type of Change

- [X] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style. 

## Outside contributors

You're great! Thanks for your contribution.
