### PR TITLE
perf: Use hf-transfer to dl large Falcon models

### DIFF
--- a/06_gpu_and_ml/falcon_bitsandbytes.py
+++ b/06_gpu_and_ml/falcon_bitsandbytes.py
@@ -45,12 +45,15 @@ image = (
         "peft @ git+https://github.com/huggingface/peft.git",
         "transformers @ git+https://github.com/huggingface/transformers.git",
         "accelerate @ git+https://github.com/huggingface/accelerate.git",
+        "hf-transfer~=0.1",
         "torch==2.0.0",
         "torchvision==0.15.1",
         "sentencepiece==0.1.97",
         "huggingface_hub==0.14.1",
         "einops==0.6.1",
     )
+    # Use huggingface's hi-perf hf-transfer library to download this large model.
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
     .run_function(download_falcon_40b)
 )
 

--- a/06_gpu_and_ml/falcon_gptq.py
+++ b/06_gpu_and_ml/falcon_gptq.py
@@ -44,11 +44,14 @@ image = (
     Image.debian_slim(python_version="3.10")
     .apt_install("git")
     .pip_install(
-        "huggingface_hub==0.14.1",
-        "transformers @ git+https://github.com/huggingface/transformers.git@f49a3453caa6fe606bb31c571423f72264152fce",
         "auto-gptq @ git+https://github.com/PanQiWei/AutoGPTQ.git@b5db750c00e5f3f195382068433a3408ec3e8f3c",
         "einops==0.6.1",
+        "hf-transfer~=0.1",
+        "huggingface_hub==0.14.1",
+        "transformers @ git+https://github.com/huggingface/transformers.git@f49a3453caa6fe606bb31c571423f72264152fce",
     )
+    # Use huggingface's hi-perf hf-transfer library to download this large model.
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
     .run_function(download_model)
 )
 


### PR DESCRIPTION
A beta-tester was having trouble with Huggingface network `Read timed out` errors when downloading a huge model from the Huggingface Hub until he started using hf-transfer: https://modalbetatesters.slack.com/archives/C031Z7DBQFL/p1688597095761039?thread_ts=1688563661.016519&cid=C031Z7DBQFL

It sacrifices progress bars for increased throughput (and possibly better download reliability?)

If `hf-transfer` is still not reliable, this snippet can be used to retry the download: 

```python
def download_model():
    import requests.exceptions
    import transformers
    from huggingface_hub import snapshot_download
    from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential

    for attempt in Retrying(
        reraise=True,
        retry=retry_if_exception_type(requests.exceptions.ConnectionError),
        stop=stop_after_attempt(5),
        wait=wait_exponential(multiplier=1, min=4, max=10),
    ):
        with attempt:
            print(f"Starting download. attempt #{attempt.retry_state.attempt_number}")
            snapshot_download(MODEL_NAME, local_dir=IMAGE_MODEL_DIR)
    transformers.utils.move_cache()
```

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)


