### PR TITLE
fix: provide default 'None' on Optional fields

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install Modal client package and jupytext
-        run: pip install modal-client jupytext pydantic
+        run: pip install modal-client jupytext pydantic~=1.10
 
       - name: Run deployment script
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,7 +97,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install dev dependencies
-        run: pip install pytest jupytext
+        run: pip install pytest jupytext pydantic~=1.10
 
       - name: Install the Modal client
         run: pip install modal-client

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -26,12 +26,12 @@ class Example(BaseModel):
     filename: str  # absolute filepath to example file
     module: Optional[
         str
-    ]  # python import path, or none if file is not a py module.
+    ] = None  # python import path, or none if file is not a py module.
     # TODO(erikbern): don't think the module is used (by docs or monitors)?
-    metadata: Optional[dict]
+    metadata: Optional[dict] = None
     repo_filename: str  # git repo relative filepath
-    cli_args: Optional[list]  # Full command line args to run it
-    stem: Optional[str]  # stem of path
+    cli_args: Optional[list] = None  # Full command line args to run it
+    stem: Optional[str] = None  # stem of path
 
 
 _RE_NEWLINE = re.compile(r"\r?\n")


### PR DESCRIPTION
In Github Actions CI we have some stricter PyDantic validation enabled that is not happy that we in some places don't provide constructor arguments for `Optional` BaseModel fields.
