### PR TITLE
pytube fix is no longer needed

### DIFF
--- a/06_gpu_and_ml/openai_whisper/streaming/main.py
+++ b/06_gpu_and_ml/openai_whisper/streaming/main.py
@@ -21,8 +21,7 @@ image = (
     .pip_install(
         "https://github.com/openai/whisper/archive/v20230314.tar.gz",
         "ffmpeg-python",
-        # Uses pytube fix from here: https://github.com/pytube/pytube/pull/1575
-        "pytube @ git+https://github.com/felipeucelli/pytube@03d72641191ced9d92f31f94f38cfb18c76cfb05",
+        "pytube @ git+https://github.com/felipeucelli/pytube",
     )
 )
 stub = modal.Stub(name="example-whisper-streaming", image=image)


### PR DESCRIPTION
…o main.

<!--
Previously, a pytube fork was needed for the Whisper example to work properly. The pull request was accepted by pytube and the branch was deleted causing the example to error. Building from source is recommended by the pytube docs.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style. 

## Outside contributors

You're great! Thanks for your contribution.
