### PR TITLE
Speed up chatbot_spa

### DIFF
--- a/07_web_endpoints/chatbot_spa.py
+++ b/07_web_endpoints/chatbot_spa.py
@@ -31,7 +31,6 @@ stub.chat_histories = Dict.new()
 
 
 def load_tokenizer_and_model():
-    import torch
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained("microsoft/DialoGPT-large")

--- a/07_web_endpoints/chatbot_spa.py
+++ b/07_web_endpoints/chatbot_spa.py
@@ -8,8 +8,8 @@ serverless web handlers and GPUs. The user visits a single-page application,
 written using Solid.js. This interface makes API requests that are handled by a
 Modal function running on the GPU.
 
-The weights of the model are cached in a network file system, so they don't need to be
-downloaded again as long as the app is running.
+The weights of the model are saved in the image, so they don't need to be
+downloaded again while the app is running.
 
 Chat history tensors are saved in a `modal.Dict` distributed dictionary.
 """
@@ -22,31 +22,38 @@ import fastapi
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from modal import Dict, Image, Mount, NetworkFileSystem, Stub, asgi_app
+from modal import Dict, Image, Mount, Stub, asgi_app
 
 assets_path = Path(__file__).parent / "chatbot_spa"
-stub = Stub("example-web-spa")
+stub = Stub("example-chatbot-spa")
 
-stub.cache = NetworkFileSystem.new()
 stub.chat_histories = Dict.new()
 
-gpu_image = Image.debian_slim()
-gpu_image = gpu_image.pip_install(
-    "torch", find_links="https://download.pytorch.org/whl/cu116"
-)
-gpu_image = gpu_image.pip_install("transformers")
-stub.gpu_image = gpu_image
 
-if stub.is_inside(stub.gpu_image):
+def load_tokenizer_and_model():
     import torch
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        "microsoft/DialoGPT-large", cache_dir="/cache"
-    )
+    tokenizer = AutoTokenizer.from_pretrained("microsoft/DialoGPT-large")
     model = AutoModelForCausalLM.from_pretrained(
-        "microsoft/DialoGPT-large", cache_dir="/cache"
+        "microsoft/DialoGPT-large",
+        device_map="auto",
     )
+    return tokenizer, model
+
+
+stub.gpu_image = (
+    Image.debian_slim()
+    .pip_install("torch", find_links="https://download.pytorch.org/whl/cu116")
+    .pip_install("transformers~=4.31", "accelerate")
+    .run_function(load_tokenizer_and_model)
+)
+
+
+if stub.is_inside(stub.gpu_image):
+    import torch
+
+    tokenizer, model = load_tokenizer_and_model()
 
 
 @stub.function(
@@ -67,17 +74,15 @@ def transformer():
     return app
 
 
-@stub.function(
-    gpu="any", image=stub.gpu_image, network_file_systems={"/cache": stub.cache}
-)
+@stub.function(gpu="any", image=stub.gpu_image)
 def generate_response(
     message: str, id: Optional[str] = None
 ) -> Tuple[str, str]:
-    chat_histories = stub.app.chat_histories  # Load the queue object.
+    chat_histories = stub.app.chat_histories  # Load the Dict object.
 
     new_input_ids = tokenizer.encode(
         message + tokenizer.eos_token, return_tensors="pt"
-    )
+    ).to("cuda")
     if id is not None:
         chat_history = chat_histories[id]
         bot_input_ids = torch.cat([chat_history, new_input_ids], dim=-1)


### PR DESCRIPTION
Replace the NetworkFileSystem with an image build step, and make it run transformer inference on the GPU. Previously, it reserved a GPU but was actually running on the CPU — oops!

This example is pretty outdated since LLMs popped off last year, but I think it's still nice to have a small & very fast one.

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style. 
