### PR TITLE
Remove meltano and dbt from synmon

### DIFF
--- a/02_building_containers/screenshot.py
+++ b/02_building_containers/screenshot.py
@@ -1,9 +1,5 @@
-# ---
-# integration-test: false
-# output-directory: "/tmp/screenshots"
-# ---
 # # Screenshot with Chromium
-
+#
 # In this example, we use Modal functions and the `playwright` package to take screenshots
 # of websites from a list of URLs in parallel.
 #

--- a/06_gpu_and_ml/dreambooth/dreambooth_app.py
+++ b/06_gpu_and_ml/dreambooth/dreambooth_app.py
@@ -1,6 +1,5 @@
 # ---
 # deploy: true
-# integration-test: false
 # ---
 #
 # # Pet Art Dreambooth with Hugging Face and Gradio

--- a/06_gpu_and_ml/falcon_bitsandbytes.py
+++ b/06_gpu_and_ml/falcon_bitsandbytes.py
@@ -1,9 +1,8 @@
 # ---
-# integration-test: false
 # args: ["--prompt", "How do planes work?"]
 # ---
 # # Run Falcon-40B with bitsandbytes
-
+#
 # In this example, we download the full-precision weights of the Falcon-40B LLM but load it in 4-bit using
 # Tim Dettmer's [`bitsandbytes`](https://github.com/TimDettmers/bitsandbytes) library. This enables it to fit
 # into a single GPU (A100 40GB).

--- a/06_gpu_and_ml/falcon_gptq.py
+++ b/06_gpu_and_ml/falcon_gptq.py
@@ -1,8 +1,5 @@
-# ---
-# integration-test: false
-# ---
 # # Run Falcon-40B with AutoGPTQ
-
+#
 # In this example, we run a quantized 4-bit version of Falcon-40B, the first open-source large language
 # model of its size, using HuggingFace's [transformers](https://huggingface.co/docs/transformers/index)
 # library and [AutoGPTQ](https://github.com/PanQiWei/AutoGPTQ).

--- a/06_gpu_and_ml/openllama.py
+++ b/06_gpu_and_ml/openllama.py
@@ -1,8 +1,5 @@
-# ---
-# integration-test: false
-# ---
 # # Run OpenLLaMa on an A100 GPU
-
+#
 # In this example, we run [OpenLLaMa](https://github.com/openlm-research/open_llama),
 # an open-source large language model, using HuggingFace's [transformers](https://huggingface.co/docs/transformers/index)
 # library.

--- a/06_gpu_and_ml/vision_model_training.py
+++ b/06_gpu_and_ml/vision_model_training.py
@@ -1,7 +1,5 @@
 # ---
-# cmd: ["modal", "run", "vision_model_training.py::stub.train"]
 # deploy: true
-# integration-test: false
 # lambda-test: false
 # ---
 #

--- a/06_gpu_and_ml/vllm_inference.py
+++ b/06_gpu_and_ml/vllm_inference.py
@@ -1,8 +1,5 @@
-# ---
-# integration-test: false
-# ---
 # # Fast inference with vLLM (Llama 2 13B)
-
+#
 # In this example, we show how to run basic inference, using [`vLLM`](https://github.com/vllm-project/vllm)
 # to take advantage of PagedAttention, which speeds up sequential inferences with optimized key-value caching.
 #

--- a/10_integrations/dbt/modal_dbt.py
+++ b/10_integrations/dbt/modal_dbt.py
@@ -1,5 +1,6 @@
 # ---
-# cmd: ["modal", "run", "code.py::run"]
+# lambda-test: false
+# cmd: ["modal", "run", "10_integrations.dbt.modal_dbt::run"]
 # ---
 
 """This is a simple demonstration of how to run a dbt-core project on Modal

--- a/10_integrations/duckdb_nyc_taxi.py
+++ b/10_integrations/duckdb_nyc_taxi.py
@@ -1,7 +1,3 @@
-# ---
-# integration-test: false
-# output-directory: "/tmp/nyc"
-# ---
 # # Use DuckDB to analyze lots of datasets in parallel
 #
 # The Taxi and Limousine Commission of NYC posts

--- a/10_integrations/meltano/meltano_modal.py
+++ b/10_integrations/meltano/meltano_modal.py
@@ -1,5 +1,6 @@
 # ---
-# cmd: ["modal", "run", "code.py::extract_and_load"]
+# lambda-test: false
+# cmd: ["modal", "run", "10_integrations/meltano/meltano_modal.py::extract_and_load"]
 # ---
 import os
 import shutil

--- a/10_integrations/modal_tailscale.py
+++ b/10_integrations/modal_tailscale.py
@@ -1,5 +1,4 @@
 # ---
-# integration-test: false
 # lambda-test: false
 # ---
 


### PR DESCRIPTION
I removed these examples, which have been failing for a while, and it's not high-priority to maintain those integrations right now.

I also removed some old `integration-test: false` annotations.