### PR TITLE
fix: more reliable dreambooth ex

### DIFF
--- a/06_gpu_and_ml/dreambooth/instance_example_urls.txt
+++ b/06_gpu_and_ml/dreambooth/instance_example_urls.txt
@@ -1,3 +1,3 @@
-https://i.imgur.com/fkRYgv6.png
-https://i.imgur.com/98k9yDg.jpg
-https://i.imgur.com/gHlW8Kw.jpg
+https://modal-public-assets.s3.amazonaws.com/example-dreambooth-app/fkRYgv6.png
+https://modal-public-assets.s3.amazonaws.com/example-dreambooth-app/98k9yDg.jpg
+https://modal-public-assets.s3.amazonaws.com/example-dreambooth-app/gHlW8Kw.jpg


### PR DESCRIPTION
We keep getting `requests.exceptions.HTTPError: 429 Client Error: Unknown Error for url: https://i.imgur.com/fkRYgv6.png` from Imgur when running this example.
