### PR TITLE
Fix dbt_sqlite monitor in examples

### DIFF
--- a/10_integrations/dbt/dbt_sqlite.py
+++ b/10_integrations/dbt/dbt_sqlite.py
@@ -1,12 +1,12 @@
 # ---
-# cmd: ["modal", "run", "10_integrations.dbt.dbt_sqlite::run"]
+# cmd: ["modal", "run", "10_integrations/dbt/dbt_sqlite.py::run"]
 # ---
 #
 # This is a simple demonstration of how to run a dbt-core project on Modal
 # using the dbt-sqlite adapter.
 #
 # The underlying DBT data and models are from https://docs.getdbt.com/docs/get-started/getting-started-dbt-core
-# To run this example, first run the meltano example in 10_integrations/meltano to load the required data
+# To run this example, first run the meltano example in `10_integrations/meltano/` to load the required data
 # into sqlite.
 #
 # **Run this example:**


### PR DESCRIPTION
This is still failing even after the last change, with:

```
✓ Initialized. View app at https://modal.com/apps/ap-fQIyzNfW1pB26LmUua28m8
✓ Created objects.
├── 🔨 Created dbt_cli.
├── 🔨 Created mount 
│   /var/task/modal-examples/10_integrations/dbt/sample_proj_sqlite
├── 🔨 Created mount /var/task/modal-examples/10_integrations/dbt/dbt_sqlite.py
└── 🔨 Created explore.
Traceback (most recent call last):
  File "/pkg/modal/_container_entrypoint.py", line 324, in handle_user_exception
    yield
  File "/pkg/modal/_container_entrypoint.py", line 641, in main
    imp_fun = import_function(container_args.function_def, ser_cls, ser_fun, container_args.serialized_params)
  File "/pkg/modal/_container_entrypoint.py", line 555, in import_function
    module = importlib.import_module(function_def.module_name)
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named '10_integrations'
2023-08-08T17:50:46+0000 User exception caught, exiting
Runner failed with exception: ModuleNotFoundError("No module named '10_integrations'")
```