### PR TITLE
preemption handling in finetune example

### DIFF
--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -51,6 +51,7 @@ stub.volume = output_vol
     volumes={VOL_MOUNT_PATH: output_vol},
 )
 def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
+    print("🏁 (re)starting finetune run")
     from datasets import load_dataset
     from transformers import (
         AutoModelForSeq2SeqLM,

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -52,6 +52,7 @@ stub.volume = output_vol
 
 stub.restart_tracker_dict = modal.Dict.new()
 
+
 def track_restarts(restart_tracker: modal.Dict):
     if not restart_tracker.contains("count"):
         preemption_count = 0
@@ -61,6 +62,7 @@ def track_restarts(restart_tracker: modal.Dict):
         preemption_count = restart_tracker.get("count") + 1
         print(f"Restarting after pre-emption. {preemption_count=}")
         restart_tracker["count"] = preemption_count
+
 
 # ## Finetuning Flan-T5 on XSum dataset
 #
@@ -82,6 +84,7 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
         Seq2SeqTrainingArguments,
         TrainerCallback,
     )
+
     track_restarts(stub.restart_tracker_dict)
 
     # Use size percentage to retrieve subset of the dataset to iterate faster
@@ -175,7 +178,6 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
         load_best_model_at_end=True,
     )
 
-
     trainer = Seq2SeqTrainer(
         model=model,
         args=training_args,
@@ -187,7 +189,7 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
 
     try:
         trainer.train(resume_from_checkpoint=True)
-    except KeyboardInterrupt: # handle possible preemption
+    except KeyboardInterrupt:  # handle possible preemption
         print("received interrupt; saving state and model")
         trainer.save_state()
         trainer.save_model()


### PR DESCRIPTION
Making the Flan T5 example complete training even in the event of multiple pre-emptions. Tested with https://github.com/modal-labs/modal-client/pull/812. 

Example completed run that had simulated preemptions every 20 minutes: https://modal.com/logs/ap-VKZKjrvnrvQRIBQh1ZoCYM. 

(Another run: https://modal.com/logs/ap-xieXQbbKddhyyY7bPxgyvU, which is ongoing at time of PR)

Also should ensure the openAI whisper finetune example is robust to preemption, but won't do that now as it's kinda time consuming to test this stuff.
