### PR TITLE
fix: A100s not working 100% on blender_video example

### DIFF
--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -109,7 +109,7 @@ if stub.is_inside():
 # Note the `gpu="any"` argument which tells Modal to use GPU workers.
 
 
-@stub.function(gpu="any")
+@stub.function(gpu="t4")
 def render_frame(i):
     print(f"Using frame {i}")
 


### PR DESCRIPTION
There's an undiagnosed problem with running this code on A100s. T4 always works fine.