### PR TITLE
fix: modal.exception.InvalidError in streaming example

### DIFF
--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -59,7 +59,7 @@ def sync_fake_video_streamer():
 @web_endpoint()
 def hook():
     return StreamingResponse(
-        sync_fake_video_streamer.remote(), media_type="text/event-stream"
+        sync_fake_video_streamer.remote_gen(), media_type="text/event-stream"
     )
 
 


### PR DESCRIPTION
https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1694721024992329?thread_ts=1694719940.675039&cid=C031Z7H15DG
