### PR TITLE
Fix examples now that we test against Python 3.11

### DIFF
--- a/02_building_containers/screenshot.py
+++ b/02_building_containers/screenshot.py
@@ -31,10 +31,10 @@ stub = modal.Stub("example-screenshot")
 
 
 image = modal.Image.debian_slim().run_commands(
+    "apt-get update",
     "apt-get install -y software-properties-common",
     "apt-add-repository non-free",
     "apt-add-repository contrib",
-    "apt-get update",
     "pip install playwright==1.30.0",
     "playwright install-deps chromium",
     "playwright install chromium",

--- a/06_gpu_and_ml/alpaca/alpaca_lora.py
+++ b/06_gpu_and_ml/alpaca/alpaca_lora.py
@@ -5,7 +5,7 @@ from modal import Image, Stub, method
 # Define a function for downloading the models, that will run once on image build.
 # This allows the weights to be present inside the image for faster startup.
 
-base_model = "decapoda-research/llama-7b-hf"
+base_model = "luodian/llama-7b-hf"
 lora_weights = "tloen/alpaca-lora-7b"
 
 
@@ -45,7 +45,7 @@ image = (
     # dependencies listed by `tloen/alpaca-lora` but that are irrelevant within Modal,
     # e.g. `black` code formatting library.
     .pip_install(
-        "accelerate==0.18.0",
+        "accelerate~=0.18.0",
         "appdirs==1.4.4",
         "bitsandbytes==0.37.0",
         "bitsandbytes-cuda117==0.26.0.post2",
@@ -54,9 +54,9 @@ image = (
         "gradio==3.23.0",
         "peft @ git+https://github.com/huggingface/peft.git@d8c3b6bca49e4aa6e0498b416ed9adc50cc1a5fd",
         "transformers @ git+https://github.com/huggingface/transformers.git@a92e0ad2e20ef4ce28410b5e05c5d63a5a304e65",
-        "torch==2.0.0",
-        "torchvision==0.15.1",
-        "sentencepiece==0.1.97",
+        "torch~=2.1.0",
+        "torchvision~=0.16",
+        "sentencepiece==0.1.99",
     )
     .run_function(download_models)
 )

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -47,7 +47,7 @@ def download_model_weights() -> None:
 
 
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.9")
     .pip_install(
         "donut-python==1.0.7",
         "huggingface-hub==0.16.4",

--- a/10_integrations/dbt/dbt_sqlite.py
+++ b/10_integrations/dbt/dbt_sqlite.py
@@ -46,7 +46,7 @@ dbt_env = modal.Secret.from_dict(
 
 image = (
     modal.Image.debian_slim()
-    .pip_install("dbt-core~=1.3.0", "dbt-sqlite~=1.3.0")
+    .pip_install("dbt-core~=1.4.0", "dbt-sqlite~=1.4.0")
     .run_commands("apt-get install -y git")
 )
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Modal and run in our cloud, spawning serverless containers on demand.
 - [**`01_getting_started/`**](01_getting_started) through [**`11_notebooks/`**](11_notebooks) provide a guided tour through Modal's concepts and capabilities.
 - [**`misc/`**](/misc) contains uncategorized, miscellaneous examples.
 
+_These examples are continuously tested for correctness against Python **3.11**._
+
 ## License
 
 The [MIT license](LICENSE).


### PR DESCRIPTION
Recently we changed our example testing system to use Python 3.11. In future we should test examples for compatibility against multiple Python versions, but for now I've just added a disclaimer to the README.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

