### PR TITLE
Don't assign volumes to stub

### DIFF
--- a/06_gpu_and_ml/dreambooth/dreambooth_app.py
+++ b/06_gpu_and_ml/dreambooth/dreambooth_app.py
@@ -78,7 +78,6 @@ image = (
 
 volume = Volume.persisted("dreambooth-finetuning-volume")
 MODEL_DIR = Path("/model")
-stub.volume = volume
 
 # ## Config
 #
@@ -270,7 +269,7 @@ def train(instance_example_urls):
     # The trained model artefacts have been output to the volume mounted at `MODEL_DIR`.
     # To persist these artefacts for use in future inference function calls, we 'commit' the changes
     # to the volume.
-    stub.volume.commit()
+    volume.commit()
 
 
 # ## The inference function.
@@ -292,7 +291,7 @@ class Model:
         from diffusers import DDIMScheduler, StableDiffusionPipeline
 
         # Reload the modal.Volume to ensure the latest state is accessible.
-        stub.volume.reload()
+        volume.reload()
 
         # set up a hugging face inference pipeline using our model
         ddim = DDIMScheduler.from_pretrained(MODEL_DIR, subfolder="scheduler")

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -39,7 +39,6 @@ image = Image.debian_slim().pip_install(
 
 stub = Stub(name="example-news-summarizer", image=image)
 output_vol = Volume.persisted("finetune-volume")
-stub.volume = output_vol
 
 # ### Handling preemption
 #
@@ -181,7 +180,7 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
     trainer = Seq2SeqTrainer(
         model=model,
         args=training_args,
-        callbacks=[CheckpointCallback(stub.volume)],
+        callbacks=[CheckpointCallback(output_vol)],
         data_collator=data_collator,
         train_dataset=tokenized_xsum_train,
         eval_dataset=tokenized_xsum_test,
@@ -198,7 +197,7 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
     # Save the trained model and tokenizer to the mounted volume
     model.save_pretrained(str(VOL_MOUNT_PATH / "model"))
     tokenizer.save_pretrained(str(VOL_MOUNT_PATH / "tokenizer"))
-    stub.volume.commit()
+    output_vol.commit()
     print("✅ done")
 
 

--- a/06_gpu_and_ml/spam-detect/spam_detect/app.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/app.py
@@ -18,4 +18,3 @@ image = modal.Image.debian_slim(python_version="3.10").pip_install(
 stub = modal.Stub(name="example-spam-detect-llm", image=image)
 # Used to store datasets, trained models, model metadata, config.
 volume = modal.Volume.persisted("example-spam-detect-vol")
-stub.volume = volume

--- a/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
+++ b/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
@@ -47,7 +47,7 @@ stub = Stub(
 # We want to run the web server for Tensorboard at the same time as we are training the Tensorflow model.
 # The easiest way to do this is to set up a shared filesystem between the training and the web server.
 
-stub.volume = NetworkFileSystem.new()
+volume = NetworkFileSystem.new()
 logdir = "/tensorboard"
 
 # ## Training function
@@ -61,9 +61,7 @@ logdir = "/tensorboard"
 #   This makes it a bit easier to run this example even if you don't have Tensorflow installed on you local computer.
 
 
-@stub.function(
-    network_file_systems={logdir: stub.volume}, gpu="any", timeout=600
-)
+@stub.function(network_file_systems={logdir: volume}, gpu="any", timeout=600)
 def train():
     import pathlib
 
@@ -155,7 +153,7 @@ def train():
 # Note that this server will be exposed to the public internet!
 
 
-@stub.function(network_file_systems={logdir: stub.volume})
+@stub.function(network_file_systems={logdir: volume})
 @wsgi_app()
 def tensorboard_app():
     import tensorboard

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -42,7 +42,7 @@ datasette_image = (
 # To separate database creation and maintenance from serving, we'll need the underlying
 # database file to be stored persistently. To achieve this we use a [`Volume`](/docs/guide/volumes).
 
-stub.volume = Volume.persisted("example-covid-datasette-cache-vol")
+volume = Volume.persisted("example-covid-datasette-cache-vol")
 
 VOLUME_DIR = "/cache-vol"
 REPORTS_DIR = pathlib.Path(VOLUME_DIR, "COVID-19")
@@ -59,7 +59,7 @@ DB_PATH = pathlib.Path(VOLUME_DIR, "covid-19.db")
 
 @stub.function(
     image=datasette_image,
-    volumes={VOLUME_DIR: stub.volume},
+    volumes={VOLUME_DIR: volume},
     retries=2,
 )
 def download_dataset(cache=True):
@@ -84,7 +84,7 @@ def download_dataset(cache=True):
     subprocess.run(f"mv {REPORTS_DIR / prefix}/* {REPORTS_DIR}", shell=True)
 
     print("Committing the volume...")
-    stub.volume.commit()
+    volume.commit()
 
     print("Finished downloading dataset.")
 
@@ -97,7 +97,7 @@ def download_dataset(cache=True):
 
 
 def load_daily_reports():
-    stub.volume.reload()
+    volume.reload()
     daily_reports = list(REPORTS_DIR.glob("*.csv"))
     if not daily_reports:
         raise RuntimeError(
@@ -159,7 +159,7 @@ def chunks(it, size):
 
 @stub.function(
     image=datasette_image,
-    volumes={VOLUME_DIR: stub.volume},
+    volumes={VOLUME_DIR: volume},
     timeout=900,
 )
 def prep_db():
@@ -185,7 +185,7 @@ def prep_db():
     db.close()
 
     print("Syncing DB with volume.")
-    stub.volume.commit()
+    volume.commit()
 
 
 # ## Keep it fresh
@@ -211,7 +211,7 @@ def refresh_db():
 
 @stub.function(
     image=datasette_image,
-    volumes={VOLUME_DIR: stub.volume},
+    volumes={VOLUME_DIR: volume},
 )
 @asgi_app()
 def app():


### PR DESCRIPTION
Recent versions of the Modal client lets you work with volumes without attaching them to the stub