### PR TITLE
Remove isort from CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,21 +36,6 @@ jobs:
       - name: Check lint with Ruff
         run: ruff check .
 
-  isort:
-    name: Isort
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-
-      - name: Install isort
-        run: pip install isort
-
-      - name: Check isort
-        run: isort . --check-only --verbose
-
   mypy:
     name: MyPy
     runs-on: ubuntu-20.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install black
         run: pip install black
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install ruff
         run: pip install ruff
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install mypy
         run: pip install mypy==0.950
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install NbConvert
         run: pip install jupyter nbconvert
 
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dev dependencies
         run: pip install pytest jupytext pydantic~=1.10

--- a/06_gpu_and_ml/vision_model_training.py
+++ b/06_gpu_and_ml/vision_model_training.py
@@ -79,7 +79,7 @@ class Config:
     epochs: int = 10
     img_dims: Tuple[int, int] = (32, 224)
     gpu: str = USE_GPU
-    wandb: WandBConfig = WandBConfig()
+    wandb: WandBConfig = dataclasses.field(default_factory=WandBConfig)
 
 
 # ## Get CIFAR-10 dataset


### PR DESCRIPTION
This is made redundant by Ruff.

Also updating CI to use Python 3.11, which is now standard here.