### PR TITLE
Example simplification using `@build`

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
@@ -56,29 +56,6 @@ model_id = "runwayml/stable-diffusion-v1-5"
 cache_path = "/vol/cache"
 
 
-def download_models():
-    import diffusers
-    import torch
-
-    # Download scheduler configuration. Experiment with different schedulers
-    # to identify one that works best for your use-case.
-    scheduler = diffusers.DPMSolverMultistepScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
-        cache_dir=cache_path,
-    )
-    scheduler.save_pretrained(cache_path, safe_serialization=True)
-
-    # Downloads all other models.
-    pipe = diffusers.StableDiffusionPipeline.from_pretrained(
-        model_id,
-        revision="fp16",
-        torch_dtype=torch.float16,
-        cache_dir=cache_path,
-    )
-    pipe.save_pretrained(cache_path, safe_serialization=True)
-
-
 image = (
     Image.debian_slim(python_version="3.10")
     .pip_install(
@@ -95,9 +72,12 @@ image = (
         find_links="https://download.pytorch.org/whl/torch_stable.html",
     )
     .pip_install("xformers", pre=True)
-    .run_function(download_models)
 )
-stub.image = image
+
+with image.run_inside():
+    import diffusers
+    import torch
+
 
 # ## Using container lifecycle methods
 #
@@ -118,14 +98,28 @@ stub.image = image
 # It sends the PIL image back to our CLI where we save the resulting image in a local file.
 
 
-@stub.cls(gpu="A10G")
+@stub.cls(image=image, gpu="A10G")
 class StableDiffusion:
-    def __enter__(self):
-        import diffusers
-        import torch
+    def _download_models(self):
+        # Download scheduler configuration. Experiment with different schedulers
+        # to identify one that works best for your use-case.
+        scheduler = diffusers.DPMSolverMultistepScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+            cache_dir=cache_path,
+        )
+        scheduler.save_pretrained(cache_path, safe_serialization=True)
 
-        torch.backends.cuda.matmul.allow_tf32 = True
+        # Downloads all other models.
+        pipe = diffusers.StableDiffusionPipeline.from_pretrained(
+            model_id,
+            revision="fp16",
+            torch_dtype=torch.float16,
+            cache_dir=cache_path,
+        )
+        pipe.save_pretrained(cache_path, safe_serialization=True)
 
+    def _initialize(self):
         scheduler = diffusers.DPMSolverMultistepScheduler.from_pretrained(
             cache_path,
             subfolder="scheduler",
@@ -146,12 +140,15 @@ class StableDiffusion:
         )
         self.pipe.enable_xformers_memory_efficient_attention()
 
-    @method()
-    def run_inference(
-        self, prompt: str, steps: int = 20, batch_size: int = 4
-    ) -> list[bytes]:
-        import torch
+    def __build__(self):
+        self._download_models()
+        self._initialize()
 
+    def __enter__(self):
+        self._initialize()
+
+    @method()
+    def run_inference(self, prompt: str, steps: int = 20, batch_size: int = 4):
         with torch.inference_mode():
             with torch.autocast("cuda"):
                 images = self.pipe(

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_cli.py
@@ -122,7 +122,9 @@ class StableDiffusion:
     __build__ = __enter__
 
     @method()
-    def run_inference(self, prompt: str, steps: int = 20, batch_size: int = 4):
+    def run_inference(
+        self, prompt: str, steps: int = 20, batch_size: int = 4
+    ) -> list[bytes]:
         with torch.inference_mode():
             with torch.autocast("cuda"):
                 images = self.pipe(

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -18,7 +18,7 @@
 import io
 from pathlib import Path
 
-from modal import Image, Mount, Stub, asgi_app, gpu, method
+from modal import Image, Mount, Stub, asgi_app, build, enter, gpu, method
 
 # ## Define a container image
 #
@@ -64,7 +64,8 @@ with sdxl_image.imports():
 
 @stub.cls(gpu=gpu.A10G(), container_idle_timeout=240, image=sdxl_image)
 class Model:
-    def __build__(self):
+    @build()
+    def build(self):
         ignore = [
             "*.bin",
             "*.onnx_data",
@@ -78,7 +79,8 @@ class Model:
             ignore_patterns=ignore,
         )
 
-    def __enter__(self):
+    @enter()
+    def enter(self):
         load_options = dict(
             torch_dtype=torch.float16,
             use_safetensors=True,

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -15,6 +15,7 @@
 
 # ## Basic setup
 
+import io
 from pathlib import Path
 
 from modal import Image, Mount, Stub, asgi_app, gpu, method
@@ -26,18 +27,6 @@ from modal import Image, Mount, Stub, asgi_app, gpu, method
 #
 # Tip: avoid using global variables in this function to ensure the download step detects model changes and
 # triggers a rebuild.
-
-
-def download_models():
-    from huggingface_hub import snapshot_download
-
-    ignore = ["*.bin", "*.onnx_data", "*/diffusion_pytorch_model.safetensors"]
-    snapshot_download(
-        "stabilityai/stable-diffusion-xl-base-1.0", ignore_patterns=ignore
-    )
-    snapshot_download(
-        "stabilityai/stable-diffusion-xl-refiner-1.0", ignore_patterns=ignore
-    )
 
 
 sdxl_image = (
@@ -52,10 +41,17 @@ sdxl_image = (
         "accelerate~=0.21",
         "safetensors~=0.3",
     )
-    .run_function(download_models)
 )
 
 stub = Stub("stable-diffusion-xl")
+
+with sdxl_image.imports():
+    import fastapi.staticfiles
+    import torch
+    from diffusers import DiffusionPipeline
+    from fastapi import FastAPI
+    from fastapi.responses import Response
+    from huggingface_hub import snapshot_download
 
 # ## Load model and run inference
 #
@@ -68,10 +64,21 @@ stub = Stub("stable-diffusion-xl")
 
 @stub.cls(gpu=gpu.A10G(), container_idle_timeout=240, image=sdxl_image)
 class Model:
-    def __enter__(self):
-        import torch
-        from diffusers import DiffusionPipeline
+    def __build__(self):
+        ignore = [
+            "*.bin",
+            "*.onnx_data",
+            "*/diffusion_pytorch_model.safetensors",
+        ]
+        snapshot_download(
+            "stabilityai/stable-diffusion-xl-base-1.0", ignore_patterns=ignore
+        )
+        snapshot_download(
+            "stabilityai/stable-diffusion-xl-refiner-1.0",
+            ignore_patterns=ignore,
+        )
 
+    def __enter__(self):
         load_options = dict(
             torch_dtype=torch.float16,
             use_safetensors=True,
@@ -114,8 +121,6 @@ class Model:
             denoising_start=high_noise_frac,
             image=image,
         ).images[0]
-
-        import io
 
         byte_stream = io.BytesIO()
         image.save(byte_stream, format="PNG")
@@ -160,15 +165,10 @@ frontend_path = Path(__file__).parent / "frontend"
 )
 @asgi_app()
 def app():
-    import fastapi.staticfiles
-    from fastapi import FastAPI
-
     web_app = FastAPI()
 
     @web_app.get("/infer/{prompt}")
     async def infer(prompt: str):
-        from fastapi.responses import Response
-
         image_bytes = Model().inference.remote(prompt)
 
         return Response(image_bytes, media_type="image/png")


### PR DESCRIPTION
Using https://github.com/modal-labs/modal-client/pull/1136 for some examples.

This is just one or two lines less for most examples, but for `stable_diffusion_cli` it's a drastic reduction since we can use the same function for both `@build()` and `@enter()`