### PR TITLE
Adds GH URL to markdown

### DIFF
--- a/10_integrations/streamlit/serve_streamlit.py
+++ b/10_integrations/streamlit/serve_streamlit.py
@@ -13,7 +13,7 @@
 # The example is structured as two files:
 #
 # 1. This module, which defines the Modal objects (name the script `serve_streamlit.py` locally).
-# 2. `app.py`, which is a Streamlit script and is mounted into a Modal function ([download script](./app.py)).
+# 2. `app.py`, which is a Streamlit script and is mounted into a Modal function ([download script](https://github.com/modal-labs/modal-examples/blob/main/10_integrations/streamlit/app.py)).
 import pathlib
 
 import modal


### PR DESCRIPTION
Python files are not copied when creating bundles, so adding a local link it was before will result in a 404.

I'm adding a Github link instead.
