### PR TITLE
Fix examples to use default image when sufficient

### DIFF
--- a/06_gpu_and_ml/jsonformer/jsonformer_generate.py
+++ b/06_gpu_and_ml/jsonformer/jsonformer_generate.py
@@ -50,7 +50,7 @@ image = (
     )
     .run_function(download_model)
 )
-stub = modal.Stub("example-jsonformer", image=image)
+stub = modal.Stub("example-jsonformer")
 
 
 # ## Generate examples
@@ -58,7 +58,7 @@ stub = modal.Stub("example-jsonformer", image=image)
 # The generate function takes two arguments `prompt` and `json_schema`, where
 # `prompt` is used to describe the domain of your data (for example, "plants")
 # and the schema contains the JSON schema you want to populate.
-@stub.function(gpu=modal.gpu.A10G())
+@stub.function(gpu=modal.gpu.A10G(), image=image)
 def generate(prompt: str, json_schema: dict[str, Any]) -> dict[str, Any]:
     from jsonformer import Jsonformer
     from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/06_gpu_and_ml/mlc_inference.py
+++ b/06_gpu_and_ml/mlc_inference.py
@@ -27,7 +27,7 @@ LLAMA_MODEL_SIZE: str = "13b"
 # Define the image and [Modal Stub](https://modal.com/docs/reference/modal.Stub#modalstub).
 # We use an [official NVIDIA CUDA 12.2 image](https://hub.docker.com/r/nvidia/cuda)
 # to match MLC CUDA requirements.
-image = (
+mlc_image = (
     modal.Image.from_registry(
         "nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04",
         add_python="3.11",
@@ -47,7 +47,7 @@ image = (
         f"cd dist/prebuilt && git clone https://huggingface.co/mlc-ai/mlc-chat-Llama-2-{LLAMA_MODEL_SIZE}-chat-hf-q4f16_1",
     )
 )
-stub = modal.Stub("mlc-inference", image=image)
+stub = modal.Stub("mlc-inference")
 
 
 LOADING_MESSAGE: str = f"""
@@ -77,7 +77,7 @@ LOADING_MESSAGE: str = f"""
 # The `generate` function will load MLC chat and the compiled model into
 # memory and run inference on an input prompt. This is a generator, streaming
 # tokens back to the client as they are generated.
-@stub.function(gpu=GPU)
+@stub.function(gpu=GPU, image=mlc_image)
 def generate(prompt: str) -> Generator[Dict[str, str], None, None]:
     from mlc_chat import ChatModule
     from mlc_chat.callback import DeltaCallback

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -40,7 +40,7 @@ def download_models():
     )
 
 
-image = (
+sdxl_image = (
     Image.debian_slim()
     .apt_install(
         "libglib2.0-0", "libsm6", "libxrender1", "libxext6", "ffmpeg", "libgl1"
@@ -55,7 +55,7 @@ image = (
     .run_function(download_models)
 )
 
-stub = Stub("stable-diffusion-xl", image=image)
+stub = Stub("stable-diffusion-xl")
 
 # ## Load model and run inference
 #
@@ -66,7 +66,7 @@ stub = Stub("stable-diffusion-xl", image=image)
 # online for 4 minutes before spinning down. This can be adjusted for cost/experience trade-offs.
 
 
-@stub.cls(gpu=gpu.A10G(), container_idle_timeout=240)
+@stub.cls(gpu=gpu.A10G(), container_idle_timeout=240, image=sdxl_image)
 class Model:
     def __enter__(self):
         import torch

--- a/06_gpu_and_ml/text_generation_inference.py
+++ b/06_gpu_and_ml/text_generation_inference.py
@@ -78,14 +78,14 @@ def download_model():
 #
 # Finally, we install the `text-generation` client to interface with TGI's Rust webserver over `localhost`.
 
-image = (
+stub = Stub("example-tgi-" + MODEL_ID.split("/")[-1])
+
+tgi_image = (
     Image.from_registry("ghcr.io/huggingface/text-generation-inference:1.0.3")
     .dockerfile_commands("ENTRYPOINT []")
     .run_function(download_model, secret=Secret.from_name("huggingface"))
     .pip_install("text-generation")
 )
-
-stub = Stub("example-tgi-" + MODEL_ID.split("/")[-1], image=image)
 
 
 # ## The model class
@@ -114,6 +114,7 @@ stub = Stub("example-tgi-" + MODEL_ID.split("/")[-1], image=image)
     allow_concurrent_inputs=10,
     container_idle_timeout=60 * 10,
     timeout=60 * 60,
+    image=tgi_image,
 )
 class Model:
     def __enter__(self):

--- a/06_gpu_and_ml/tgi_mixtral.py
+++ b/06_gpu_and_ml/tgi_mixtral.py
@@ -64,14 +64,14 @@ def download_model():
 #
 # Finally, we install the `text-generation` client to interface with TGI's Rust webserver over `localhost`.
 
-image = (
+tgi_image = (
     Image.from_registry("ghcr.io/huggingface/text-generation-inference:1.3.1")
     .dockerfile_commands("ENTRYPOINT []")
     .run_function(download_model, timeout=60 * 20)
     .pip_install("text-generation")
 )
 
-stub = Stub("example-tgi-mixtral", image=image)
+stub = Stub("example-tgi-mixtral")
 
 
 # ## The model class
@@ -98,6 +98,7 @@ stub = Stub("example-tgi-mixtral", image=image)
     allow_concurrent_inputs=10,
     container_idle_timeout=60 * 10,
     timeout=60 * 60,
+    image=tgi_image,
 )
 class Model:
     def __enter__(self):

--- a/06_gpu_and_ml/vllm_mixtral.py
+++ b/06_gpu_and_ml/vllm_mixtral.py
@@ -56,7 +56,7 @@ def download_model_to_folder():
 # run_function to run the function defined above to ensure the weights of
 # the model are saved within the container image.
 
-image = (
+vllm_image = (
     Image.from_registry(
         "nvidia/cuda:12.1.0-base-ubuntu22.04", add_python="3.10"
     )
@@ -65,7 +65,7 @@ image = (
     .run_function(download_model_to_folder, timeout=60 * 20)
 )
 
-stub = Stub("example-vllm-mixtral", image=image)
+stub = Stub("example-vllm-mixtral")
 
 
 # ## The model class
@@ -82,6 +82,7 @@ stub = Stub("example-vllm-mixtral", image=image)
     timeout=60 * 10,
     container_idle_timeout=60 * 10,
     allow_concurrent_inputs=10,
+    image=vllm_image,
 )
 class Model:
     def __enter__(self):


### PR DESCRIPTION
Some of our examples build an image with a bunch of deps and then use it for both the ASGI app image and also the GPU container. Fixing it so it's only used for the latter. 

This was also misleading users into thinking they can only have one image for a stub.