### PR TITLE
Update A1111 example to 1.7.0

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/a1111_webui.py
+++ b/06_gpu_and_ml/stable_diffusion/a1111_webui.py
@@ -48,7 +48,7 @@ def wait_for_port(port: int):
     )
     .env({"LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"})
     .run_commands(
-        "git clone --depth 1 --branch v1.6.0 https://github.com/AUTOMATIC1111/stable-diffusion-webui /webui",
+        "git clone --depth 1 --branch v1.7.0 https://github.com/AUTOMATIC1111/stable-diffusion-webui /webui",
         "python -m venv /webui/venv",
         "cd /webui && . venv/bin/activate && "
         + "python -c 'from modules import launch_utils; launch_utils.prepare_environment()' --xformers",


### PR DESCRIPTION
This Git tag contains a fix for a dependency versioning issue introduced upstream by the stable-diffusion-webui authors on httpx 0.24.1. Bumping the tag fixes the issue.

Resolves #531.
