### PR TITLE
Pin Python and dep versions for embedding download

### DIFF
--- a/06_gpu_and_ml/embeddings/wikipedia/download.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/download.py
@@ -8,7 +8,9 @@ DATASET_CONFIG = "20220301.en"
 
 # We define our Modal Resources that we'll need
 volume = Volume.persisted("embedding-wikipedia")
-image = Image.debian_slim().pip_install("datasets", "apache_beam")
+image = Image.debian_slim(python_version="3.9").pip_install(
+    "datasets==2.16.1", "apache_beam==2.53.0"
+)
 stub = Stub(image=image)
 
 


### PR DESCRIPTION
Looks like this doesn't work for `3.11`, we're investigating.