### PR TITLE
Fix CI and pin black version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install black
-        run: pip install black
+        run: pip install black==23.11.0
 
       - name: Black
         run: black --check .

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/__main__.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/__main__.py
@@ -206,9 +206,11 @@ def train(
     # Distributed training:
     # The .from_pretrained methods guarantee that only one local process can concurrently
     config = AutoConfig.from_pretrained(
-        model_args.config_name
-        if model_args.config_name
-        else model_args.model_name_or_path,
+        (
+            model_args.config_name
+            if model_args.config_name
+            else model_args.model_name_or_path
+        ),
         cache_dir=model_args.cache_dir,
         revision=model_args.model_revision,
         use_auth_token=os.environ["HF_TOKEN"],
@@ -224,17 +226,21 @@ def train(
     config.update({"apply_spec_augment": model_args.apply_spec_augment})
 
     feature_extractor = AutoFeatureExtractor.from_pretrained(
-        model_args.feature_extractor_name
-        if model_args.feature_extractor_name
-        else model_args.model_name_or_path,
+        (
+            model_args.feature_extractor_name
+            if model_args.feature_extractor_name
+            else model_args.model_name_or_path
+        ),
         cache_dir=model_args.cache_dir,
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
     )
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.tokenizer_name
-        if model_args.tokenizer_name
-        else model_args.model_name_or_path,
+        (
+            model_args.tokenizer_name
+            if model_args.tokenizer_name
+            else model_args.model_name_or_path
+        ),
         cache_dir=model_args.cache_dir,
         use_fast=model_args.use_fast_tokenizer,
         revision=model_args.model_revision,
@@ -404,17 +410,17 @@ def train(
     trainer = Seq2SeqTrainer(
         model=model,
         args=training_args,
-        train_dataset=vectorized_datasets["train"]
-        if training_args.do_train
-        else None,
-        eval_dataset=vectorized_datasets["eval"]
-        if training_args.do_eval
-        else None,
+        train_dataset=(
+            vectorized_datasets["train"] if training_args.do_train else None
+        ),
+        eval_dataset=(
+            vectorized_datasets["eval"] if training_args.do_eval else None
+        ),
         tokenizer=feature_extractor,
         data_collator=data_collator,
-        compute_metrics=compute_metrics
-        if training_args.predict_with_generate
-        else None,
+        compute_metrics=(
+            compute_metrics if training_args.predict_with_generate else None
+        ),
     )
 
     logger.info("12. Running training")

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/end_to_end_check.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/end_to_end_check.py
@@ -6,6 +6,7 @@ This module contains an end-to-end test that runs only 1 step of training,
 before testing that the partially trained model can be serialized, saved to
 persistent storage, and then downloaded locally for inference.
 """
+
 import pathlib
 
 import modal

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -2,6 +2,7 @@
 whisper-pod-transcriber uses OpenAI's Whisper modal to do speech-to-text transcription
 of podcasts.
 """
+
 import dataclasses
 import datetime
 import json

--- a/06_gpu_and_ml/spam-detect/spam_detect/app.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/app.py
@@ -2,6 +2,7 @@
 Contains only definitions of Modal objects, to be imported
 from other modules.
 """
+
 import modal
 
 image = modal.Image.debian_slim(python_version="3.10").pip_install(

--- a/06_gpu_and_ml/spam-detect/spam_detect/dataset.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/dataset.py
@@ -2,6 +2,7 @@
 Module for the fetching, pre-processing, and loading of spam classification datasets.
 Currently only provides access to the ENRON email dataset.
 """
+
 import csv
 import json
 import pathlib

--- a/06_gpu_and_ml/spam-detect/spam_detect/model_registry.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/model_registry.py
@@ -3,6 +3,7 @@ Defines minimal data structures and command-line interface (CLI) commands for a 
 The CLI commands are operationally useful, used to inspect prior trained models and promote the
 most promising models to production serving.
 """
+
 import json
 from typing import Callable, NamedTuple, Optional
 

--- a/06_gpu_and_ml/spam-detect/spam_detect/model_storage.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/model_storage.py
@@ -2,6 +2,7 @@
 The model storage module contains functions for the serialization, and
 disk-based storage of the email spam models defined within models.py.
 """
+
 import datetime
 import hashlib
 import io

--- a/06_gpu_and_ml/spam-detect/spam_detect/models.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/models.py
@@ -9,6 +9,7 @@ Current model implementations are:
 * LLM (a fine-tuned BERT language classifier)
 * NaiveBayes
 """
+
 import json
 import math
 import pathlib

--- a/06_gpu_and_ml/spam-detect/spam_detect/serving.py
+++ b/06_gpu_and_ml/spam-detect/spam_detect/serving.py
@@ -1,6 +1,7 @@
 """
 Defines a serverless web API to expose trained models
 """
+
 from typing import Optional
 
 import modal

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/inpaint.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/inpaint.py
@@ -6,6 +6,7 @@ Pokémon character.
 
 This code is partly based on code from github.com/Sanster/lama-cleaner/.
 """
+
 import io
 
 import modal

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
@@ -4,6 +4,7 @@ the development and maintenance of the application.
 
 eg. python -m text_to_pokemon.ops reset-diskcache
 """
+
 import argparse
 import io
 import json

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
@@ -1,6 +1,7 @@
 """
 Our AI-generated Pokémon characters need their own names!
 """
+
 import dataclasses
 import json
 import time

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -124,12 +124,12 @@ def load_report(filepath):
             )
             yield {
                 "day": f"{yyyy}-{mm}-{dd}",
-                "country_or_region": country_or_region.strip()
-                if country_or_region
-                else None,
-                "province_or_state": province_or_state.strip()
-                if province_or_state
-                else None,
+                "country_or_region": (
+                    country_or_region.strip() if country_or_region else None
+                ),
+                "province_or_state": (
+                    province_or_state.strip() if province_or_state else None
+                ),
                 "confirmed": int(float(row["Confirmed"] or 0)),
                 "deaths": int(float(row["Deaths"] or 0)),
                 "recovered": int(float(row["Recovered"] or 0)),

--- a/internal/typecheck.py
+++ b/internal/typecheck.py
@@ -2,6 +2,7 @@
 MyPy type-checking script.
 Unvalidated, incorrect type-hints are worse than no type-hints!
 """
+
 import pathlib
 import subprocess
 import sys

--- a/misc/news_summarizer.py
+++ b/misc/news_summarizer.py
@@ -101,9 +101,9 @@ def latest_science_stories(n_stories: int = 5) -> List[NYArticle]:
     articles = [
         NYArticle(
             title=u["title"],
-            image_url=u.get("multimedia")[0]["url"]
-            if u.get("multimedia")
-            else "",
+            image_url=(
+                u.get("multimedia")[0]["url"] if u.get("multimedia") else ""
+            ),
             url=u.get("url"),
         )
         for u in results["results"]


### PR DESCRIPTION
Seems like CI on modal-examples is breaking (see #566) because of the recent black 24.1.0 release, which is suddenly a lot stricter about formatting rules.

I'm pinning the black version to 23.11 so we don't have any more surprises in the future.