### PR TITLE
Fix usage of deprecated secret= kwarg

### DIFF
--- a/04_secrets/db_to_sheet.py
+++ b/04_secrets/db_to_sheet.py
@@ -49,7 +49,7 @@ import modal
 stub = modal.Stub("example-db-to-sheet")
 
 
-@stub.function(secret=modal.Secret.from_name("postgres-secret"))
+@stub.function(secrets=[modal.Secret.from_name("postgres-secret")])
 def my_func():
     # automatically filled from the specified secret
     print("Host is " + os.environ["PGHOST"])
@@ -73,7 +73,7 @@ pg_image = (
 
 @stub.function(
     image=pg_image,
-    secret=modal.Secret.from_name("postgres-secret"),
+    secrets=[modal.Secret.from_name("postgres-secret")],
 )
 def get_db_rows():
     import psycopg2
@@ -100,7 +100,7 @@ requests_image = modal.Image.debian_slim().pip_install("requests")
 
 @stub.function(
     image=requests_image,
-    secret=modal.Secret.from_name("weather-secret"),
+    secrets=[modal.Secret.from_name("weather-secret")],
 )
 def city_weather(city):
     import requests
@@ -169,7 +169,7 @@ pygsheets_image = modal.Image.debian_slim().pip_install("pygsheets")
 
 @stub.function(
     image=pygsheets_image,
-    secret=modal.Secret.from_name("gsheets-secret"),
+    secrets=[modal.Secret.from_name("gsheets-secret")],
 )
 def update_sheet_report(rows):
     import pygsheets

--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -34,7 +34,7 @@ slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 
 
 @stub.function(
-    image=slack_sdk_image, secret=modal.Secret.from_name("hn-bot-slack")
+    image=slack_sdk_image, secrets=[modal.Secret.from_name("hn-bot-slack")]
 )
 async def post_to_slack(message: str):
     import slack_sdk

--- a/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
+++ b/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
@@ -237,7 +237,8 @@ image = (
     )
     .apt_install("ffmpeg", "libsm6", "libxext6")
     .run_function(
-        download_demo_files, secret=Secret.from_dict({"DEMO_NAME": DEMO_NAME})
+        download_demo_files,
+        secrets=[Secret.from_dict({"DEMO_NAME": DEMO_NAME})],
     )
 )
 stub = Stub(name="example-controlnet", image=image)

--- a/06_gpu_and_ml/embeddings/text_embeddings_inference.py
+++ b/06_gpu_and_ml/embeddings/text_embeddings_inference.py
@@ -72,7 +72,7 @@ tei_image = (
     .run_function(
         download_model,
         gpu=GPU_CONFIG,
-        secret=Secret.from_name("huggingface-secret"),
+        secrets=[Secret.from_name("huggingface-secret")],
     )
     .pip_install("httpx")
 )
@@ -84,7 +84,7 @@ with tei_image.imports():
 
 
 @stub.cls(
-    secret=Secret.from_name("huggingface-secret"),
+    secrets=[Secret.from_name("huggingface-secret")],
     gpu=GPU_CONFIG,
     image=tei_image,
     # Use up to 20 GPU containers at once.

--- a/06_gpu_and_ml/embeddings/wikipedia/main.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/main.py
@@ -260,7 +260,7 @@ def upload_result_to_hf(batch_size: int) -> None:
         CHECKPOINT_DIR: EMBEDDING_CHECKPOINT_VOLUME,
     },
     timeout=86400,
-    secret=Secret.from_name("huggingface-secret"),
+    secrets=[Secret.from_name("huggingface-secret")],
 )
 def embed_dataset(down_scale: float = 1, batch_size: int = 512 * 50):
     """

--- a/06_gpu_and_ml/mini_dalle_slackbot.py
+++ b/06_gpu_and_ml/mini_dalle_slackbot.py
@@ -31,7 +31,7 @@ stub = Stub(
 
 @stub.function(
     image=Image.debian_slim().pip_install("slack-sdk"),
-    secret=Secret.from_name("dalle-bot-slack-secret"),
+    secrets=[Secret.from_name("dalle-bot-slack-secret")],
 )
 def post_to_slack(prompt: str, channel_name: str, image_bytes: bytes):
     import slack_sdk

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_aitemplate.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_aitemplate.py
@@ -224,9 +224,7 @@ stub = modal.Stub("example-stable-diffusion-aitemplate")
 
 
 class InferenceRequest(BaseModel):
-    prompt: str = (
-        "photo of a wolf in the snow, blue eyes, highly detailed, 8k, 200mm canon lens, shallow depth of field"
-    )
+    prompt: str = "photo of a wolf in the snow, blue eyes, highly detailed, 8k, 200mm canon lens, shallow depth of field"
     num_inference_steps: int = 10
     guidance_scale: float = 7.5
     negative_prompt: str = "deformed, extra legs, no tail"

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_aitemplate.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_aitemplate.py
@@ -200,7 +200,7 @@ image = (
     )
     .run_function(
         download_and_compile,
-        secret=modal.Secret.from_name("huggingface-secret"),
+        secrets=[modal.Secret.from_name("huggingface-secret")],
         timeout=60 * 30,
         gpu=GPU_TYPE,
     )
@@ -224,7 +224,9 @@ stub = modal.Stub("example-stable-diffusion-aitemplate")
 
 
 class InferenceRequest(BaseModel):
-    prompt: str = "photo of a wolf in the snow, blue eyes, highly detailed, 8k, 200mm canon lens, shallow depth of field"
+    prompt: str = (
+        "photo of a wolf in the snow, blue eyes, highly detailed, 8k, 200mm canon lens, shallow depth of field"
+    )
     num_inference_steps: int = 10
     guidance_scale: float = 7.5
     negative_prompt: str = "deformed, extra legs, no tail"

--- a/06_gpu_and_ml/text_generation_inference.py
+++ b/06_gpu_and_ml/text_generation_inference.py
@@ -86,7 +86,9 @@ stub = Stub("example-tgi-" + MODEL_ID.split("/")[-1])
 tgi_image = (
     Image.from_registry("ghcr.io/huggingface/text-generation-inference:1.0.3")
     .dockerfile_commands("ENTRYPOINT []")
-    .run_function(download_model, secret=Secret.from_name("huggingface-secret"))
+    .run_function(
+        download_model, secrets=[Secret.from_name("huggingface-secret")]
+    )
     .pip_install("text-generation")
 )
 
@@ -112,7 +114,7 @@ tgi_image = (
 
 
 @stub.cls(
-    secret=Secret.from_name("huggingface-secret"),
+    secrets=[Secret.from_name("huggingface-secret")],
     gpu=GPU_CONFIG,
     allow_concurrent_inputs=10,
     container_idle_timeout=60 * 10,

--- a/06_gpu_and_ml/vision_model_training.py
+++ b/06_gpu_and_ml/vision_model_training.py
@@ -59,9 +59,9 @@ FASTAI_HOME = "/fastai_home"
 MODEL_CACHE = pathlib.Path(FASTAI_HOME, "models")
 USE_GPU = os.environ.get("MODAL_GPU")
 MODEL_EXPORT_PATH = pathlib.Path(MODEL_CACHE, "model-exports", "inference.pkl")
-os.environ["FASTAI_HOME"] = (
-    FASTAI_HOME  # Ensure fastai saves data into persistent volume path.
-)
+os.environ[
+    "FASTAI_HOME"
+] = FASTAI_HOME  # Ensure fastai saves data into persistent volume path.
 
 # ## Config
 #

--- a/06_gpu_and_ml/vision_model_training.py
+++ b/06_gpu_and_ml/vision_model_training.py
@@ -59,9 +59,9 @@ FASTAI_HOME = "/fastai_home"
 MODEL_CACHE = pathlib.Path(FASTAI_HOME, "models")
 USE_GPU = os.environ.get("MODAL_GPU")
 MODEL_EXPORT_PATH = pathlib.Path(MODEL_CACHE, "model-exports", "inference.pkl")
-os.environ[
-    "FASTAI_HOME"
-] = FASTAI_HOME  # Ensure fastai saves data into persistent volume path.
+os.environ["FASTAI_HOME"] = (
+    FASTAI_HOME  # Ensure fastai saves data into persistent volume path.
+)
 
 # ## Config
 #
@@ -119,7 +119,7 @@ def download_dataset():
 # utilization.
 #
 # If you want to run this example without setting up Weights & Biases, just remove the
-# `secret=Secret.from_name("wandb")` line from the Function decorator below; this will disable Weights & Biases
+# `secrets=[Secret.from_name("wandb")]` line from the Function decorator below; this will disable Weights & Biases
 # functionality.
 #
 # ### Detaching our training run
@@ -135,7 +135,7 @@ def download_dataset():
     image=image,
     gpu=USE_GPU,
     network_file_systems={str(MODEL_CACHE): volume},
-    secret=Secret.from_name("wandb"),
+    secrets=[Secret.from_name("wandb")],
     timeout=2700,  # 45 minutes
 )
 def train():

--- a/06_gpu_and_ml/vllm_inference.py
+++ b/06_gpu_and_ml/vllm_inference.py
@@ -67,7 +67,7 @@ image = (
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
     .run_function(
         download_model_to_folder,
-        secret=Secret.from_name("huggingface-secret"),
+        secrets=[Secret.from_name("huggingface-secret")],
         timeout=60 * 20,
     )
 )
@@ -82,7 +82,7 @@ stub = Stub("example-vllm-inference", image=image)
 # on the GPU for each subsequent invocation of the function.
 #
 # The `vLLM` library allows the code to remain quite clean.
-@stub.cls(gpu="A100", secret=Secret.from_name("huggingface-secret"))
+@stub.cls(gpu="A100", secrets=[Secret.from_name("huggingface-secret")])
 class Model:
     def __enter__(self):
         from vllm import LLM

--- a/10_integrations/multion_news_agent.py
+++ b/10_integrations/multion_news_agent.py
@@ -37,7 +37,7 @@ multion_image = modal.Image.debian_slim().pip_install("multion")
 
 
 @stub.function(
-    image=multion_image, secret=modal.Secret.from_name("MULTION_API_KEY")
+    image=multion_image, secrets=[modal.Secret.from_name("MULTION_API_KEY")]
 )
 def news_tweet_agent():
     # Import MultiOn

--- a/10_integrations/stable_diffusion_slackbot.py
+++ b/10_integrations/stable_diffusion_slackbot.py
@@ -80,7 +80,7 @@ image = (
         "ftfy",
         "accelerate",
     )
-    .run_function(fetch_model, secret=Secret.from_name("huggingface-secret"))
+    .run_function(fetch_model, secrets=[Secret.from_name("huggingface-secret")])
 )
 
 # ### The actual function
@@ -98,7 +98,7 @@ image = (
 @stub.function(
     gpu="A10G",
     image=image,
-    secret=Secret.from_name("huggingface-secret"),
+    secrets=[Secret.from_name("huggingface-secret")],
 )
 async def run_stable_diffusion(prompt: str, channel_name: Optional[str] = None):
     pipe = fetch_model(local_files_only=True)
@@ -165,7 +165,7 @@ async def entrypoint(request: Request):
 
 @stub.function(
     image=Image.debian_slim().pip_install("slack-sdk"),
-    secret=Secret.from_name("stable-diff-slackbot-secret"),
+    secrets=[Secret.from_name("stable-diff-slackbot-secret")],
 )
 def post_image_to_slack(title: str, channel_name: str, image_bytes: bytes):
     import slack_sdk

--- a/misc/news_summarizer.py
+++ b/misc/news_summarizer.py
@@ -84,7 +84,7 @@ class NYArticle:
 
 
 @stub.function(
-    secret=modal.Secret.from_name("nytimes"),
+    secrets=[modal.Secret.from_name("nytimes")],
     image=scraping_image,
 )
 def latest_science_stories(n_stories: int = 5) -> List[NYArticle]:

--- a/misc/webscraper.py
+++ b/misc/webscraper.py
@@ -42,7 +42,7 @@ slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 
 @stub.function(
     image=slack_sdk_image,
-    secret=modal.Secret.from_name("scraper-slack-secret"),
+    secrets=[modal.Secret.from_name("scraper-slack-secret")],
 )
 def bot_token_msg(channel, message):
     import slack_sdk


### PR DESCRIPTION
Fixing usage of `secret=` which was recently deprecated in the client

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)