### PR TITLE
fix stable diffusion app

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -46,11 +46,8 @@ sdxl_image = (
 stub = Stub("stable-diffusion-xl")
 
 with sdxl_image.imports():
-    import fastapi.staticfiles
     import torch
     from diffusers import DiffusionPipeline
-    from fastapi import FastAPI
-    from fastapi.responses import Response
     from huggingface_hub import snapshot_download
 
 # ## Load model and run inference
@@ -167,6 +164,10 @@ frontend_path = Path(__file__).parent / "frontend"
 )
 @asgi_app()
 def app():
+    import fastapi.staticfiles
+    from fastapi import FastAPI
+    from fastapi.responses import Response
+
     web_app = FastAPI()
 
     @web_app.get("/infer/{prompt}")

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -30,7 +30,7 @@ from modal import Image, Mount, Stub, asgi_app, build, enter, gpu, method
 
 
 sdxl_image = (
-    Image.debian_slim()
+    Image.debian_slim(python_version="3.10")
     .apt_install(
         "libglib2.0-0", "libsm6", "libxrender1", "libxext6", "ffmpeg", "libgl1"
     )


### PR DESCRIPTION
Currently the deployed app fails because it fails to find FastAPI see https://github.com/modal-labs/modal-examples/issues/569

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins all dependencies and specifies a `python_version` for the base image
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
