### PR TITLE
Kning/fix whisper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/__pycache__
+.DS_STore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 **/__pycache__
-.DS_STore
+.DS_Store

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -277,7 +277,7 @@ def split_silences(
 
     # silencedetect can place the silence end *after* the end of the full audio segment.
     # Such segments definitions are negative length and invalid.
-    if duration > cur_start and (duration - cur_start) > min_segment_length:
+    if duration > cur_start:
         yield cur_start, duration
         num_segments += 1
     logger.info(f"Split {path} into {num_segments} segments")

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -26,7 +26,7 @@ logger = config.get_logger(__name__)
 volume = NetworkFileSystem.persisted("dataset-cache-vol")
 
 app_image = (
-    Image.debian_slim()
+    Image.debian_slim(python_version="3.10")
     .apt_install("git")
     .pip_install(
         "git+https://github.com/openai/whisper.git",
@@ -41,7 +41,7 @@ app_image = (
     .apt_install("ffmpeg")
     .pip_install("ffmpeg-python")
 )
-search_image = Image.debian_slim().pip_install(
+search_image = Image.debian_slim(python_version="3.10").pip_install(
     "scikit-learn~=1.3.0",
     "tqdm~=4.46.0",
     "numpy~=1.23.3",


### PR DESCRIPTION
Fixes [this issue](https://github.com/modal-labs/modal-examples/issues/214) some ending sentences get trimmed off.

Tested this with a few examples and seems to be working:

<img width="976" alt="Screen Shot 2024-02-09 at 12 50 39 PM" src="https://github.com/modal-labs/modal-examples/assets/1820651/a804618a-890b-461b-91e0-228fe5e02254">

compared to [in production](https://modal-labs--whisper-pod-transcriber-fastapi-app.modal.run/#/episode/603405/395973d69318e935d059f39abed4ce87).

Also this one:
<img width="954" alt="image" src="https://github.com/modal-labs/modal-examples/assets/1820651/69d6d158-2d93-4ed2-a8f7-f5606679d798">

compared to [in production](https://modal-labs--whisper-pod-transcriber-fastapi-app.modal.run/#/episode/4861529/d3aa80319a5ee09634115b2d97472a9b) 
 
### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins all dependencies and specifies a `python_version` for the base image
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.

## Outside contributors

Addresses issue flagged here: https://github.com/modal-labs/modal-examples/issues/214
