### PR TITLE
pin dependencies for sdxl turbo

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl_turbo.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl_turbo.py
@@ -27,10 +27,10 @@ from modal import Image, Stub, build, enter, gpu, method
 
 image = Image.debian_slim().pip_install(
     "Pillow~=10.1.0",
-    "diffusers~=0.24",
-    "transformers~=4.35",  # This is needed for `import torch`
-    "accelerate~=0.25",  # Allows `device_map="auto"``, which allows computation of optimized device_map
-    "safetensors~=0.4",  # Enables safetensor format as opposed to using unsafe pickle format
+    "diffusers~=0.24.0",
+    "transformers~=4.35.2",  # This is needed for `import torch`
+    "accelerate~=0.25.0",  # Allows `device_map="auto"``, which allows computation of optimized device_map
+    "safetensors~=0.4.1",  # Enables safetensor format as opposed to using unsafe pickle format
 )
 
 stub = Stub("stable-diffusion-xl-turbo", image=image)


### PR DESCRIPTION
Pins the Python dependencies more tightly -- `~=0.x` means `~0.*` are all acceptable, so we want to pin `~=0.x.y`. Before `0`, it's SemVer-compliant to break on minor releases!

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins all dependencies and specifies a `python_version` for the base image
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.