### PR TITLE
Remove parameters from functions decorated with `@exit`

### DIFF
--- a/06_gpu_and_ml/embeddings/text_embeddings_inference.py
+++ b/06_gpu_and_ml/embeddings/text_embeddings_inference.py
@@ -99,7 +99,7 @@ class TextEmbeddingsInference:
         self.client = AsyncClient(base_url="http://127.0.0.1:8000")
 
     @exit()
-    def teardown_server(self, exc_type, exc_value, traceback):
+    def teardown_server(self):
         self.process.terminate()
 
     @method()

--- a/06_gpu_and_ml/embeddings/wikipedia/main.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/main.py
@@ -137,7 +137,7 @@ class TextEmbeddingsInference:
         self.client = AsyncClient(base_url="http://127.0.0.1:8000", timeout=30)
 
     @exit()
-    def terminate_connection(self, exc_type, exc_value, traceback):
+    def terminate_connection(self):
         self.process.terminate()
 
     async def _embed(self, chunk_batch):

--- a/06_gpu_and_ml/llm-serving/text_generation_inference.py
+++ b/06_gpu_and_ml/llm-serving/text_generation_inference.py
@@ -166,7 +166,7 @@ class Model:
         print("Webserver ready!")
 
     @exit()
-    def terminate_server(self, exc_type, exc_value, traceback):
+    def terminate_server(self):
         self.launcher.terminate()
 
     @method()

--- a/06_gpu_and_ml/llm-serving/tgi_mixtral.py
+++ b/06_gpu_and_ml/llm-serving/tgi_mixtral.py
@@ -133,7 +133,7 @@ class Model:
                 time.sleep(1.0)
 
     @exit()
-    def terminate_server(self, exc_type, exc_value, traceback):
+    def terminate_server(self):
         self.launcher.terminate()
 
     @method()


### PR DESCRIPTION
This is now deprecated (and never actually worked)

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

