### PR TITLE
Change llm-frontend path since it is now one level up after modal-exa…

### DIFF
--- a/06_gpu_and_ml/llm-serving/text_generation_inference.py
+++ b/06_gpu_and_ml/llm-serving/text_generation_inference.py
@@ -206,7 +206,7 @@ def main():
 #
 # You can try our deployment [here](https://modal-labs--tgi-app.modal.run).
 
-frontend_path = Path(__file__).parent / "llm-frontend"
+frontend_path = Path(__file__).parent.parent / "llm-frontend"
 
 
 @stub.function(


### PR DESCRIPTION
Change llm-frontend path since it is now in the parent directory after modal-examples directory was refactored.
