### PR TITLE
tighten dependencies, update name of wandb secret

### DIFF
--- a/06_gpu_and_ml/vision_model_training.py
+++ b/06_gpu_and_ml/vision_model_training.py
@@ -41,9 +41,9 @@ from modal import (
 web_app = FastAPI()
 assets_path = pathlib.Path(__file__).parent / "vision_model_training" / "assets"
 stub = Stub(name="example-fastai-wandb-gradio-cifar10-demo")
-image = Image.debian_slim().pip_install(
+image = Image.debian_slim(python_version="3.10").pip_install(
     "fastai~=2.7.9",
-    "gradio~=3.6",
+    "gradio~=3.6.0",
     "httpx~=0.23.0",
     # When using pip PyTorch is not automatically installed by fastai.
     "torch~=1.12.1",
@@ -136,7 +136,7 @@ def download_dataset():
     image=image,
     gpu=USE_GPU,
     network_file_systems={str(MODEL_CACHE): volume},
-    secrets=[Secret.from_name("wandb")],
+    secrets=[Secret.from_name("my-wandb-secret")],
     timeout=2700,  # 45 minutes
 )
 def train():


### PR DESCRIPTION
`vision_model_training.py` has been red in CI for deployment for the last two commits.

Not entirely sure what the change was -- possibly in an upstream dependency? -- but with these changes (plus a small tweak to the secrets) it was deployable with `modal deploy` in main and in the synmon environment.

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins all dependencies
- [x] Example dependencies with `version < 1` are pinned to minor version, `~=0.x.y`
- [x] Example specifies a `python_version` for the base image
