### PR TITLE
moves slow mypy type checking out of main check script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,23 +25,6 @@ jobs:
 
       - run: ruff format --check
 
-  mypy:
-    name: MyPy
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Install mypy
-        run: pip install mypy==0.950
-
-      - name: Run
-        run: python3 internal/typecheck.py
-
   nbconvert:
     name: NbConvert
     runs-on: ubuntu-20.04

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,9 @@
 name: Typecheck
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "17 16 * * *"
+    # Run on main every day at 16:17 UTC
 
 jobs:
   mypy:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,21 @@
+name: Typecheck
+on:
+  workflow_dispatch:
+
+jobs:
+  mypy:
+    name: MyPy
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install mypy
+        run: pip install mypy==0.950
+
+      - name: Run
+        run: python3 internal/typecheck.py


### PR DESCRIPTION
I love a good type system, but I'm not convinced of the value of the mypy type check.

Most of our examples break due to rotting from insufficiently-controlled dependencies, rather than anything detectable with types. Recall that the types of functions on Modal are often not even checkable locally. Furthermore, type hints in other Python libraries in the ML ecosystem are often poorly instrumented and so the checker is subject to false positives and negatives. And finally, we have other checks in place to ensure examples run end-to-end, so the most common user facing errors can be caught directly.

It is also about 4x slower than the other checks we run in CI,  >2min instead of ~30s, which IME pushes "waiting on a PR" into context switch territory.

But rather than fully removing the check, this PR makes it a daily cronjob that is also triggerable manually. Whoever last changed the schedule (me, for now) will be notified of failures.

### Type of Change

- [x] Other (changes to the codebase, but not to examples)
