### PR TITLE
fixes use in local_entrypoint, pins dependencies

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -145,9 +145,10 @@ class Model:
     @web_endpoint()
     def web_inference(self, prompt, n_steps=24, high_noise_frac=0.8):
         return Response(
-            self._inference(
+            content=self._inference(
                 prompt, n_steps=n_steps, high_noise_frac=high_noise_frac
-            )
+            ).getvalue(),
+            media_type="image/jpeg",
         )
 
 

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -203,9 +203,9 @@ def app():
 
     with open("/assets/index.html", "w") as f:
         html = template.render(
-            inference_url=Model.inference.web_url,
+            inference_url=Model.web_inference.web_url,
             model_name="Stable Diffusion XL",
-            default_prompt="A cinematic shot of a baby racoon wearing an intricate italian priest robe.",
+            default_prompt="A cinematic shot of a baby raccoon wearing an intricate italian priest robe.",
         )
         f.write(html)
 


### PR DESCRIPTION
This example was calling a `webendpoint` with `.remote`, which is not possible.

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins all dependencies
- [x] Example dependencies with `version < 1` are pinned to minor version, `==0.x.y`
- [x] Example specifies a `python_version` for the base image
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
