### PR TITLE
Documents frontmatter fields and dependency pinning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,12 +10,16 @@
 
 ## Checklist
 
-- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
-- [ ] Example does _not_ require third-party dependencies to be installed locally
-- [ ] Example pins all dependencies
-- [ ] Example dependencies with `version < 1` are pinned to minor version, `==0.x.y`
-- [ ] Example specifies a `python_version` for the base image
+- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
+  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
+  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
 - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
+- [ ] Example does _not_ require third-party dependencies to be installed locally
+- [ ] Example pins its dependencies
+  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
+  - [ ] Example specifies a `python_version` for the base image, if it is used
+  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
+  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
 
 ## Outside contributors
 


### PR DESCRIPTION
Clarifies the use of some of the frontmatter fields, elaborates on the dependency-pinning practices.

### Type of Change

- [x] Other (changes to the codebase, but not to examples)