### PR TITLE
adds local entrypoint for playground, matches infra with deployed version, pins deps

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/playground.py
+++ b/06_gpu_and_ml/stable_diffusion/playground.py
@@ -12,7 +12,7 @@ stub = modal.Stub("playground-2-5")
 DIFFUSERS_GIT_SHA = "2e31a759b5bd8ca2b288b5c61709636a96c4bae9"
 
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.10")
     .apt_install("git")
     .pip_install(
         f"git+https://github.com/huggingface/diffusers.git@{DIFFUSERS_GIT_SHA}",

--- a/06_gpu_and_ml/stable_diffusion/playground.py
+++ b/06_gpu_and_ml/stable_diffusion/playground.py
@@ -9,14 +9,16 @@ import modal
 
 stub = modal.Stub("playground-2-5")
 
+DIFFUSERS_GIT_SHA = "2e31a759b5bd8ca2b288b5c61709636a96c4bae9"
+
 image = (
     modal.Image.debian_slim()
     .apt_install("git")
     .pip_install(
-        "git+https://github.com/huggingface/diffusers.git",
-        "transformers",
-        "accelerate",
-        "safetensors",
+        f"git+https://github.com/huggingface/diffusers.git@{DIFFUSERS_GIT_SHA}",
+        "transformers~=4.38.1",
+        "accelerate==0.27.2",
+        "safetensors==0.4.2",
     )
 )
 


### PR DESCRIPTION
Note that this example is still missing comments and explanations

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`