### PR TITLE
Remove a few use cases of .new

### DIFF
--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -49,7 +49,9 @@ output_vol = Volume.from_name("finetune-volume", create_if_missing=True)
 #
 # See the [guide on preemptions](/docs/guide/preemption#preemption) for more details on preemption handling.
 
-stub.restart_tracker_dict = modal.Dict.new()
+restart_tracker_dict = modal.Dict.from_name(
+    "finetune-restart-tracker", create_if_missing=True
+)
 
 
 def track_restarts(restart_tracker: modal.Dict) -> int:
@@ -85,7 +87,7 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
         Seq2SeqTrainingArguments,
     )
 
-    restarts = track_restarts(stub.restart_tracker_dict)
+    restarts = track_restarts(restart_tracker_dict)
 
     # Use size percentage to retrieve subset of the dataset to iterate faster
     if size_percentage:

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/end_to_end_check.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/end_to_end_check.py
@@ -17,7 +17,9 @@ from .config import DataTrainingArguments, ModelArguments, app_config
 from .logs import get_logger
 from .transcribe import whisper_transcribe_audio
 
-test_volume = modal.NetworkFileSystem.new()
+test_volume = modal.NetworkFileSystem.from_name(
+    "example-whisper-fine-tune-test-vol", create_if_missing=True
+)
 
 logger = get_logger(__name__)
 

--- a/07_web_endpoints/chatbot_spa.py
+++ b/07_web_endpoints/chatbot_spa.py
@@ -25,8 +25,9 @@ from modal import Dict, Image, Mount, Stub, asgi_app
 
 assets_path = Path(__file__).parent / "chatbot_spa"
 stub = Stub("example-chatbot-spa")
-
-stub.chat_histories = Dict.new()
+chat_histories = Dict.from_name(
+    "example-chatbot-spa-history", create_if_missing=True
+)
 
 
 def load_tokenizer_and_model():
@@ -80,7 +81,7 @@ def generate_response(
         message + tokenizer.eos_token, return_tensors="pt"
     ).to("cuda")
     if id is not None:
-        chat_history = stub.chat_histories[id]
+        chat_history = chat_histories[id]
         bot_input_ids = torch.cat([chat_history, new_input_ids], dim=-1)
     else:
         id = str(uuid.uuid4())
@@ -93,7 +94,7 @@ def generate_response(
         chat_history[:, bot_input_ids.shape[-1] :][0], skip_special_tokens=True
     )
 
-    stub.chat_histories[id] = chat_history
+    chat_histories[id] = chat_history
     return id, response
 
 


### PR DESCRIPTION
I'm preparing to deprecate `.new`

There _are_ some semi-legit use cases of it, but I think more generally it's not the case that you want to tie the lifecycle of any object to the lifecycle of an app – only sometimes. So I think we should resurrect the idea of ephemeral objects but in a slightly different way where you can just create them anywhere not associated with apps. But until then, the only valid use cases of `.new` are pretty fringe and you can easily get around it.