### PR TITLE
fixes deprecated path for ChatGPT streaming example, makes modal run version cleaner

### DIFF
--- a/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
+++ b/06_gpu_and_ml/chatgpt/chatgpt_streaming.py
@@ -34,6 +34,7 @@ stub = Stub(
 # regular Python function, which becomes important below.
 
 
+@stub.function()
 def stream_chat(prompt: str):
     import openai
 
@@ -44,7 +45,6 @@ def stream_chat(prompt: str):
         stream=True,
     ):
         content = chunk.choices[0].delta.content
-        print(content)
         if content is not None:
             yield content
 
@@ -90,7 +90,7 @@ def web(prompt: str):
 #
 # ## CLI interface
 #
-# Doing `modal run chatgpt_streaming.py --prompt="Generate a list of the world's most famous people"` also works, and uses the `local_entrypoint` defined below.
+# Doing `modal run -q chatgpt_streaming.py --prompt="Generate a list of the world's most famous people"` also works, and uses the `local_entrypoint` defined below.
 
 default_prompt = (
     "Generate a list of 20 great names for sentient cheesecakes that teach SQL"
@@ -99,5 +99,7 @@ default_prompt = (
 
 @stub.local_entrypoint()
 def main(prompt: str = default_prompt):
+    print("Prompt:", prompt)
     for part in stream_chat.remote_gen(prompt=prompt):
-        print(part, end="")
+        print(part, end="", flush=True)
+    print()


### PR DESCRIPTION
### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`