### PR TITLE
Fix command example not working on Windows

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -153,7 +153,7 @@ class Model:
 
 
 # And this is our entrypoint; where the CLI is invoked. Explore CLI options
-# with: `modal run stable_diffusion_xl.py --prompt 'An astronaut riding a green horse'`
+# with: `modal run stable_diffusion_xl.py --prompt "An astronaut riding a green horse"`
 
 
 @stub.local_entrypoint()

--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl_lightning.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl_lightning.py
@@ -79,7 +79,7 @@ class Model:
 
 
 # And this is our entrypoint; where the CLI is invoked. Run this example
-# with: `modal run stable_diffusion_xl_lightning.py --prompt 'An astronaut riding a green horse'`
+# with: `modal run stable_diffusion_xl_lightning.py --prompt "An astronaut riding a green horse"`
 
 
 @stub.local_entrypoint()


### PR DESCRIPTION
Fix command example not working on Windows

By changing single-quotes to double-quotes