### PR TITLE
allow multiple checkpoints, comfy manager

### DIFF
--- a/06_gpu_and_ml/comfyui/checkpoints.txt
+++ b/06_gpu_and_ml/comfyui/checkpoints.txt
@@ -1,0 +1,1 @@
+https://huggingface.co/dreamlike-art/dreamlike-photoreal-2.0/resolve/main/dreamlike-photoreal-2.0.safetensors

--- a/06_gpu_and_ml/comfyui/comfy_ui.py
+++ b/06_gpu_and_ml/comfyui/comfy_ui.py
@@ -23,37 +23,38 @@ import modal
 # [notebooks/comfyui_colab.ipynb](https://github.com/comfyanonymous/ComfyUI/blob/master/notebooks/comfyui_colab.ipynb).
 #
 # This download function is run as the final image building step, and takes around 10 seconds to download
-# the ~2.0 GiB model checkpoint.
+# the ~2.0 GiB model checkpoint. To download other checkpoints, add the download url to checkpoints.txt.
 
 
 def download_checkpoint():
     import httpx
     from tqdm import tqdm
 
-    url = "https://huggingface.co/dreamlike-art/dreamlike-photoreal-2.0/resolve/main/dreamlike-photoreal-2.0.safetensors"
-    checkpoints_directory = "/root/models/checkpoints"
-    local_filename = url.split("/")[-1]
-    local_filepath = pathlib.Path(checkpoints_directory, local_filename)
-    local_filepath.parent.mkdir(parents=True, exist_ok=True)
+    with open("/checkpoints.txt") as f:
+        checkpoints = [line.strip() for line in f.readlines()]
 
-    print(f"downloading {url} ...")
-    with httpx.stream("GET", url, follow_redirects=True) as stream:
-        total = int(stream.headers["Content-Length"])
-        with open(local_filepath, "wb") as f, tqdm(
-            total=total, unit_scale=True, unit_divisor=1024, unit="B"
-        ) as progress:
-            num_bytes_downloaded = stream.num_bytes_downloaded
-            for data in stream.iter_bytes():
-                f.write(data)
-                progress.update(
-                    stream.num_bytes_downloaded - num_bytes_downloaded
-                )
+    for url in checkpoints:
+        checkpoints_directory = "/root/models/checkpoints"
+        local_filename = url.split("/")[-1]
+        local_filepath = pathlib.Path(checkpoints_directory, local_filename)
+        local_filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        print(f"downloading {url} ...")
+        with httpx.stream("GET", url, follow_redirects=True) as stream:
+            total = int(stream.headers["Content-Length"])
+            with open(local_filepath, "wb") as f, tqdm(
+                total=total, unit_scale=True, unit_divisor=1024, unit="B"
+            ) as progress:
                 num_bytes_downloaded = stream.num_bytes_downloaded
+                for data in stream.iter_bytes():
+                    f.write(data)
+                    progress.update(stream.num_bytes_downloaded - num_bytes_downloaded)
+                    num_bytes_downloaded = stream.num_bytes_downloaded
 
 
 # Pin to a specific commit from https://github.com/comfyanonymous/ComfyUI/commits/master/
 # for stability. To update to a later ComfyUI version, change this commit identifier.
-comfyui_commit_sha = "b3b5ddb07a23b3d070df292c7a7fd6f83dc8fd50"
+comfyui_commit_sha = "a38b9b3ac152fb5679dad03813a93c09e0a4d15e"
 
 image = (
     modal.Image.debian_slim()
@@ -67,13 +68,13 @@ image = (
         "cd /root && git remote add --fetch origin https://github.com/comfyanonymous/ComfyUI",
         f"cd /root && git checkout {comfyui_commit_sha}",
         "cd /root && pip install xformers!=0.0.18 -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121",
+        # Use Comfy Manager to install plugins (remember to restart your Comfy instance afterwards)
+        "cd /root/custom_nodes && git clone https://github.com/ltdrdata/ComfyUI-Manager.git",
+        "cd /root/custom_nodes/ComfyUI-Manager && pip install -r requirements.txt",
     )
-    # Use fork of https://github.com/valohai/asgiproxy with bugfixes.
-    .pip_install(
-        "git+https://github.com/modal-labs/asgiproxy.git@ef25fe52cf226f9a635e87616e7c049e451e2bd8",
-        "httpx",
-        "tqdm",
-    )
+    # Use fork until https://github.com/valohai/asgiproxy/pull/11 is merged.
+    .pip_install("git+https://github.com/modal-labs/asgiproxy.git", "httpx", "tqdm")
+    .copy_local_file("checkpoints.txt")
     .run_function(download_checkpoint)
 )
 stub = modal.Stub(name="example-comfy-ui", image=image)
@@ -135,6 +136,8 @@ def spawn_comfyui_in_background():
     # to be on a single container.
     concurrency_limit=1,
     timeout=10 * 60,
+    # Consider uncommenting the line below so that the server stays up for a longer session (default is 60s)
+    container_idle_timeout=300,
 )
 @modal.asgi_app()
 def web():

--- a/06_gpu_and_ml/comfyui/comfy_ui.py
+++ b/06_gpu_and_ml/comfyui/comfy_ui.py
@@ -137,7 +137,7 @@ def spawn_comfyui_in_background():
     concurrency_limit=1,
     timeout=10 * 60,
     # Consider uncommenting the line below so that the server stays up for a longer session (default is 60s)
-    container_idle_timeout=300,
+    # container_idle_timeout=300,
 )
 @modal.asgi_app()
 def web():

--- a/06_gpu_and_ml/comfyui/comfy_ui.py
+++ b/06_gpu_and_ml/comfyui/comfy_ui.py
@@ -48,7 +48,9 @@ def download_checkpoint():
                 num_bytes_downloaded = stream.num_bytes_downloaded
                 for data in stream.iter_bytes():
                     f.write(data)
-                    progress.update(stream.num_bytes_downloaded - num_bytes_downloaded)
+                    progress.update(
+                        stream.num_bytes_downloaded - num_bytes_downloaded
+                    )
                     num_bytes_downloaded = stream.num_bytes_downloaded
 
 
@@ -73,7 +75,9 @@ image = (
         "cd /root/custom_nodes/ComfyUI-Manager && pip install -r requirements.txt",
     )
     # Use fork until https://github.com/valohai/asgiproxy/pull/11 is merged.
-    .pip_install("git+https://github.com/modal-labs/asgiproxy.git", "httpx", "tqdm")
+    .pip_install(
+        "git+https://github.com/modal-labs/asgiproxy.git", "httpx", "tqdm"
+    )
     .copy_local_file("checkpoints.txt")
     .run_function(download_checkpoint)
 )


### PR DESCRIPTION
- allow multiple checkpoints to be downloaded
- install [Comfy UI Manager](https://github.com/ltdrdata/ComfyUI-Manager) by default to enable convenient plugin installation
<img width="1673" alt="image" src="https://github.com/modal-labs/modal-examples/assets/1820651/37e3ca5b-fa5a-4562-a92b-3a565c2bf927">


### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
