### PR TITLE
fix: ComfyUI stuck for 10mins issue

### DIFF
--- a/06_gpu_and_ml/comfyui/comfy_ui.py
+++ b/06_gpu_and_ml/comfyui/comfy_ui.py
@@ -134,7 +134,11 @@ def spawn_comfyui_in_background():
     # Restrict to 1 container because we want to our ComfyUI session state
     # to be on a single container.
     concurrency_limit=1,
-    timeout=10 * 60,
+    # Extend idle timeout of container so that you can switch tabs, read a
+    # quick article, and come back to resume work on same container.
+    container_idle_timeout=10 * 5,
+    # Timeout requests after 60s
+    timeout=60,
 )
 @modal.asgi_app()
 def web():


### PR DESCRIPTION
**User issue:** https://modal-com.slack.com/archives/C05TCR1B2UA/p1709558199272249

**Explanation of issue:**

This comfyUI issue is because the container gets EOF input on idle timeout but gets stuck here https://github.com/modal-labs/modal-client/blob/main/modal/_container_entrypoint.py#L396

This is a known issue where a container _with concurrent inputs enabled_ must wait for its inputs to finish before shutting down. In the case of this example I'd set the input timeout to 10 minutes, and an inputs is consistently getting stuck for 10 minutes (this is a separate possible bug to what I'm fixing here). 

Because the idle timeout is 60s, the input timeout is 10 minutes, and the container concurrency limit is **1**, the web app can get stuck unable to spin up a new container for **9 minutes.**

This is obviously quite bad. But it's quite rare to have this happen and only happens here because the configuration of this example is unusual. 

An alternative way to stabilize this example would be to use `keep_warm=1` so that the app has to be explicitly killed to stop the single container.