### PR TITLE
adds a langserve/langgraph example with code execution

### DIFF
--- a/06_gpu_and_ml/langchains/codelangchain/agent.py
+++ b/06_gpu_and_ml/langchains/codelangchain/agent.py
@@ -1,0 +1,63 @@
+"""This module defines our agent and attaches it to the Modal Stub.
+
+Our agent is defined as a graph: a collection of nodes and edges,
+where nodes represent actions and edges represent transitions between actions.
+
+The meat of the logic is therefore in the edges and nodes modules.
+
+We have a very simple "context-stuffing" retrieval approach in the retrieval module.
+Replace this with something that retrieves your documentation and adjust the prompts accordingly.
+
+You can test the agent from the command line with `modal run agent.py --question` followed by your query"""
+
+import edges
+import nodes
+import retrieval
+from common import stub
+
+
+@stub.local_entrypoint()
+def main(question: str = "How do I build a RAG pipeline?", debug: bool = False):
+    """Sends a question to the LCEL code generation agent.
+
+    Switch to debug mode for shorter context and smaller model."""
+    if debug:
+        if question == "How do I build a RAG pipeline?":
+            question = "gm king, how are you?"
+    print(go.remote(question, debug=debug)["keys"]["response"])
+
+
+@stub.function()
+def go(question: str = "How do I build a RAG pipeline?", debug: bool = False):
+    """Compiles the LCEL code generation agent graph and runs it, returning the result."""
+    graph = construct_graph(debug=debug)
+    runnable = graph.compile()
+    result = runnable.invoke(
+        {"keys": {"question": question, "iterations": 0}},
+        config={"recursion_limit": 50},
+    )
+
+    return result
+
+
+def construct_graph(debug=False):
+    from common import GraphState
+    from langgraph.graph import StateGraph
+
+    context = retrieval.retrieve_docs(debug=debug)
+
+    graph = StateGraph(GraphState)
+
+    # attach our nodes to the graph
+    graph_nodes = nodes.Nodes(context, debug=debug)
+    for key, value in graph_nodes.node_map.items():
+        graph.add_node(key, value)
+
+    # construct the graph by adding edges
+    graph = edges.enrich(graph)
+
+    # set the starting and ending nodes of the graph
+    graph.set_entry_point(key="generate")
+    graph.set_finish_point(key="finish")
+
+    return graph

--- a/06_gpu_and_ml/langchains/codelangchain/app.py
+++ b/06_gpu_and_ml/langchains/codelangchain/app.py
@@ -1,6 +1,6 @@
 import agent
 import modal
-from agent import stub
+from agent import nodes, stub
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -28,20 +28,20 @@ def serve():
     from langchain_core.runnables import RunnableLambda
     from langserve import add_routes
 
-    def inp(question: str):
+    def inp(question: str) -> dict:
         return {"keys": {"question": question, "iterations": 0}}
 
     def out(state: dict) -> str:
-        print(state)
-        if "generate" in state:  # patch issue with langserve playground
-            return "\n".join(
-                str(elem) for elem in state["generate"]["keys"]["generation"]
-            )
-        return state["keys"]["response"]
+        if "keys" in state:
+            return state["keys"]["response"]
+        elif "generate" in state:
+            return nodes.extract_response(state["generate"])
+        else:
+            return str(state)
 
-    runnable = agent.construct_graph(debug=False).compile()
+    graph = agent.construct_graph(debug=False).compile()
 
-    chain = RunnableLambda(inp) | runnable | RunnableLambda(out)
+    chain = RunnableLambda(inp) | graph | RunnableLambda(out)
 
     add_routes(
         web_app,

--- a/06_gpu_and_ml/langchains/codelangchain/app.py
+++ b/06_gpu_and_ml/langchains/codelangchain/app.py
@@ -1,0 +1,52 @@
+import agent
+import modal
+from agent import stub
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+web_app = FastAPI(
+    title="CodeLangChain Server",
+    version="1.0",
+    description="Answers questions about LangChain Expression Language (LCEL).",
+)
+
+
+# Set all CORS enabled origins
+web_app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+    expose_headers=["*"],
+)
+
+
+@stub.function(keep_warm=1)
+@modal.asgi_app()
+def serve():
+    from langchain_core.runnables import RunnableLambda
+    from langserve import add_routes
+
+    def inp(question: str):
+        return {"keys": {"question": question, "iterations": 0}}
+
+    def out(state: dict) -> str:
+        print(state)
+        if "generate" in state:  # patch issue with langserve playground
+            return "\n".join(
+                str(elem) for elem in state["generate"]["keys"]["generation"]
+            )
+        return state["keys"]["response"]
+
+    runnable = agent.construct_graph(debug=False).compile()
+
+    chain = RunnableLambda(inp) | runnable | RunnableLambda(out)
+
+    add_routes(
+        web_app,
+        chain,
+        path="/codelangchain",
+    )
+
+    return web_app

--- a/06_gpu_and_ml/langchains/codelangchain/common.py
+++ b/06_gpu_and_ml/langchains/codelangchain/common.py
@@ -1,0 +1,51 @@
+import os
+from typing import Dict, TypedDict
+
+import modal
+
+image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "beautifulsoup4~=4.12.3",  # TODO: move to a "retrieval_image"
+    "langchain==0.1.11",
+    "langgraph==0.0.26",
+    "langchain_community==0.0.27",
+    "langchain-openai==0.0.8",
+    "langserve[all]==0.0.46",
+)
+
+agent_image = image.pip_install(
+    "chromadb==0.4.24",
+    "langchainhub==0.1.15",
+    "faiss-cpu~=1.8.0",
+    "tiktoken==0.6.0",
+)
+
+stub = modal.Stub(
+    "code-langchain",
+    image=image,
+    secrets=[
+        modal.Secret.from_name("my-openai-secret"),
+        modal.Secret.from_name("my-langsmith-secret"),
+    ],
+)
+
+
+class GraphState(TypedDict):
+    """
+    Represents the state of our graph.
+
+    Attributes:
+        keys: A dictionary where each key is a string.
+    """
+
+    keys: Dict[str, any]
+
+
+os.environ["LANGCHAIN_PROJECT"] = "codelangchain"
+
+COLOR = {
+    "HEADER": "\033[95m",
+    "BLUE": "\033[94m",
+    "GREEN": "\033[92m",
+    "RED": "\033[91m",
+    "ENDC": "\033[0m",
+}

--- a/06_gpu_and_ml/langchains/codelangchain/common.py
+++ b/06_gpu_and_ml/langchains/codelangchain/common.py
@@ -4,7 +4,7 @@ from typing import Dict, TypedDict
 import modal
 
 image = modal.Image.debian_slim(python_version="3.11").pip_install(
-    "beautifulsoup4~=4.12.3",  # TODO: move to a "retrieval_image"
+    "beautifulsoup4~=4.12.3",
     "langchain==0.1.11",
     "langgraph==0.0.26",
     "langchain_community==0.0.27",

--- a/06_gpu_and_ml/langchains/codelangchain/edges.py
+++ b/06_gpu_and_ml/langchains/codelangchain/edges.py
@@ -1,0 +1,95 @@
+"""Defines functions that transition our agent from one state to another."""
+
+from typing import Callable
+
+from common import GraphState
+
+EXPECTED_NODES = [
+    "generate",
+    "check_code_imports",
+    "check_code_execution",
+    "finish",
+]
+
+
+def enrich(graph):
+    """Adds transition edges to the graph."""
+
+    for node_name in set(EXPECTED_NODES):
+        assert node_name in graph.nodes, f"Node {node_name} not found in graph"
+
+    graph.add_edge("generate", "check_code_imports")
+    graph.add_conditional_edges(
+        "check_code_imports",
+        EDGE_MAP["decide_to_check_code_exec"],
+        {
+            "check_code_execution": "check_code_execution",
+            "generate": "generate",
+        },
+    )
+    graph.add_conditional_edges(
+        "check_code_execution",
+        EDGE_MAP["decide_to_finish"],
+        {
+            "finish": "finish",
+            "generate": "generate",
+        },
+    )
+    return graph
+
+
+def decide_to_check_code_exec(state: GraphState) -> str:
+    """
+    Determines whether to test code execution, or re-try answer generation.
+
+    Args:
+    state (dict): The current graph state
+
+    Returns:
+        str: Next node to call
+    """
+
+    print("---DECIDE TO TEST CODE EXECUTION---")
+    state_dict = state["keys"]
+    error = state_dict["error"]
+
+    if error == "None":
+        # All documents have been filtered check_relevance
+        # We will re-generate a new query
+        print("---DECISION: TEST CODE EXECUTION---")
+        return "check_code_execution"
+    else:
+        # We have relevant documents, so generate answer
+        print("---DECISION: RE-TRY SOLUTION---")
+        return "generate"
+
+
+def decide_to_finish(state: GraphState) -> str:
+    """
+    Determines whether to finish (re-try code 3 times).
+
+    Args:
+        state (dict): The current graph state
+
+    Returns:
+        str: Next node to call
+    """
+
+    print("---DECIDE TO TEST CODE EXECUTION---")
+    state_dict = state["keys"]
+    error = state_dict["error"]
+    iter = state_dict["iterations"]
+
+    if error == "None" or iter >= 3:
+        # give up :<
+        print("---DECISION: FINISH---")
+        return "finish"
+    else:
+        print("---DECISION: RE-TRY SOLUTION---")
+        return "generate"
+
+
+EDGE_MAP: dict[str, Callable] = {
+    "decide_to_check_code_exec": decide_to_check_code_exec,
+    "decide_to_finish": decide_to_finish,
+}

--- a/06_gpu_and_ml/langchains/codelangchain/edges.py
+++ b/06_gpu_and_ml/langchains/codelangchain/edges.py
@@ -81,7 +81,6 @@ def decide_to_finish(state: GraphState) -> str:
     iter = state_dict["iterations"]
 
     if error == "None" or iter >= 3:
-        # give up :<
         print("---DECISION: FINISH---")
         return "finish"
     else:

--- a/06_gpu_and_ml/langchains/codelangchain/nodes.py
+++ b/06_gpu_and_ml/langchains/codelangchain/nodes.py
@@ -1,0 +1,294 @@
+import sys
+from operator import itemgetter
+
+import sandbox
+from common import GraphState, agent_image, image
+
+with image.imports():
+    from langchain.output_parsers.openai_tools import PydanticToolsParser
+    from langchain.prompts import PromptTemplate
+    from langchain_core.pydantic_v1 import BaseModel, Field
+    from langchain_core.utils.function_calling import convert_to_openai_tool
+    from langchain_openai import ChatOpenAI
+
+
+class Nodes:
+    def __init__(self, context: str, debug: bool = False):
+        self.context = context
+        self.debug = debug
+        self.model = (
+            "gpt-4-0125-preview" if not self.debug else "gpt-3.5-turbo-0125"
+        )
+        self.node_map = {
+            "generate": self.generate,
+            "check_code_imports": self.check_code_imports,
+            "check_code_execution": self.check_code_execution,
+            "finish": self.finish,
+        }
+
+    def generate(self, state: GraphState) -> GraphState:
+        """
+        Generate a code solution based on LCEL docs and the input question
+        with optional feedback from code execution tests
+
+        Args:
+            state (dict): The current graph state
+
+        Returns:
+            state (dict): New key added to state, documents, that contains retrieved documents
+        """
+
+        ## State
+        state_dict = state["keys"]
+        question = state_dict["question"]
+        iter = state_dict["iterations"]
+
+        ## Data model
+        class code(BaseModel):
+            """Code output"""
+
+            prefix: str = Field(
+                description="Description of the problem and approach"
+            )
+            imports: str = Field(description="Code block import statements")
+            code: str = Field(
+                description="Code block not including import statements"
+            )
+
+        ## LLM
+        llm = ChatOpenAI(temperature=0, model=self.model, streaming=True)
+
+        # Tool
+        code_tool_oai = convert_to_openai_tool(code)
+
+        # LLM with tool and enforce invocation
+        llm_with_tool = llm.bind(
+            tools=[code_tool_oai],
+            tool_choice={"type": "function", "function": {"name": "code"}},
+        )
+
+        # Parser
+        parser_tool = PydanticToolsParser(tools=[code])
+
+        ## Prompt
+        template = (
+            """You are a coding assistant with expertise in LCEL, LangChain expression language. \n
+        You are able to execute Python code in a sandbox environment that was constructed by chaining together the following two Dockerfile commands: \n
+        """
+            + f"{image.dockerfile_commands()}"
+            + "\n"
+            + f"{agent_image.dockerfile_commands()}"
+            + """
+            You are tasked with responding to the following user question: {question}
+            Your response will be shown to the user.
+            Here is a full set of LCEL documentation:
+            \n ------- \n
+            {context}
+            \n ------- \n
+            Answer the user question based on the above provided documentation. \n
+            Ensure any code you provide can be executed with all required imports and variables defined. \n
+            Structure your answer as a description of the code solution, \n
+            then a list of the imports, and then finally list the functioning code block. \n
+            Here is the user question again: \n --- --- --- \n {question}
+        """
+        )
+
+        ## Generation
+        if "error" in state_dict:
+            print("---RE-GENERATE SOLUTION w/ ERROR FEEDBACK---")
+
+            error = state_dict["error"]
+            code_solution = state_dict["generation"]
+
+            # Update prompt
+            addendum = """  \n --- --- --- \n You previously tried to solve this problem. \n Here is your solution:
+                        \n --- --- --- \n {generation}  \n --- --- --- \n  Here is the resulting error from code
+                        execution:  \n --- --- --- \n {error}  \n --- --- --- \n Please re-try to answer this.
+                        Structure your answer with a description of the code solution. \n Then list the imports.
+                        And finally list the functioning code block. Structure your answer with a description of
+                        the code solution. \n Then list the imports. And finally list the functioning code block.
+                        \n Here is the user question: \n --- --- --- \n {question}"""
+            template = template + addendum
+
+            # Prompt
+            prompt = PromptTemplate(
+                template=template,
+                input_variables=["context", "question", "generation", "error"],
+            )
+
+            # Chain
+            chain = (
+                {
+                    "context": lambda _: self.context,
+                    "question": itemgetter("question"),
+                    "generation": itemgetter("generation"),
+                    "error": itemgetter("error"),
+                }
+                | prompt
+                | llm_with_tool
+                | parser_tool
+            )
+
+            code_solution = chain.invoke(
+                {
+                    "question": question,
+                    "generation": str(code_solution[0]),
+                    "error": error,
+                }
+            )
+
+        else:
+            print("---GENERATE SOLUTION---")
+
+            # Prompt
+            prompt = PromptTemplate(
+                template=template,
+                input_variables=["context", "question"],
+            )
+
+            # Chain
+            chain = (
+                {
+                    "context": lambda _: self.context,
+                    "question": itemgetter("question"),
+                }
+                | prompt
+                | llm_with_tool
+                | parser_tool
+            )
+
+            code_solution = chain.invoke({"question": question})
+
+        iter = iter + 1
+        return {
+            "keys": {
+                "generation": code_solution,
+                "question": question,
+                "iterations": iter,
+            }
+        }
+
+    def check_code_imports(self, state: GraphState) -> GraphState:
+        """
+        Check imports
+
+        Args:
+            state (dict): The current graph state
+
+        Returns:
+            state (dict): New key added to state, error
+        """
+
+        ## State
+        print("---CHECKING CODE IMPORTS---")
+        state_dict = state["keys"]
+        question = state_dict["question"]
+        code_solution = state_dict["generation"]
+        imports = code_solution[0].imports
+        iter = state_dict["iterations"]
+
+        # Attempt to execute the imports
+        sb = sandbox.run(imports)
+        output, error = sb.stdout.read(), sb.stderr.read()
+        if error:
+            print("---CODE IMPORT CHECK: FAILED---")
+            # Catch any error during execution (e.g., ImportError, SyntaxError)
+            error = f"Execution error: {error}"
+            print(f"Error: {error}", file=sys.stderr)
+            if "error" in state_dict:
+                error_prev_runs = state_dict["error"]
+                error = (
+                    error_prev_runs
+                    + "\n --- Most recent run output and error --- \n"
+                    " ------ output ------ \n"
+                    + output
+                    + "\n ------ error ------ \n"
+                    + error
+                )
+        else:
+            print("---CODE IMPORT CHECK: SUCCESS---")
+            # No errors occurred
+            error = "None"
+
+        return {
+            "keys": {
+                "generation": code_solution,
+                "question": question,
+                "error": error,
+                "iterations": iter,
+            }
+        }
+
+    def check_code_execution(self, state: GraphState) -> GraphState:
+        """
+        Check code block execution
+
+        Args:
+            state (dict): The current graph state
+
+        Returns:
+            state (dict): New key added to state, error
+        """
+
+        ## State
+        print("---CHECKING CODE EXECUTION---")
+        state_dict = state["keys"]
+        question = state_dict["question"]
+        code_solution = state_dict["generation"]
+        prefix = code_solution[0].prefix
+        imports = code_solution[0].imports
+        code = code_solution[0].code
+        code_block = imports + "\n" + code
+        iter = state_dict["iterations"]
+
+        sb = sandbox.run(code_block)
+        output, error = sb.stdout.read(), sb.stderr.read()
+        if error:
+            print("---CODE BLOCK CHECK: FAILED---")
+            error = f"Execution error: {error}"
+            print(f"Error: {error}", file=sys.stderr)
+            if "error" in state_dict:
+                error_prev_runs = state_dict["error"]
+                error = (
+                    error_prev_runs
+                    + "\n --- Most recent run output and error --- \n"
+                    " ------ output ------ \n"
+                    + output
+                    + "\n ------ error ------ \n"
+                    + error
+                )
+        else:
+            print("---CODE BLOCK CHECK: SUCCESS---")
+            # No errors occurred
+            error = "None"
+
+        return {
+            "keys": {
+                "generation": code_solution,
+                "question": question,
+                "error": error,
+                "prefix": prefix,
+                "imports": imports,
+                "iterations": iter,
+                "code": code,
+            }
+        }
+
+    def finish(self, state: GraphState) -> dict:
+        """
+        Finish the graph
+
+        Returns:
+            dict: Final result
+        """
+
+        print("---FINISHING---")
+        state_dict = state["keys"]
+        code_solution = state_dict["generation"]
+        prefix = code_solution[0].prefix
+        imports = code_solution[0].imports
+        code = code_solution[0].code
+
+        response = "\n".join([prefix, imports, code])
+
+        return {"keys": {"response": response}}

--- a/06_gpu_and_ml/langchains/codelangchain/nodes.py
+++ b/06_gpu_and_ml/langchains/codelangchain/nodes.py
@@ -283,12 +283,27 @@ class Nodes:
         """
 
         print("---FINISHING---")
-        state_dict = state["keys"]
-        code_solution = state_dict["generation"]
-        prefix = code_solution[0].prefix
-        imports = code_solution[0].imports
-        code = code_solution[0].code
 
-        response = "\n".join([prefix, imports, code])
+        response = extract_response(state)
 
         return {"keys": {"response": response}}
+
+
+def extract_response(state: GraphState) -> str:
+    """
+    Extract the response from the graph state
+
+    Args:
+        state (dict): The current graph state
+
+    Returns:
+        str: The response
+    """
+
+    state_dict = state["keys"]
+    code_solution = state_dict["generation"][0]
+    prefix = code_solution.prefix
+    imports = code_solution.imports
+    code = code_solution.code
+
+    return "\n".join([prefix, imports, code])

--- a/06_gpu_and_ml/langchains/codelangchain/retrieval.py
+++ b/06_gpu_and_ml/langchains/codelangchain/retrieval.py
@@ -1,0 +1,45 @@
+from common import COLOR
+
+lcel_docs_url = "https://python.langchain.com/docs/expression_language/"
+
+
+def retrieve_docs(url: str = lcel_docs_url, debug=False):
+    from bs4 import BeautifulSoup as Soup
+    from langchain_community.document_loaders.recursive_url_loader import (
+        RecursiveUrlLoader,
+    )
+
+    print(
+        f"{COLOR['HEADER']}📜: Retrieving documents from {url}{COLOR['ENDC']}"
+    )
+    loader = RecursiveUrlLoader(
+        url=lcel_docs_url,
+        max_depth=20 // (int(debug) + 1),  # retrieve fewer docs in debug mode
+        extractor=lambda x: Soup(x, "html.parser").text,
+    )
+    docs = loader.load()
+
+    # sort the list based on the URLs
+    d_sorted = sorted(docs, key=lambda x: x.metadata["source"], reverse=True)
+
+    # combine them all together
+    concatenated_content = "\n\n\n --- \n\n\n".join(
+        [
+            "## " + doc.metadata["source"] + "\n\n" + doc.page_content.strip()
+            for doc in d_sorted
+        ]
+    )
+
+    print(
+        f"{COLOR['HEADER']}📜: Retrieved {len(docs)} documents{COLOR['ENDC']}",
+        f"{COLOR['GREEN']}{concatenated_content[:100].strip()}{COLOR['ENDC']}",
+        sep="\n",
+    )
+
+    if debug:
+        print(
+            f"{COLOR['HEADER']}📜: Restricting to at most 30,000 characters{COLOR['ENDC']}"
+        )
+        concatenated_content = concatenated_content[:30_000]
+
+    return concatenated_content

--- a/06_gpu_and_ml/langchains/codelangchain/sandbox.py
+++ b/06_gpu_and_ml/langchains/codelangchain/sandbox.py
@@ -1,0 +1,31 @@
+import modal
+from common import COLOR, agent_image, stub
+
+
+def run(code: str):
+    print(
+        f"{COLOR['HEADER']}📦: Running in sandbox{COLOR['ENDC']}",
+        f"{COLOR['GREEN']}{code}{COLOR['ENDC']}",
+        sep="\n",
+    )
+    sb = stub.spawn_sandbox(
+        "python",
+        "-c",
+        code,
+        image=agent_image,
+        timeout=60 * 10,  # 10 minutes
+        secrets=[
+            modal.Secret.from_name(
+                "my-openai-secret"
+            )  # could be a different secret!
+        ],
+    )
+
+    sb.wait()
+
+    if sb.returncode != 0:
+        print(
+            f"{COLOR['HEADER']}📦: Failed with exitcode {sb.returncode}{COLOR['ENDC']}"
+        )
+
+    return sb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 filterwarnings = [
     "error::DeprecationWarning",
     "error::modal.exception.DeprecationError",
-    "ignore::DeprecationWarning:pytest.*:",
+    # "ignore::DeprecationWarning:pytest.*:",
 ]
 pythonpath = ["06_gpu_and_ml/spam-detect", "06_gpu_and_ml/text-to-pokemon"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error::DeprecationWarning",
+    # "error::DeprecationWarning",
     "error::modal.exception.DeprecationError",
-    # "ignore::DeprecationWarning:pytest.*:",
+    "ignore::DeprecationWarning:pytest.*:",
 ]
 pythonpath = ["06_gpu_and_ml/spam-detect", "06_gpu_and_ml/text-to-pokemon"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.pytest.ini_options]
 filterwarnings = [
-    # "error::DeprecationWarning",
-    "error::modal.exception.DeprecationError",
+    "ignore::DeprecationWarning",
+    "ignore::modal.exception.DeprecationError",
     "ignore::DeprecationWarning:pytest.*:",
 ]
 pythonpath = ["06_gpu_and_ml/spam-detect", "06_gpu_and_ml/text-to-pokemon"]


### PR DESCRIPTION
This example shows off the use of Sandboxes for securely executing code from LLMs and how to serve a LangServe application with `asgi_app`.

It comprises a LangGraph-defined agent that has access to the LangChain Expression Language docs and answers questions about LCEL by providing code samples. 

### Type of Change

- [x] New example
## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
