### PR TITLE
Fix Jupyter example

### DIFF
--- a/02_building_containers/install_cuda.py
+++ b/02_building_containers/install_cuda.py
@@ -6,11 +6,10 @@
 
 from modal import Image, Stub
 
-stub = Stub()
-
-stub.image = Image.from_registry(
+image = Image.from_registry(
     "nvidia/cuda:12.2.0-devel-ubuntu22.04", add_python="3.11"
 )
+stub = Stub(image=image)
 
 # Now, we can create a function with GPU capabilities. Run this file with
 # `modal run install_cuda.py`.

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -9,10 +9,10 @@ from . import config
 from .main import (
     get_episode_metadata_path,
     get_transcript_path,
+    in_progress,
     populate_podcast_metadata,
     process_episode,
     search_podcast,
-    stub,
 )
 from .podcast import coalesce_short_transcript_segments
 
@@ -104,7 +104,7 @@ async def podcasts_endpoint(request: Request):
 async def transcribe_job(podcast_id: str, episode_id: str):
     now = int(time.time())
     try:
-        inprogress_job = stub.in_progress[episode_id]
+        inprogress_job = in_progress[episode_id]
         # NB: runtime type check is to handle present of old `str` values that didn't expire.
         if (
             isinstance(inprogress_job, InProgressJob)
@@ -119,7 +119,7 @@ async def transcribe_job(podcast_id: str, episode_id: str):
         pass
 
     call = process_episode.spawn(podcast_id, episode_id)
-    stub.in_progress[episode_id] = InProgressJob(
+    in_progress[episode_id] = InProgressJob(
         call_id=call.object_id, start_time=now
     )
 

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -56,7 +56,7 @@ stub = Stub(
     secrets=[Secret.from_name("podchaser")],
 )
 
-stub.in_progress = Dict.new()
+in_progress = Dict.from_name("pod-transcriber-in-progress")
 
 
 def utc_now() -> datetime.datetime:
@@ -412,7 +412,7 @@ def process_episode(podcast_id: str, episode_id: str):
                 model=model,
             )
     finally:
-        del stub.in_progress[episode_id]
+        del in_progress[episode_id]
 
     return episode
 

--- a/06_gpu_and_ml/stable_diffusion/a1111_webui.py
+++ b/06_gpu_and_ml/stable_diffusion/a1111_webui.py
@@ -15,8 +15,8 @@ import webbrowser
 from modal import Image, Queue, Stub, forward
 
 stub = Stub("example-a1111-webui")
-stub.urls = Queue.from_name(
-    "a1111-webui-example", create_if_missing=True
+url_queue = Queue.from_name(
+    "a1111-webui-example-queue", create_if_missing=True
 )  # TODO: FunctionCall.get() doesn't support generators.
 
 
@@ -85,7 +85,7 @@ accelerate launch \
         p = subprocess.Popen(START_COMMAND, shell=True)
         wait_for_port(8000)
         print("[MODAL] ==> Accepting connections at", tunnel.url)
-        stub.urls.put(tunnel.url)
+        url_queue.put(tunnel.url)
         p.wait(3600)
 
 
@@ -96,7 +96,7 @@ accelerate launch \
 @stub.local_entrypoint()
 def main(no_browser: bool = False):
     start_web_ui.spawn()
-    url = stub.urls.get()
+    url = url_queue.get()
     if not no_browser:
         webbrowser.open(url)
     while True:  # TODO: FunctionCall.get() doesn't support generators.

--- a/10_integrations/pyjulia.py
+++ b/10_integrations/pyjulia.py
@@ -1,7 +1,6 @@
 import modal
 
-stub = modal.Stub("example-pyjulia")
-stub.image = (
+image = image = (
     modal.Image.debian_slim()
     # Install Julia 1.10
     .apt_install("wget", "ca-certificates")
@@ -15,6 +14,7 @@ stub.image = (
     .pip_install("julia")
     .run_commands('python -c "import julia; julia.install()"')
 )
+stub = modal.Stub("example-pyjulia", image=image)
 
 
 @stub.function()


### PR DESCRIPTION
Noticed that this was red in the example synmon — it was a casualty of the `.new()` deprecation.

I also updated it to demonstrate `Volume` which we're trying to encourage everyone to adopt.

Funny enough we rolled out the new Volume viewer in the dashboard — which kind of obviates this example. We should think of a better hook for demonstrating the features here.

---

Additionally, there are a few bonus fixes for the `stub.<object>` deprecation that landed recently.