### PR TITLE
Fix link to code in LoRAs example Gradio app

### DIFF
--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -305,7 +305,7 @@ def app():
         title="LoRAs Galore",
         description="# Try out some of the top custom SDXL models!"
         "\n\nPick a LoRA finetune of SDXL from the dropdown, then prompt it to generate an image."
-        "\n\nCheck out [the code on GitHub](https://github.com/modal-labs/examples/blob/main/10_integrations/cloud_bucket_mount_loras.py)"
+        "\n\nCheck out [the code on GitHub](https://github.com/modal-labs/modal-examples/blob/main/10_integrations/cloud_bucket_mount_loras.py)"
         " if you want to create your own version or just see how it works."
         "\n\nPowered by [Modal](https://modal.com) 🚀",
         theme="soft",


### PR DESCRIPTION
Hi, just fixing the link to GitHub, the repo name was wrong

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
