### PR TITLE
Update playwright version for debian 12 compat

### DIFF
--- a/02_building_containers/screenshot.py
+++ b/02_building_containers/screenshot.py
@@ -35,7 +35,7 @@ image = modal.Image.debian_slim().run_commands(
     "apt-get install -y software-properties-common",
     "apt-add-repository non-free",
     "apt-add-repository contrib",
-    "pip install playwright==1.30.0",
+    "pip install playwright==1.42.0",
     "playwright install-deps chromium",
     "playwright install chromium",
 )


### PR DESCRIPTION
Updates the version of playwright that we install in the screenshot example for compatibility with Debian 12 (bookworm).

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
