### PR TITLE
Update algolia_indexer.py

### DIFF
--- a/10_integrations/algolia_indexer.py
+++ b/10_integrations/algolia_indexer.py
@@ -21,11 +21,11 @@ from modal import Image, Secret, Stub, web_endpoint
 # Modal lets you [use and extend existing Docker images](/docs/guide/custom-container#use-an-existing-container-image-with-from_registry),
 # as long as they have `python` and `pip` available. We'll use the official crawler image built by Algolia, with a small
 # adjustment: since this image has `python` symlinked to `python3.6` and Modal is not compatible with Python 3.6, we
-# install Python 3.8 and symlink that as the `python` executable instead.
+# install Python 3.11 and symlink that as the `python` executable instead.
 
 algolia_image = Image.from_registry(
-    "algolia/docsearch-scraper",
-    add_python="3.8",
+    "algolia/docsearch-scraper:v1.16.0",
+    add_python="3.11",
     setup_dockerfile_commands=["ENTRYPOINT []"],
 )
 


### PR DESCRIPTION
Fixes some errors with anyio/exceptiongroup handling on the new builder version.

```
  File "/usr/local/lib/python3.9/site-packages/anyio/_core/_sockets.py", line 35, in <module>
    from exceptiongroup import ExceptionGroup
ModuleNotFoundError: No module named 'exceptiongroup'
```