### PR TITLE
Replace keep_warm with container_idle_timeout in example

### DIFF
--- a/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
+++ b/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
@@ -274,17 +274,21 @@ def import_gradio_app_blocks(demo: DemoApp):
     return blocks
 
 
-# Because the ControlNet gradio app's are so time and compute intensive to cold-start
-# the web app function is limited to running just 1 warm container. This way, while playing
-# with the demos we can pay the cold-start cost once and have all web requests hit the warm
-# container. Spinning up extra containers to handle additional requests would not be efficient
+# Because the ControlNet gradio apps are so time and compute intensive to cold-start,
+# the web app function is limited to running just 1 warm container (concurrency_limit=1).
+# This way, while playing with the demos we can pay the cold-start cost once and have
+# all web requests hit the same warm container.
+# Spinning up extra containers to handle additional requests would not be efficient
 # given the cold-start time.
+# We set the container_idle_timeout to 600 seconds so the container will be kept
+# running for 10 minutes after the last request, to keep the app responsive in case
+# of continued experimentation.
 
 
 @stub.function(
     gpu="A10G",
     concurrency_limit=1,
-    keep_warm=1,
+    container_idle_timeout=600,
 )
 @asgi_app()
 def run():


### PR DESCRIPTION
Keep warm can easily lead to a budget getting consumed by an unknowing user who deploys this to play around with it and then forgets it.
