### PR TITLE
Add python version to the image to prevent pip install error

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_gemma.py
+++ b/06_gpu_and_ml/llm-serving/vllm_gemma.py
@@ -76,7 +76,7 @@ def download_model_to_image(model_dir, model_name):
 # and save the resulting files to the container image -- that way we don't need
 # to redownload the weights every time we change the server's code or start up more instances of the server.
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.10")
     .pip_install(
         "vllm==0.4.0.post1",
         "torch==2.1.2",


### PR DESCRIPTION
### Short summary of the PR
There was an error when I tried the example. Since my local python version was 3.12.2, ray package with version 2.10 was not supported throwing an error:
```
ERROR: Could not find a version that satisfies the requirement ray==2.10.0 (from versions: none)
ERROR: No matching distribution found for ray==2.10.0
```
I added a python version to the image to resolve this error. 

### Type of Change
Example updates (Bug fixes, new features, etc.)
