### PR TITLE
python_version in Image declaration

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -56,7 +56,7 @@ def download_model_to_image(model_dir, model_name):
 # We’ll start from Modal's Debian slim image.
 # Then we’ll use `run_function` with `download_model_to_image` to write the model into the container image.
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.10")
     .pip_install(
         "vllm==0.4.0.post1",
         "torch==2.1.2",

--- a/06_gpu_and_ml/llm-serving/vllm_mixtral.py
+++ b/06_gpu_and_ml/llm-serving/vllm_mixtral.py
@@ -63,7 +63,7 @@ def download_model_to_image(model_dir, model_name, model_revision):
 # the model are saved within the container image.
 
 vllm_image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.10")
     .pip_install(
         "vllm==0.4.0.post1",
         "torch==2.1.2",


### PR DESCRIPTION
I've realized that the `ray==2.10.0` dependency only works with `python<=3.10`. Added `python_version="3.10"` to avoid `pip install` errors.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
