### PR TITLE
Add Nerf Studio Example

### DIFF
--- a/06_gpu_and_ml/comfyui/comfy_ui.py
+++ b/06_gpu_and_ml/comfyui/comfy_ui.py
@@ -46,7 +46,9 @@ def download_checkpoints():
                 num_bytes_downloaded = stream.num_bytes_downloaded
                 for data in stream.iter_bytes():
                     f.write(data)
-                    progress.update(stream.num_bytes_downloaded - num_bytes_downloaded)
+                    progress.update(
+                        stream.num_bytes_downloaded - num_bytes_downloaded
+                    )
                     num_bytes_downloaded = stream.num_bytes_downloaded
 
 
@@ -58,96 +60,14 @@ PLUGINS = [
     {
         "url": "https://github.com/coreyryanhanson/ComfyQR",
         "requirements": "requirements.txt",
-    },
-    # Kosinkadink/ComfyUI-Advanced-ControlNet
-    {
-        "url": "https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet",
-        "requirements": "requirements.txt",
-    },
-    # Nourepide/ComfyUI-Allor
-    {
-        "url": "https://github.com/Nourepide/ComfyUI-Allor",
-        "requirements": "requirements.txt",
-    },
-    # Add form requirement
-    {
-        "url": "https://github.com/formanek/ComfyUI-Form",
-        "requirements": "requirements.txt",
-    },
-    # Add ComfyUI-Manager
-    {
-        "url": "https://github.com/ltdrdata/ComfyUI-Manager",
-        "requirements": "requirements.txt",
-    },
-    # cubiq/ComfyUI_IPAdapter_plus
-    # {
-    #     "url": "https://github.com/cubiq/ComfyUI_IPAdapter_plus",
-    # },
-    # {
-    #     "url": "https://github.com/SeargeDP/SeargeSDXL",
-    # },
-    # jags111/efficiency-nodes-comfyui
-    {
-        "url": "https://github.com/jags111/efficiency-nodes-comfyui",
-        "requirements": "requirements.txt",
-    },
-    # https://github.com/banodoco/Steerable-Motion
-    {
-        "url": "https://github.com/banodoco/Steerable-Motion",
-        "requirements": "requirements.txt",
-    },
-    # ADE_AnimateDiffLoRALoader
-    {
-        "url": "https://github.com/ADE-AI/ADE_AnimateDiffLoRALoader",
-        "requirements": "requirements.txt",
-    },
-    {
-        "url": "https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved",
-    },
-    # https://github.com/Fannovel16/ComfyUI-Frame-Interpolation
-    {
-        "url": "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation",
-    },
-    # https://github.com/cubiq/ComfyUI_IPAdapter_plus
-    {
-        "url": "https://github.com/cubiq/ComfyUI_IPAdapter_plus",
-    },
-    # https://github.com/cubiq/ComfyUI_essentials
-    {
-        "url": "https://github.com/cubiq/ComfyUI_essentials",
-    },
-    # "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
-    {
-        "url": "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite",
-    },
-    # https://github.com/M1kep/ComfyLiterals
-    {
-        "url": "https://github.com/M1kep/ComfyLiterals",
-    },
-    # https://github.com/M1kep/Comfy_KepMatteAnything
-    {
-        "url": "https://github.com/M1kep/Comfy_KepMatteAnything",
-    },
-    # https://github.com/M1kep/KepPromptLang
-    {
-        "url": "https://github.com/M1kep/KepPromptLang",
-    },
-]
-
-extra_plugins = [
-    {
-        "url": "https://github.com/FizzleDorf/ComfyUI_FizzNodes",
-    },
-    {
-        "url": "https://github.com/SeargeDP/SeargeSDXL",
-    },
+    }
 ]
 
 
-def download_plugins(plugin_list):
+def download_plugins():
     import subprocess
 
-    for plugin in plugin_list:
+    for plugin in PLUGINS:
         url = plugin["url"]
         name = url.split("/")[-1]
         command = f"cd /root/custom_nodes && git clone {url}"
@@ -156,14 +76,13 @@ def download_plugins(plugin_list):
             print(f"Repository {url} cloned successfully")
         except subprocess.CalledProcessError as e:
             print(f"Error cloning repository: {e.stderr}")
-
         if plugin.get("requirements"):
             pip_command = f"cd /root/custom_nodes/{name} && pip install -r {plugin['requirements']}"
-            try:
-                subprocess.run(pip_command, shell=True, check=True)
-                print(f"Requirements for {url} installed successfully")
-            except subprocess.CalledProcessError as e:
-                print(f"Error installing requirements: {e.stderr}")
+        try:
+            subprocess.run(pip_command, shell=True, check=True)
+            print(f"Requirements for {url} installed successfully")
+        except subprocess.CalledProcessError as e:
+            print(f"Error installing requirements: {e.stderr}")
 
 
 # Pin to a specific commit from https://github.com/comfyanonymous/ComfyUI/commits/master/
@@ -172,50 +91,30 @@ comfyui_commit_sha = "a38b9b3ac152fb5679dad03813a93c09e0a4d15e"
 
 image = (
     modal.Image.debian_slim(python_version="3.11")
-    # modal.Image.debian_slim(python_version="3.11")
     .apt_install("git")
     # Here we place the latest ComfyUI repository code into /root.
     # Because /root is almost empty, but not entirely empty
     # as it contains this comfy_ui.py script, `git clone` won't work.
     # As a workaround we `init` inside the non-empty directory, then `checkout`.
-    .pip_install("torch")
     .run_commands(
         "cd /root && git init .",
         "cd /root && git remote add --fetch origin https://github.com/comfyanonymous/ComfyUI",
-        # f"cd /root && git checkout {comfyui_commit_sha}",
-        "cd /root && git checkout master; git pull",
+        f"cd /root && git checkout {comfyui_commit_sha}",
         "cd /root && pip install xformers!=0.0.18 -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121",
         "cd /root && git clone https://github.com/pydn/ComfyUI-to-Python-Extension.git",
         "cd /root/ComfyUI-to-Python-Extension && pip install -r requirements.txt",
-        "cd /root/custom_nodes && git clone https://github.com/ltdrdata/ComfyUI-Manager.git",
     )
     .pip_install(
         "httpx",
         "requests",
         "tqdm",
     )
-    .run_commands(
-        "python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'"
-    )
-    .pip_install(
-        "lark",
-    )
-    .run_commands(
-        # Ensure wget is installed before attempting to download the file
-        "apt-get install -y wget",
-    )
-    .run_commands(
-        "git clone https://github.com/IDEA-Research/GroundingDINO.git",
-        "cd GroundingDINO && pip install -e .",
-        "mkdir -p GroundingDINO/weights",
-        "cd GroundingDINO/weights && wget -q https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth",
-    )
     .run_function(download_checkpoints)
-    .run_function(download_plugins, PLUGINS)
-    .pip_install("simpleeval")
-    .run_function(download_plugins, extra_plugins)
+    .run_function(download_plugins)
 )
-app = modal.App(name="example-comfy-ui", image=image)
+app = modal.App(
+    name="example-comfy-ui", image=image
+)  # Note: prior to April 2024, "app" was called "stub"
 
 # ## Start the ComfyUI server
 #
@@ -235,7 +134,7 @@ app = modal.App(name="example-comfy-ui", image=image)
     keep_warm=1,
     timeout=1800,
 )
-@modal.web_server(8188, startup_timeout=600)
+@modal.web_server(8188, startup_timeout=30)
 def web():
     cmd = "python main.py --dont-print-server --multi-user --listen --port 8188"
     subprocess.Popen(cmd, shell=True)

--- a/06_gpu_and_ml/comfyui/comfy_ui.py
+++ b/06_gpu_and_ml/comfyui/comfy_ui.py
@@ -46,9 +46,7 @@ def download_checkpoints():
                 num_bytes_downloaded = stream.num_bytes_downloaded
                 for data in stream.iter_bytes():
                     f.write(data)
-                    progress.update(
-                        stream.num_bytes_downloaded - num_bytes_downloaded
-                    )
+                    progress.update(stream.num_bytes_downloaded - num_bytes_downloaded)
                     num_bytes_downloaded = stream.num_bytes_downloaded
 
 
@@ -60,14 +58,96 @@ PLUGINS = [
     {
         "url": "https://github.com/coreyryanhanson/ComfyQR",
         "requirements": "requirements.txt",
-    }
+    },
+    # Kosinkadink/ComfyUI-Advanced-ControlNet
+    {
+        "url": "https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet",
+        "requirements": "requirements.txt",
+    },
+    # Nourepide/ComfyUI-Allor
+    {
+        "url": "https://github.com/Nourepide/ComfyUI-Allor",
+        "requirements": "requirements.txt",
+    },
+    # Add form requirement
+    {
+        "url": "https://github.com/formanek/ComfyUI-Form",
+        "requirements": "requirements.txt",
+    },
+    # Add ComfyUI-Manager
+    {
+        "url": "https://github.com/ltdrdata/ComfyUI-Manager",
+        "requirements": "requirements.txt",
+    },
+    # cubiq/ComfyUI_IPAdapter_plus
+    # {
+    #     "url": "https://github.com/cubiq/ComfyUI_IPAdapter_plus",
+    # },
+    # {
+    #     "url": "https://github.com/SeargeDP/SeargeSDXL",
+    # },
+    # jags111/efficiency-nodes-comfyui
+    {
+        "url": "https://github.com/jags111/efficiency-nodes-comfyui",
+        "requirements": "requirements.txt",
+    },
+    # https://github.com/banodoco/Steerable-Motion
+    {
+        "url": "https://github.com/banodoco/Steerable-Motion",
+        "requirements": "requirements.txt",
+    },
+    # ADE_AnimateDiffLoRALoader
+    {
+        "url": "https://github.com/ADE-AI/ADE_AnimateDiffLoRALoader",
+        "requirements": "requirements.txt",
+    },
+    {
+        "url": "https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved",
+    },
+    # https://github.com/Fannovel16/ComfyUI-Frame-Interpolation
+    {
+        "url": "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation",
+    },
+    # https://github.com/cubiq/ComfyUI_IPAdapter_plus
+    {
+        "url": "https://github.com/cubiq/ComfyUI_IPAdapter_plus",
+    },
+    # https://github.com/cubiq/ComfyUI_essentials
+    {
+        "url": "https://github.com/cubiq/ComfyUI_essentials",
+    },
+    # "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
+    {
+        "url": "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite",
+    },
+    # https://github.com/M1kep/ComfyLiterals
+    {
+        "url": "https://github.com/M1kep/ComfyLiterals",
+    },
+    # https://github.com/M1kep/Comfy_KepMatteAnything
+    {
+        "url": "https://github.com/M1kep/Comfy_KepMatteAnything",
+    },
+    # https://github.com/M1kep/KepPromptLang
+    {
+        "url": "https://github.com/M1kep/KepPromptLang",
+    },
+]
+
+extra_plugins = [
+    {
+        "url": "https://github.com/FizzleDorf/ComfyUI_FizzNodes",
+    },
+    {
+        "url": "https://github.com/SeargeDP/SeargeSDXL",
+    },
 ]
 
 
-def download_plugins():
+def download_plugins(plugin_list):
     import subprocess
 
-    for plugin in PLUGINS:
+    for plugin in plugin_list:
         url = plugin["url"]
         name = url.split("/")[-1]
         command = f"cd /root/custom_nodes && git clone {url}"
@@ -76,13 +156,14 @@ def download_plugins():
             print(f"Repository {url} cloned successfully")
         except subprocess.CalledProcessError as e:
             print(f"Error cloning repository: {e.stderr}")
+
         if plugin.get("requirements"):
             pip_command = f"cd /root/custom_nodes/{name} && pip install -r {plugin['requirements']}"
-        try:
-            subprocess.run(pip_command, shell=True, check=True)
-            print(f"Requirements for {url} installed successfully")
-        except subprocess.CalledProcessError as e:
-            print(f"Error installing requirements: {e.stderr}")
+            try:
+                subprocess.run(pip_command, shell=True, check=True)
+                print(f"Requirements for {url} installed successfully")
+            except subprocess.CalledProcessError as e:
+                print(f"Error installing requirements: {e.stderr}")
 
 
 # Pin to a specific commit from https://github.com/comfyanonymous/ComfyUI/commits/master/
@@ -91,30 +172,50 @@ comfyui_commit_sha = "a38b9b3ac152fb5679dad03813a93c09e0a4d15e"
 
 image = (
     modal.Image.debian_slim(python_version="3.11")
+    # modal.Image.debian_slim(python_version="3.11")
     .apt_install("git")
     # Here we place the latest ComfyUI repository code into /root.
     # Because /root is almost empty, but not entirely empty
     # as it contains this comfy_ui.py script, `git clone` won't work.
     # As a workaround we `init` inside the non-empty directory, then `checkout`.
+    .pip_install("torch")
     .run_commands(
         "cd /root && git init .",
         "cd /root && git remote add --fetch origin https://github.com/comfyanonymous/ComfyUI",
-        f"cd /root && git checkout {comfyui_commit_sha}",
+        # f"cd /root && git checkout {comfyui_commit_sha}",
+        "cd /root && git checkout master; git pull",
         "cd /root && pip install xformers!=0.0.18 -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121",
         "cd /root && git clone https://github.com/pydn/ComfyUI-to-Python-Extension.git",
         "cd /root/ComfyUI-to-Python-Extension && pip install -r requirements.txt",
+        "cd /root/custom_nodes && git clone https://github.com/ltdrdata/ComfyUI-Manager.git",
     )
     .pip_install(
         "httpx",
         "requests",
         "tqdm",
     )
+    .run_commands(
+        "python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'"
+    )
+    .pip_install(
+        "lark",
+    )
+    .run_commands(
+        # Ensure wget is installed before attempting to download the file
+        "apt-get install -y wget",
+    )
+    .run_commands(
+        "git clone https://github.com/IDEA-Research/GroundingDINO.git",
+        "cd GroundingDINO && pip install -e .",
+        "mkdir -p GroundingDINO/weights",
+        "cd GroundingDINO/weights && wget -q https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth",
+    )
     .run_function(download_checkpoints)
-    .run_function(download_plugins)
+    .run_function(download_plugins, PLUGINS)
+    .pip_install("simpleeval")
+    .run_function(download_plugins, extra_plugins)
 )
-app = modal.App(
-    name="example-comfy-ui", image=image
-)  # Note: prior to April 2024, "app" was called "stub"
+app = modal.App(name="example-comfy-ui", image=image)
 
 # ## Start the ComfyUI server
 #
@@ -134,7 +235,7 @@ app = modal.App(
     keep_warm=1,
     timeout=1800,
 )
-@modal.web_server(8188, startup_timeout=30)
+@modal.web_server(8188, startup_timeout=600)
 def web():
     cmd = "python main.py --dont-print-server --multi-user --listen --port 8188"
     subprocess.Popen(cmd, shell=True)

--- a/06_gpu_and_ml/nerf_studio.py
+++ b/06_gpu_and_ml/nerf_studio.py
@@ -41,8 +41,10 @@ image = (
     )
     .run_commands(
         "pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch",
-        "git clone https://github.com/nerfstudio-project/nerfstudio.git",
-        "cd nerfstudio && pip install -e .",
+    )
+    .run_commands(
+        "git clone https://github.com/nerfstudio-project/nerfstudio.git /nerfstudio",
+        "cd /nerfstudio && pip install -e .",
         gpu=gpu_device,
     )
     .pip_install(
@@ -67,5 +69,5 @@ app = modal.App(name="nerfstudio-on-modal", image=image)
 def nerfstudio_web():
     import subprocess
 
-    cmd = "cd nerfstudio && python -m nerfstudio.server --port 7007"
+    cmd = "cd /nerfstudio && python -m nerfstudio.server --port 7007"
     subprocess.Popen(cmd, shell=True)

--- a/06_gpu_and_ml/nerf_studio.py
+++ b/06_gpu_and_ml/nerf_studio.py
@@ -1,0 +1,71 @@
+import modal
+import subprocess  # Import subprocess to fix the NameError
+
+gpu_device = "a100"
+
+# Define the container image using Conda for package management
+image = (
+    modal.Image.conda()
+    .apt_install("git")
+    .run_commands(
+        "apt-get update",
+        "apt-get install -y wget build-essential git",
+        "pip install --upgrade pip",
+    )
+    .conda_install(
+        "nvidia::cuda-toolkit=12.4.1",
+        channels=["nvidia"],
+        gpu=gpu_device,
+    )
+    .conda_install(
+        "nvidia::cuda-nvcc=12.4.131",
+        channels=["nvidia"],
+        gpu=gpu_device,
+    )
+    .run_commands(
+        "which nvidia-smi",
+        "which nvcc",
+        "ls /usr/local/",
+        # "ls /usr/local/cuda-12.4.1",
+    )
+    # .env(
+    #     {
+    #         "CUDA_HOME": "/usr/local/cuda-12.4.1",
+    #     },
+    # )
+    .pip_install(
+        "torch",
+        "transformers",
+        "huggingface-hub",
+        gpu=gpu_device,
+    )
+    .run_commands(
+        "pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch",
+        "git clone https://github.com/nerfstudio-project/nerfstudio.git",
+        "cd nerfstudio && pip install -e .",
+        gpu=gpu_device,
+    )
+    .pip_install(
+        "httpx",
+        "requests",
+        "tqdm",
+    )
+    .pip_install("kplanes-nerfstudio")
+)
+
+app = modal.App(name="nerfstudio-on-modal", image=image)
+
+
+@app.function(
+    gpu=gpu_device,
+    allow_concurrent_inputs=100,
+    concurrency_limit=1,
+    keep_warm=1,
+    timeout=1800,
+)
+@modal.web_server(7007, startup_timeout=600)
+def nerfstudio_web():
+    import subprocess
+
+    cmd = "cd nerfstudio && python -m nerfstudio.server --port 7007"
+    subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION
This adds a nerf studio example to modal. 

Setting this up for myself and the build setup got a little complicated. 

### Type of Change

- [X] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
