### PR TITLE
Install numpy explicitly in wikipedia example

### DIFF
--- a/06_gpu_and_ml/embeddings/wikipedia/main.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/main.py
@@ -78,7 +78,7 @@ tei_image = (
         add_python="3.10",
     )
     .dockerfile_commands("ENTRYPOINT []")
-    .pip_install("httpx")
+    .pip_install("httpx", "numpy")
 )
 
 with tei_image.imports():


### PR DESCRIPTION
New base image version no longer has `numpy` pre-installed