### PR TITLE
Specify bpy / Blender 4.1.0

### DIFF
--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -37,7 +37,7 @@ app = modal.App("examples-blender-video")
 rendering_image = (
     modal.Image.debian_slim(python_version="3.11")
     .apt_install("xorg", "libxkbcommon0")  # X11 (Unix GUI) dependencies
-    .pip_install("bpy")  # Blender as a Python package
+    .pip_install("bpy==4.1.0")  # Blender as a Python package
 )
 
 # ## Rendering a single frame


### PR DESCRIPTION
> Each Blender release supports one Python version, and the package is only compatible with that version.

Just realized we should probably pin this dependency to avoid future breakage. Blender 4.1.0 happens to match Python 3.11.
