### PR TITLE
set up testing of serve_streamlit, pin versions

### DIFF
--- a/10_integrations/streamlit/serve_streamlit.py
+++ b/10_integrations/streamlit/serve_streamlit.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# deploy: true
 # cmd: ["modal", "serve", "10_integrations/streamlit/serve_streamlit.py"]
 # ---
 #
@@ -26,7 +26,9 @@ import modal
 # The `app.py` script imports three third-party packages, so we include these in the example's
 # image definition.
 
-image = modal.Image.debian_slim().pip_install("streamlit", "numpy", "pandas")
+image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "streamlit~=1.35.0", "numpy~=1.26.4", "pandas~=2.2.2"
+)
 
 app = modal.App(
     name="example-modal-streamlit", image=image


### PR DESCRIPTION
### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`