### PR TITLE
pin pyjulia version, trigger rebuild

### DIFF
--- a/10_integrations/pyjulia.py
+++ b/10_integrations/pyjulia.py
@@ -11,7 +11,7 @@ image = image = (
         "ln -s /opt/julia-1.10.0/bin/julia /usr/local/bin/julia",
     )
     # Install PyJulia bindings
-    .pip_install("julia")
+    .pip_install("julia==0.6.1")
     .run_commands('python -c "import julia; julia.install()"')
 )
 app = modal.App("example-pyjulia", image=image)


### PR DESCRIPTION
This example [failed in CI recently](https://github.com/modal-labs/modal-examples/actions/runs/9474947842/job/26105482247). 

Pinning to the last known-working version of `pyjulia`, but I suspect this was actually just due to an out-of-date or otherwise invalid code cache (see error message in failed CI run).