### PR TITLE
Update vLLM example link

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_mixtral.py
+++ b/06_gpu_and_ml/llm-serving/vllm_mixtral.py
@@ -207,7 +207,7 @@ def main():
 #
 # We can stream inference from a FastAPI backend, also deployed on Modal.
 #
-# You can try our deployment [here](https://modal-labs--vllm-mixtral.modal.run).
+# You can try our deployment [here](https://modal-labs--example-vllm-mixtral-vllm-mixtral.modal.run).
 
 from pathlib import Path
 


### PR DESCRIPTION
Replace outdated link to vLLM example (https://modal-labs--vllm-mixtral.modal.run/) with new link: https://modal-labs--example-vllm-mixtral-vllm-mixtral.modal.run/

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
