### PR TITLE
Add web endpoint labels back

### DIFF
--- a/06_gpu_and_ml/llm-serving/tgi_mixtral.py
+++ b/06_gpu_and_ml/llm-serving/tgi_mixtral.py
@@ -187,7 +187,7 @@ frontend_path = Path(__file__).parent.parent / "llm-frontend"
     allow_concurrent_inputs=20,
     timeout=60 * 10,
 )
-@asgi_app()
+@asgi_app(label="tgi-mixtral")
 def tgi_mixtral():
     import json
 

--- a/06_gpu_and_ml/llm-serving/vllm_mixtral.py
+++ b/06_gpu_and_ml/llm-serving/vllm_mixtral.py
@@ -222,7 +222,7 @@ frontend_path = Path(__file__).parent.parent / "llm-frontend"
     allow_concurrent_inputs=20,
     timeout=60 * 10,
 )
-@asgi_app()
+@asgi_app(label="vllm-mixtral")
 def vllm_mixtral():
     import json
 


### PR DESCRIPTION
These labels were accidentally removed in #704, breaking some existing links. (`tgi_app` has it's own label `llama3`, so it's not included in this PR)

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

