### PR TITLE
Update trtllm_llama.py

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -576,7 +576,7 @@ class GenerateRequest(pydantic.BaseModel):
 )
 def generate_web(data: GenerateRequest) -> list[str]:
     """Generate responses to a batch of prompts, optionally with custom inference settings."""
-    return Model.generate.remote(data["prompts"], settings=None)
+    return Model.generate.remote(data.prompts, settings=None)
 
 
 # To set our function up as a web endpoint, we need to run this file --


### PR DESCRIPTION
I was testing this file in modal examples and it broke because data is a `GenerateRequest` object. The error shown was `TypeError: 'GenerateRequest' object is not subscriptable`. This updates it to access the property.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

