### PR TITLE
Dataset ingestion scripts update: parallelize ingest for RoseTTAFold, CoCo

### DIFF
--- a/12_datasets/coco.py
+++ b/12_datasets/coco.py
@@ -125,7 +125,7 @@ def _do_part(url: str) -> None:
     subprocess.run(command, shell=True, check=True)
     print(f"Download of {name} completed successfully.")
     extract_tmp_path.mkdir()
-    extractall(zip_path, dest_path)  # extract into /tmp/
+    extractall(zip_path, extract_tmp_path, desc=f"Extracting {name}")  # extract into /tmp/
     zip_path.unlink()  # free up disk space by deleting the zip
     print(f"Copying extract {name} data to volume.")
     copy_concurrent(

--- a/12_datasets/coco.py
+++ b/12_datasets/coco.py
@@ -36,7 +36,7 @@ app = modal.App(
 )
 
 
-def start_monitoring_disk_space(interval: int = 30) -> None:
+def start_monitoring_disk_space(interval: int = 120) -> None:
     """Start monitoring the disk space in a separate thread."""
     task_id = os.environ["MODAL_TASK_ID"]
 
@@ -109,98 +109,45 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
 
 @app.function(
     volumes={"/vol/": volume},
-    timeout=60 * 60 * 4,  # 4 hours
-    ephemeral_disk=600 * 1024,  # 600 GiB
+    timeout=60 * 60 * 5, # 5 hours
+    ephemeral_disk=600 * 1024,  # 600 GiB,
+)
+def _do_part(url: str) -> None:
+    start_monitoring_disk_space()
+    part = url.replace("http://images.cocodataset.org/", "")
+    name = pathlib.Path(part).name.replace(".zip", "")
+    zip_path =  pathlib.Path("/tmp/") / pathlib.Path(part).name
+    extract_tmp_path = pathlib.Path("/tmp", name)
+    dest_path = pathlib.Path("/vol/coco/", name)
+
+    print(f"Downloading {name} from {url}")
+    command = f"wget {url} -O {zip_path}"
+    subprocess.run(command, shell=True, check=True)
+    print(f"Download of {name} completed successfully.")
+    extract_tmp_path.mkdir()
+    extractall(zip_path, dest_path)  # extract into /tmp/
+    zip_path.unlink()  # free up disk space by deleting the zip
+    print(f"Copying extract {name} data to volume.")
+    copy_concurrent(
+        extract_tmp_path, dest_path
+    )  # copy from /tmp/ into mounted volume
+
+# We can process each part of the dataset in parallel, using a 'parent' Function just to execute
+# the map and wait on completion of all children.
+
+@app.function(
+    timeout=60 * 60 * 5,  # 5 hours
 )
 def import_transform_load() -> None:
-    start_monitoring_disk_space()
-
-    train2017_tmp = pathlib.Path("/tmp/train2017.zip")
-    val2017_tmp = pathlib.Path("/tmp/val2017.zip")
-    test2017_tmp = pathlib.Path("/tmp/test2017.zip")
-    unlabeled2017_tmp = pathlib.Path("/tmp/unlabeled2017.zip")
-    annotations_trainval2017 = pathlib.Path("/tmp/annotations_trainval2017.zip")
-    stuff_annotations_trainval2017 = pathlib.Path(
-        "/tmp/stuff_annotations_trainval2017.zip"
-    )
-    image_info_test2017 = pathlib.Path("/tmp/image_info_test2017.zip")
-    image_info_unlabeled2017 = pathlib.Path("/tmp/image_info_unlabeled2017.zip")
-    commands = [
-        f"wget http://images.cocodataset.org/zips/train2017.zip -O {train2017_tmp}",
-        f"wget http://images.cocodataset.org/zips/val2017.zip -O {val2017_tmp}",
-        f"wget http://images.cocodataset.org/zips/test2017.zip -O {test2017_tmp}",
-        f"wget http://images.cocodataset.org/zips/unlabeled2017.zip -O {unlabeled2017_tmp}",
-        f"wget http://images.cocodataset.org/annotations/annotations_trainval2017.zip -O {annotations_trainval2017}",
-        f"wget http://images.cocodataset.org/annotations/stuff_annotations_trainval2017.zip -O {stuff_annotations_trainval2017}",
-        f"wget http://images.cocodataset.org/annotations/image_info_test2017.zip -O {image_info_test2017}",
-        f"wget http://images.cocodataset.org/annotations/image_info_unlabeled2017.zip -O {image_info_unlabeled2017}",
-    ]
-    # Start all downloads in parallel
-    processes = [subprocess.Popen(cmd, shell=True) for cmd in commands]
-    # Wait for all downloads to complete
-    errors = []
-    for p in processes:
-        returncode = p.wait()
-        if returncode == 0:
-            print("Download completed successfully.")
-        else:
-            errors.append(
-                f"Error in downloading. {p.args!r} failed {returncode=}"
-            )
-    if errors:
-        raise RuntimeError(errors)
-
-    destination = pathlib.Path("/tmp/train2017/")
-    for (
-        src,
-        extract_dest,
-        final_dest,
-    ) in [
-        (
-            train2017_tmp,
-            pathlib.Path("/tmp/train2017/"),
-            pathlib.Path("/vol/coco/train2017/"),
-        ),
-        (
-            val2017_tmp,
-            pathlib.Path("/tmp/val2017/"),
-            pathlib.Path("/vol/coco/val2017/"),
-        ),
-        (
-            test2017_tmp,
-            pathlib.Path("/tmp/test2017/"),
-            pathlib.Path("/vol/coco/test2017/"),
-        ),
-        (
-            unlabeled2017_tmp,
-            pathlib.Path("/tmp/unlabeled2017/"),
-            pathlib.Path("/vol/coco/unlabeled2017/"),
-        ),
-        (
-            annotations_trainval2017,
-            pathlib.Path("/tmp/annotations_trainval2017/"),
-            pathlib.Path("/vol/coco/annotations_trainval2017/"),
-        ),
-        (
-            stuff_annotations_trainval2017,
-            pathlib.Path("/tmp/stuff_annotations_trainval2017/"),
-            pathlib.Path("/vol/coco/stuff_annotations_trainval2017/"),
-        ),
-        (
-            image_info_test2017,
-            pathlib.Path("/tmp/image_info_test2017/"),
-            pathlib.Path("/vol/coco/image_info_test2017/"),
-        ),
-        (
-            image_info_unlabeled2017,
-            pathlib.Path("/tmp/image_info_unlabeled2017/"),
-            pathlib.Path("/vol/coco/image_info_unlabeled2017/"),
-        ),
-    ]:
-        extract_dest.mkdir()
-        extractall(src, destination)  # extract into /tmp/
-        src.unlink()  # free up disk space by deleting the zip
-        copy_concurrent(
-            destination, final_dest
-        )  # copy from /tmp/ into mounted volume
+    print("Starting import, transform, and load of COCO dataset")
+    list(_do_part.map([
+        "http://images.cocodataset.org/zips/train2017.zip",
+        "http://images.cocodataset.org/zips/val2017.zip",
+        "http://images.cocodataset.org/zips/test2017.zip",
+        "http://images.cocodataset.org/zips/unlabeled2017.zip",
+        "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
+        "http://images.cocodataset.org/annotations/stuff_annotations_trainval2017.zip",
+        "http://images.cocodataset.org/annotations/image_info_test2017.zip",
+        "http://images.cocodataset.org/annotations/image_info_unlabeled2017.zip",
+    ]))
     print("✅ Done")

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -143,7 +143,6 @@ def _do_part(url: str) -> None:
     timeout=60 * 60 * 24,
 )
 def import_transform_load() -> None:
-    start_monitoring_disk_space()
     # NOTE:
     # The mmseq.com server upload speed is quite slow so this download takes a while.
     # The download speed is also quite variable, sometimes taking over 5 hours.

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -101,6 +101,39 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
             src, dest, copy_function=copier.copy, dirs_exist_ok=True
         )
 
+@app.function(
+    volumes={"/mnt/": volume},
+    timeout=60 * 60 * 24,
+    ephemeral_disk=2560 * 1024,
+)
+def _do_part(url: str) -> None:
+    name = url.split("/")[-1].replace(".tar.gz", "")
+    print(f"Downloading {name}")
+    compressed = pathlib.Path("/tmp", name)
+    cmd = f"wget {url} -O {compressed}"
+    p = subprocess.Popen(cmd, shell=True)
+    returncode = p.wait()
+    if returncode != 0:
+        raise RuntimeError(
+            f"Error in downloading. {p.args!r} failed {returncode=}"
+        )
+    decompressed = pathlib.Path("/tmp/rosettafold/", name)
+
+    # Decompression is much faster against the container's local SSD disk
+    # compared with against the mounted volume. So we first compress into /tmp/.
+    print(f"Decompressing {compressed} into {decompressed}.")
+    decompress_tar_gz(compressed, decompressed)
+    print(
+        f"✅ Decompressed {compressed} into {decompressed}. Now deleting it to free up disk.."
+    )
+    compressed.unlink()  # delete compressed file to free up disk
+
+    # Finally, we move the decompressed data from /tmp/ into the mounted volume.
+    # There are a large mount of files to copy so this step takes a while.
+    dest = pathlib.Path("/mnt/rosettafold/")
+    copy_concurrent(decompressed, dest)
+    shutil.rmtree(decompressed, ignore_errors=True)  # free up disk
+    print(f"Dataset part {url} is loaded ✅")
 
 @app.function(
     volumes={"/mnt/": volume},
@@ -108,79 +141,15 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
     # because downloading, decompressing and storing almost 2 TiB of
     # files takes a long time.
     timeout=60 * 60 * 24,
-    ephemeral_disk=2560 * 1024,
 )
 def import_transform_load() -> None:
     start_monitoring_disk_space()
-    uniref30 = pathlib.Path("/tmp/UniRef30_2020_06_hhsuite.tar.gz")
-    bfd_dataset = pathlib.Path(
-        "/tmp/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz"
-    )
-    structure_templates = pathlib.Path("/tmp/pdb100_2021Mar03.tar.gz")
-    commands = []
-    print("Downloading uniref30 [46G]")
-    commands.append(
-        f"wget http://wwwuser.gwdg.de/~compbiol/uniclust/2020_06/UniRef30_2020_06_hhsuite.tar.gz -O {uniref30}"
-    )
-    print("Downloading BFD [272G]")
     # NOTE:
     # The mmseq.com server upload speed is quite slow so this download takes a while.
     # The download speed is also quite variable, sometimes taking over 5 hours.
-    commands.append(
-        f"wget https://bfd.mmseqs.com/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz -O {bfd_dataset}"
-    )
-    print(
-        "Downloading structure templates (including *_a3m.ffdata, *_a3m.ffindex)"
-    )
-    commands.append(
-        f"wget https://files.ipd.uw.edu/pub/RoseTTAFold/pdb100_2021Mar03.tar.gz -O {structure_templates}"
-    )
-
-    # Start all downloads in parallel and wait for all of them to complete.
-    processes = [subprocess.Popen(cmd, shell=True) for cmd in commands]
-    errors = []
-    for p in processes:
-        returncode = p.wait()
-        if returncode != 0:
-            errors.append(
-                f"Error in downloading. {p.args!r} failed {returncode=}"
-            )
-    if errors:
-        raise RuntimeError(errors)
-
-    # Decompression is much faster against the container's local SSD disk
-    # compared with against the mounted volume. So we first compress into /tmp/.
-    uniref30_decompressed = pathlib.Path(
-        "/tmp/rosettafold/UniRef30_2020_06_hhsuite"
-    )
-    bfd_dataset_decompressed = pathlib.Path(
-        "/tmp/rosettafold/bfd_metaclust_clu_complete_id30_c90_final_seq"
-    )
-    structure_templates_decompressed = pathlib.Path(
-        "/tmp/rosettafold/pdb100_2021Mar03/"
-    )
-    decompression_jobs = {
-        (uniref30, uniref30_decompressed),
-        (bfd_dataset, bfd_dataset_decompressed),
-        (structure_templates, structure_templates_decompressed),
-    }
-    for file_path, extract_dir in decompression_jobs:
-        print(f"Decompressing {file_path} into {extract_dir}.")
-        decompress_tar_gz(file_path, extract_dir)
-        print(
-            f"✅ Decompressed {file_path} into {extract_dir}. Now deleting it to free up disk.."
-        )
-        file_path.unlink()  # delete compressed file to free up disk
-
-    print("All decompression tasks completed.")
-
-    # Finally, we move the decompressed data from /tmp/ into the mounted volume.
-    # There are a large mount of files to copy so this step takes a while.
-
-    dest = pathlib.Path("/mnt/rosettafold/")
-    copy_concurrent(uniref30_decompressed, dest)
-    shutil.rmtree(uniref30_decompressed, ignore_errors=True)  # free up disk
-    copy_concurrent(bfd_dataset_decompressed, dest)
-    shutil.rmtree(bfd_dataset_decompressed, ignore_errors=True)  # free up disk
-    copy_concurrent(structure_templates_decompressed, dest)
+    list(_do_part.map([
+        "http://wwwuser.gwdg.de/~compbiol/uniclust/2020_06/UniRef30_2020_06_hhsuite.tar.gz",
+        "https://bfd.mmseqs.com/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz",
+        "https://files.ipd.uw.edu/pub/RoseTTAFold/pdb100_2021Mar03.tar.gz",
+    ]))
     print("Dataset is loaded ✅")

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -101,6 +101,7 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
             src, dest, copy_function=copier.copy, dirs_exist_ok=True
         )
 
+
 @app.function(
     volumes={"/mnt/": volume},
     timeout=60 * 60 * 24,
@@ -135,6 +136,7 @@ def _do_part(url: str) -> None:
     shutil.rmtree(decompressed, ignore_errors=True)  # free up disk
     print(f"Dataset part {url} is loaded ✅")
 
+
 @app.function(
     volumes={"/mnt/": volume},
     # Timeout for this Function is set at the maximum, 24 hours,
@@ -146,9 +148,13 @@ def import_transform_load() -> None:
     # NOTE:
     # The mmseq.com server upload speed is quite slow so this download takes a while.
     # The download speed is also quite variable, sometimes taking over 5 hours.
-    list(_do_part.map([
-        "http://wwwuser.gwdg.de/~compbiol/uniclust/2020_06/UniRef30_2020_06_hhsuite.tar.gz",
-        "https://bfd.mmseqs.com/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz",
-        "https://files.ipd.uw.edu/pub/RoseTTAFold/pdb100_2021Mar03.tar.gz",
-    ]))
+    list(
+        _do_part.map(
+            [
+                "http://wwwuser.gwdg.de/~compbiol/uniclust/2020_06/UniRef30_2020_06_hhsuite.tar.gz",
+                "https://bfd.mmseqs.com/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz",
+                "https://files.ipd.uw.edu/pub/RoseTTAFold/pdb100_2021Mar03.tar.gz",
+            ]
+        )
+    )
     print("Dataset is loaded ✅")


### PR DESCRIPTION
Dunno why it took me so long to just do this. 

Successful and much faster runs on CoCo and RoseTTAFold with this added parallelization. 

<img width="1374" alt="image" src="https://github.com/modal-labs/modal-examples/assets/12058921/42fedc9d-4347-47f5-8b51-4912a855c6e1">
<img width="1360" alt="image" src="https://github.com/modal-labs/modal-examples/assets/12058921/418e9869-5615-48c9-aa27-ccac522cf212">


### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)