### PR TITLE
Clean up push gateway metrics on exit

### DIFF
--- a/10_integrations/pushgateway.py
+++ b/10_integrations/pushgateway.py
@@ -86,6 +86,7 @@ with client_image.imports():
     from prometheus_client import (
         CollectorRegistry,
         Counter,
+        delete_from_gateway,
         push_to_gateway,
     )
 
@@ -101,6 +102,16 @@ class ExampleClientApplication:
             "hello_counter",
             "This is a counter",
             registry=self.registry,
+        )
+
+    # We must explicitly clean up the metric when the app exits so Prometheus doesn't
+    # keep stale metrics around.
+    @modal.exit()
+    def cleanup(self):
+        delete_from_gateway(
+            self.web_url,
+            job="hello",
+            grouping_key={"instance": self.instance_id},
         )
 
     @web_endpoint()


### PR DESCRIPTION
This commit adds a cleanup step to the pushgateway application. This will make it so stale metrics don't hang around.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

