### PR TITLE
Change pushgateway deployment method to `modal deploy`

### DIFF
--- a/10_integrations/pushgateway.py
+++ b/10_integrations/pushgateway.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "serve", "10_integrations/pushgateway.py"]
+# cmd: ["modal", "deploy", "10_integrations/pushgateway.py"]
 # ---
 # # Publish custom metrics with Prometheus Pushgateway
 #
@@ -131,7 +131,16 @@ app.include(gw_app)
 # Now, we can deploy the `client-example` app and see the metrics in the Pushgateway's web interface.
 
 # ```shell
-# modal serve pushgateway.py
+# $ modal deploy pushgateway.py
+# ✓ Created objects.
+# ├── 🔨 Created mount /Users/example/projects/scratch/pushgateway/pushgateway.py
+# ├── 🔨 Created web function run_pushgateway => https://modal-labs-example--client-example-run-pushgateway.modal.run
+# ├── 🔨 Created function ExampleClientApplication.*.
+# └── 🔨 Created web function ExampleClientApplication.hello =>
+#     https://modal-labs-example--client-example-exampleclientappli-4c6f64.modal.run (label truncated)
+# ✓ App deployed! 🎉
+#
+# View Deployment: https://modal.com/modal-labs/example/apps/deployed/client-example
 # ```
 #
 # Go to both the client application and Pushgateway URLs to see the metrics being pushed.


### PR DESCRIPTION
Modal deploy is better fitted here because these are long-lived services which we want to have a consistent URL.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

