### PR TITLE
Feature/openai cli

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_oai_compatible/api.py
+++ b/06_gpu_and_ml/llm-serving/vllm_oai_compatible/api.py
@@ -196,5 +196,5 @@ def serve():
 #
 # ```bash
 # # pip install openai==1.13.3
-# python client.py
+# python client.py --chat
 # ```

--- a/06_gpu_and_ml/llm-serving/vllm_oai_compatible/client.py
+++ b/06_gpu_and_ml/llm-serving/vllm_oai_compatible/client.py
@@ -40,8 +40,8 @@ def get_completion(client, model_id, messages, args):
 def main():
     parser = argparse.ArgumentParser(description="OpenAI Client CLI")
 
-    parser.add_argument('--model', type=str, default=None, help='The model to use for completion, defaults to the first available model.')
-    parser.add_argument('--api-key', type=str, default="super-secret-token", help='The API key to use for authentication, set in your api.py.')
+    parser.add_argument('--model', type=str, default=None, help='The model to use for completion, defaults to the first available model')
+    parser.add_argument('--api-key', type=str, default="super-secret-token", help='The API key to use for authentication, set in your api.py')
     
     # Completion parameters
     parser.add_argument('--max-tokens', type=int, default=None)
@@ -50,16 +50,16 @@ def main():
     parser.add_argument('--top-k', type=int, default=0)
     parser.add_argument('--frequency-penalty', type=float, default=0)
     parser.add_argument('--presence-penalty', type=float, default=0)
-    parser.add_argument('--n', type=int, default=1)
+    parser.add_argument('--n', type=int, default=1, help='Number of completions to generate. Streaming and chat mode only support n=1.')
     parser.add_argument('--stop', type=str, default=None)
     parser.add_argument('--seed', type=int, default=None)
 
     # Prompting
-    parser.add_argument('--prompt', type=str, default="Compose a limerick about baboons and racoons.", help='The user prompt for the chat completion.')
-    parser.add_argument('--system-prompt', type=str, default="You are a poetic assistant, skilled in writing satirical doggerel with creative flair.", help='The system prompt for the chat completion.')
+    parser.add_argument('--prompt', type=str, default="Compose a limerick about baboons and racoons.", help='The user prompt for the chat completion')
+    parser.add_argument('--system-prompt', type=str, default="You are a poetic assistant, skilled in writing satirical doggerel with creative flair.", help='The system prompt for the chat completion')
     
     # UI options
-    parser.add_argument('--no-stream', dest='stream', action='store_false')
+    parser.add_argument('--no-stream', dest='stream', action='store_false', help='Disable streaming of response chunks')
     parser.add_argument('--chat', action='store_true', help='Enable interactive chat mode')
 
     args = parser.parse_args()
@@ -123,6 +123,7 @@ def main():
             
             if response:
                 if args.stream:
+                    # only stream assuming n=1
                     print(Colors.BLUE + "\n🤖: ", end="")
                     assistant_message = ""
                     for chunk in response:
@@ -148,7 +149,9 @@ def main():
                         print(chunk.choices[0].delta.content, end="")
                 print(Colors.END)
             else:
-                print(Colors.BLUE + "\n🤖:" + response.choices[0].message.content + Colors.END, sep="")
+                # only case where multiple completions are returned
+                for i, response in enumerate(response.choices):
+                    print(Colors.BLUE + f"\n🤖 Choice {i+1}:{response.message.content}" + Colors.END, sep="")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Adds more CLI options to OpenAI client example
- Streaming
- Batching
- Chat mode with message history retained
- Prompt and system prompt in args

Batch generation:
![Screenshot 2024-07-23 at 4 42 16 PM](https://github.com/user-attachments/assets/4e905d48-b47d-4705-9a63-111982bbfeef)

Chat:
![Screenshot 2024-07-23 at 4 43 46 PM](https://github.com/user-attachments/assets/477699d6-bbae-40dc-8576-5e495d1efd6f)

Overriding system prompt (uwu)
![Screenshot 2024-07-23 at 4 46 05 PM](https://github.com/user-attachments/assets/8b9e45b6-f2a8-447f-bdd4-db50a84c4658)

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
