### PR TITLE
add example for running flux

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -1,0 +1,89 @@
+# ---
+# output-directory: "/tmp/flux"
+# ---
+# example originally contributed by [@Arro](https://github.com/Arro)
+from io import BytesIO
+from pathlib import Path
+
+import modal
+
+diffusers_commit_sha = "1fcb811a8e6351be60304b1d4a4a749c36541651"
+
+flux_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install(
+        "git",
+        "libglib2.0-0",
+        "libsm6",
+        "libxrender1",
+        "libxext6",
+        "ffmpeg",
+        "libgl1",
+    )
+    .run_commands(
+        f"pip install git+https://github.com/huggingface/diffusers.git@{diffusers_commit_sha} 'numpy<2'"
+    )
+    .pip_install(
+        "invisible_watermark==0.2.0",
+        "transformers==4.44.0",
+        "accelerate==0.33.0",
+        "safetensors==0.4.4",
+        "sentencepiece==0.2.0",
+    )
+)
+
+app = modal.App("example-flux")
+
+with flux_image.imports():
+    import torch
+    from diffusers import FluxPipeline
+
+
+@app.cls(
+    gpu=modal.gpu.A100(size="40GB"),
+    container_idle_timeout=100,
+    image=flux_image,
+)
+class Model:
+    @modal.build()
+    def build(self):
+        from huggingface_hub import snapshot_download
+
+        snapshot_download("black-forest-labs/FLUX.1-schnell")
+
+    @modal.enter()
+    def enter(self):
+        self.pipe = FluxPipeline.from_pretrained(
+            "black-forest-labs/FLUX.1-schnell", torch_dtype=torch.bfloat16
+        )
+        self.pipe.to("cuda")
+
+    @modal.method()
+    def inference(self, prompt):
+        print("Generating image...")
+        out = self.pipe(
+            prompt,
+            output_type="pil",
+            num_inference_steps=4,  # use a larger number if you are using [dev]
+        ).images[0]
+        print("Generated image.")
+
+        byte_stream = BytesIO()
+        out.save(byte_stream, format="JPEG")
+        return byte_stream.getvalue()
+
+
+@app.local_entrypoint()
+def main(
+    prompt: str = "the word 'Modal' where the shapes of all the letters combine to form an entire system-on-a-chip using clever typography, neon green",
+):
+    image_bytes = Model().inference.remote(prompt)
+
+    dir = Path("/tmp/flux")
+    if not dir.exists():
+        dir.mkdir(exist_ok=True, parents=True)
+
+    output_path = dir / "output.jpg"
+    print(f"Saving it to {output_path}")
+    with open(output_path, "wb") as f:
+        f.write(image_bytes)


### PR DESCRIPTION
thanks @Arro for the initial version!

### Type of Change

- [x] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
