### PR TITLE
Change batch function param name for batched whisper example

### DIFF
--- a/06_gpu_and_ml/openai_whisper/batched_whisper.py
+++ b/06_gpu_and_ml/openai_whisper/batched_whisper.py
@@ -123,14 +123,14 @@ class Model:
 
         start = time.monotonic_ns()
         print(f"Transcribing {len(audio_samples)} audio samples")
-        transcription = self.pipeline(
+        transcriptions = self.pipeline(
             audio_samples, batch_size=len(audio_samples)
         )
         end = time.monotonic_ns()
         print(
             f"Transcribed {len(audio_samples)} samples in {round((end - start) / 1e9, 2)}s"
         )
-        return transcription
+        return transcriptions
 
 
 # ## Transcribe a dataset


### PR DESCRIPTION
Change batched function param name to make batched output clearer

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

