### PR TITLE
adds a very simple fastHTML example

### DIFF
--- a/07_web_endpoints/fasthtml_app.py
+++ b/07_web_endpoints/fasthtml_app.py
@@ -1,0 +1,25 @@
+# ---
+# deploy: true
+# cmd: ["modal", "serve", "07_web_endpoints/fasthtml_app.py"]
+# ---
+import modal
+
+app = modal.App("example-fasthtml")
+
+
+@app.function(
+    image=modal.Image.debian_slim(python_version="3.12").pip_install(
+        "python-fasthtml==0.5.2"
+    )
+)
+@modal.asgi_app()  # must define a function decorated with asgi_app and app.function that returns your fastHTML app
+def serve():
+    import fasthtml.common as fh
+
+    app = fh.FastHTML()
+
+    @app.get("/")
+    def home():
+        return fh.Div(fh.P("Hello World!"), hx_get="/change")
+
+    return app


### PR DESCRIPTION
### Type of Change

- [x] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
