### PR TITLE
turn off preview docs on main

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,9 +1,6 @@
 # deploys a preview version of the frontend including example changes
 name: Preview Docs
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
It fails because there's no issue to comment on.

Could add conditional logic for posting but running the check is not necessary since the action is run on a merge commit already.