### PR TITLE
Patch flux to use flash attention 3

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -175,7 +175,8 @@ class Model:
 # ```
 
 # By default, we call `generate` twice to demonstrate how much faster
-# the inference is after cold start. We save the output bytes to a temporary file.
+# the inference is after cold start. In our tests, clients received images in about 1.5 seconds.
+# We save the output bytes to a temporary file.
 
 
 @app.local_entrypoint()

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -16,7 +16,7 @@
 # is to break the QKV operations into tiny blocks that can be computed quickly
 # in high bandwidth SRAM rather than constantly using low bandwidth VRAM. Read
 # more [here](https://gordicaleksa.medium.com/eli5-flash-attention-5c44017022ad).
-# Note that Flash Attention 3 (FA3) is specifically designed for H100 GPUs.
+# Note that Flash Attention 3 (FA3), which we use here, is specifically designed for H100 GPUs.
 
 # We start off by importing `BytesIO` for return image byte streams,
 # along with `Path` and `modal`.
@@ -27,9 +27,9 @@ from pathlib import Path
 
 import modal
 
-# We'll use the schnell variant of Flux.1 which is faster but less accurate.
-# If you want to use the dev variant, get yourself a Hugging Face  API key,
-# put it in your [Secrets](https://modal.com/docs/guide/secrets) and include
+# We'll use the `schnell` variant of Flux.1 which is the fastest but lowest quality model in the series.
+# If you want to use the dev variant, get yourself a Hugging Face API key,
+# put it in your Modal [Secrets](https://modal.com/docs/guide/secrets) and include
 # it in the `@app.cls()` below.
 
 VARIANT = "schnell"  # or "dev", but note [dev] requires you to accept terms and conditions on HF
@@ -67,7 +67,7 @@ flux_image = (
         "safetensors==0.4.4",
         "sentencepiece==0.2.0",
     )
-    # Since Hugging Face does not support Flash Attention 3 (FA3) yet (Sep 2024),
+    # Since Hugging Face does not support Flash Attention 3 as of writing (Sep 2024),
     # let's build it from source and add it to our `PYTHONPATH`.
     .pip_install(
         "ninja==1.11.1.1",
@@ -96,8 +96,8 @@ with flux_image.imports():
 
 # Now we can define our `Model` class which will
 # 1) Download the model from Hugging Face Hub
-# 2) Optimize the Flux's internal Transformer and VAE models to use FA3
-# 3) Call `torch.compile() `with the `max-autotune` mode to optimize the models
+# 2) Swap in FA3 in Flux's internal Transformer and VAE models
+# 3) Call `torch.compile()` in `max-autotune` mode to optimize the models
 # even further.
 @app.cls(
     gpu="H100",  # Necessary for FA3
@@ -164,7 +164,7 @@ class Model:
         return byte_stream.getvalue()
 
 
-# Finally we write our `main` entrypoint to  utilize the `Model`
+# Finally we write our `main` entrypoint to use the `Model`
 # class to generate an image. We'll use `BytesIO` to receive the image and
 # save it to a JPEG file for easy viewing.
 

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -3,20 +3,51 @@
 # ---
 # # Run Flux.1 (Schnell) on Modal
 #
-# This example runs the popular [Flux.1-schnell](https://huggingface.co/black-forest-labs/FLUX.1-schnell) text-to-image model on Modal.
-#
 # Thanks to [@Arro](https://github.com/Arro) for the original contribution.
+#
+# This example runs the popular [Flux.1-schnell](https://huggingface.co/black-forest-labs/FLUX.1-schnell) text-to-image model on Modal.
+# Flux was created by the folks from [Black Forest Labs](https://blackforestlabs.ai/)
+# who previously created Stable Diffusion.
+#
+# To make this example go [brrrr](https://horace.io/brrr_intro.html) we will use
+# the latest version of [Flash Attention](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file)
+# which significanly reduces the latency of the Query, Key, Value (QKV)
+# operations of Transformer models on GPUs. The key insight of Flash Attention
+# is to break the QKV operations into tiny blocks that can be computed quickly
+# in high bandwidth SRAM rather than constantly using low bandwidth VRAM. Read
+# more [here](https://gordicaleksa.medium.com/eli5-flash-attention-5c44017022ad).
+# Note that Flash Attention 3 (FA3) is specifically designed for H100 GPUs.
+
+# We start off by importing `BytesIO` for return image byte streams,
+# along with `Path` and `modal`.
+
+import time
 from io import BytesIO
 from pathlib import Path
 
 import modal
 
+# We'll use the schnell variant of Flux.1 which is faster but less accurate.
+# If you want to use the dev variant, get yourself a Hugging Face  API key,
+# put it in your [Secrets](https://modal.com/docs/guide/secrets) and include
+# it in the `@app.cls()` below.
+
 VARIANT = "schnell"  # or "dev", but note [dev] requires you to accept terms and conditions on HF
 
-diffusers_commit_sha = "1fcb811a8e6351be60304b1d4a4a749c36541651"
+
+# Build the image with the required dependencies. We use an image with the
+# the full CUDA toolkit to ensure we can compile the latest Flash Attention
+
+# diffusers_commit_sha = "1fcb811a8e6351be60304b1d4a4a749c36541651"
+diffusers_commit_sha = "81cf3b2f155f1de322079af28f625349ee21ec6b"
+
+cuda_version = "12.4.0"  # should be no greater than host CUDA version
+flavor = "devel"  #  includes full CUDA toolkit
+operating_sys = "ubuntu22.04"
+tag = f"{cuda_version}-{flavor}-{operating_sys}"
 
 flux_image = (
-    modal.Image.debian_slim(python_version="3.12")
+    modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.11")
     .apt_install(
         "git",
         "libglib2.0-0",
@@ -36,7 +67,24 @@ flux_image = (
         "safetensors==0.4.4",
         "sentencepiece==0.2.0",
     )
+    # Since Hugging Face does not support Flash Attention 3 (FA3) yet (Sep 2024),
+    # let's build it from source and add it to our `PYTHONPATH`.
+    .pip_install(
+        "ninja",
+        "packaging",
+        "wheel",
+        "torch==2.4.1",
+    )
+    .run_commands(
+        "ln -s /usr/bin/g++ /usr/bin/clang++",  # Use clang
+        "git clone https://github.com/Dao-AILab/flash-attention.git",
+        "cd flash-attention/hopper && python setup.py install",
+    )
+    .env({"PYTHONPATH": "/root/flash-attention/hopper"})
 )
+
+# Next we construct our [App](https://modal.com/docs/reference/modal.App)
+# and import `torch` & the `FluxPipeline` from Hugging Face's `diffusers` library.
 
 app = modal.App("example-flux")
 
@@ -45,25 +93,60 @@ with flux_image.imports():
     from diffusers import FluxPipeline
 
 
+# Now we can define our `Model` class which will
+# 1) Download the model from Hugging Face Hub
+# 2) Optimize the Flux's internal Transformer and VAE models to use FA3
+# 3) Call `torch.compile() `with the `max-autotune` mode to optimize the models
+# even further.
 @app.cls(
-    gpu=modal.gpu.A100(size="40GB"),
-    container_idle_timeout=100,
+    gpu="H100",  # Necessary for FA3
+    container_idle_timeout=60 * 3,
     image=flux_image,
+    timeout=60 * 10,  # 5m -> 10m to leave room for compile time.
 )
 class Model:
-    @modal.build()
-    @modal.enter()
-    def enter(self):
+    def _download_model(self):
         from huggingface_hub import snapshot_download
-        from transformers.utils import move_cache
 
         snapshot_download(f"black-forest-labs/FLUX.1-{VARIANT}")
 
+    @modal.build()
+    def build(self):
+        self._download_model()
+
+    @modal.enter()
+    def enter(self):
+        from transformers.utils import move_cache
+
+        self._download_model()
         self.pipe = FluxPipeline.from_pretrained(
             f"black-forest-labs/FLUX.1-{VARIANT}", torch_dtype=torch.bfloat16
         )
+
         self.pipe.to("cuda")
+        self.pipe.transformer.fuse_qkv_projections()
+        self.pipe.vae.fuse_qkv_projections()
+        self.pipe.transformer.to(memory_format=torch.channels_last)
+        self.pipe.transformer = torch.compile(
+            self.pipe.transformer, mode="max-autotune", fullgraph=True
+        )
+        self.pipe.vae.to(memory_format=torch.channels_last)
+        self.pipe.vae.decode = torch.compile(
+            self.pipe.vae.decode, mode="max-autotune", fullgraph=True
+        )
+
         move_cache()
+
+        # Runs for 1-2minutes
+        print("Calling pipe() to trigger torch compiliation...")
+
+        self.pipe(
+            "Test prompt to trigger torch compilation.",
+            output_type="pil",
+            num_inference_steps=4,  # use ~50 for [dev], smaller for [schnell]
+        ).images[0]
+
+        print("Finished compilation.")
 
     @modal.method()
     def inference(self, prompt):
@@ -71,7 +154,7 @@ class Model:
         out = self.pipe(
             prompt,
             output_type="pil",
-            num_inference_steps=4,  # use a larger number if you are using [dev], smaller for [schnell]
+            num_inference_steps=4,  # use ~50 for [dev], smaller for [schnell]
         ).images[0]
         print("Generated.")
 
@@ -80,11 +163,29 @@ class Model:
         return byte_stream.getvalue()
 
 
+# Finally we write our `main` entrypoint to  utilize the `Model`
+# class to generate an image. We'll use `BytesIO` to receive the image and
+# save it to a JPEG file for easy viewing.
+
+# By default, we hit generate an image twice to demonstrate how much faster
+# the inference is once the server is running.
+
+
 @app.local_entrypoint()
 def main(
-    prompt: str = "a computer screen showing ASCII terminal art of the word 'Modal' in neon green. two programmers are pointing excitedly at the screen.",
+    prompt: str = "a computer screen showing ASCII terminal art of the"
+    " word 'Modal' in neon green. two programmers are pointing excitedly"
+    " at the screen.",
+    twice=True,
 ):
+    t0 = time.time()
     image_bytes = Model().inference.remote(prompt)
+    print(f"1st latency: {time.time() - t0:.2f} seconds")
+
+    if twice:
+        t0 = time.time()
+        image_bytes = Model().inference.remote(prompt)
+        print(f"2nd latency: {time.time() - t0:.2f} seconds")
 
     dir = Path("/tmp/flux")
     if not dir.exists():

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -12,11 +12,11 @@
 # ## Overview
 # In this guide we'll show you how to compile Flux to run at bleeding edge speeds,
 # create a Modal class for downloading and serving the model, and generate
-# unlimited images with a Modal entrypoint.
+# unlimited images via `remote` calls in a Modal entrypoint.
 
 # ### Flux Variants
 # We'll use the `schnell` variant of Flux.1 which is the fastest but lowest quality model in the series.
-# If you want to use the `dev` variant, get yourself a Hugging Face API key,
+# If you want to use the `dev` variant: get yourself a Hugging Face API key,
 # put it in your Modal [Secrets](https://modal.com/docs/guide/secrets) and include
 # it in the `@app.cls()` below.
 
@@ -24,8 +24,8 @@
 # To run Flux.1 at bleeding edge speeds we will use [Flash Attention (FA3)](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file)
 # which makes the attention blocks in Transformers go
 # [brrrr](https://horace.io/brrr_intro.html) on GPUs. FA3 does this by
-# breaking the Query, Key, Value (QKV) operations into tiny block that can be
-# computed quickly in high bandwidth SRAM rather than constantly using low
+# breaking the Query, Key, and Value (QKV) operations into tiny block that can be
+# computed quickly in high bandwidth SRAM rather than overusing low
 # bandwidth VRAM. Read more [here](https://gordicaleksa.medium.com/eli5-flash-attention-5c44017022ad).
 
 # ### Quick note
@@ -33,7 +33,7 @@
 # this example.
 #
 # ## Setting up the image and dependencies
-# To setup we'll need to import `BytesIO` for returning image bytes,
+# To set up we'll need to import `BytesIO` for returning image bytes,
 # use a specific CUDA image to ensure we can compile FA3, build and install FA3,
 # and import the Hugging Face `diffusers` library to download and run Flux via
 # the `FluxPipeline` class.
@@ -110,7 +110,7 @@ with flux_image.imports():
 # 3. Call `torch.compile()` in `max-autotune` mode to optimize the models
 
 # Once we do that we define the `generate` method which generates images via
-# Flux given a text prompt. At Modal's H100 pricing, generating an image every
+# Flux given a text `prompt`. At Modal's `H100` pricing, generating an image every
 # second works out to less than 1 cent per image!
 
 
@@ -220,4 +220,5 @@ def main(
         f.write(image_bytes)
 
 
-# That's it! We can now run our `main` function to generate an image.
+# That's it! The first time you run it will take a several minutes but the
+# second latency will be around ~1 second.


### PR DESCRIPTION
Improve Flux example to use Flash Attention 3.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
