### PR TITLE
Add ColQwen2 example

### DIFF
--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 
 MINUTES = 60  # seconds
 
+
 def download_model(model_dir, model_name):
     from huggingface_hub import snapshot_download
     from transformers.utils import move_cache
@@ -12,26 +13,36 @@ def download_model(model_dir, model_name):
     os.makedirs(model_dir, exist_ok=True)
     snapshot_download(
         model_name,
-        local_dir= model_dir,
+        local_dir=model_dir,
         ignore_patterns=["*.pt", "*.bin"],  # using safetensors
     )
     move_cache()
 
+
 model_image = (
     modal.Image.debian_slim(python_version="3.12")
     .apt_install("git")
-    .pip_install([
-        "git+https://github.com/illuin-tech/colpali", 
-        "hf_transfer", 
-        "qwen-vl-utils",
-        "torchvision"
-    ])
+    .pip_install(
+        [
+            "git+https://github.com/illuin-tech/colpali",
+            "hf_transfer",
+            "qwen-vl-utils",
+            "torchvision",
+        ]
+    )
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
     .run_function(
         download_model,
-        secrets=[modal.Secret.from_name("huggingface-secret", required_keys=["HF_TOKEN"])],
+        secrets=[
+            modal.Secret.from_name(
+                "huggingface-secret", required_keys=["HF_TOKEN"]
+            )
+        ],
         timeout=MINUTES * 20,
-        kwargs={"model_dir": "/model-qwen2-VL-2B-Instruct", "model_name": "Qwen/Qwen2-VL-2B-Instruct"},
+        kwargs={
+            "model_dir": "/model-qwen2-VL-2B-Instruct",
+            "model_name": "Qwen/Qwen2-VL-2B-Instruct",
+        },
     )
 )
 
@@ -61,20 +72,27 @@ class Model:
             torch_dtype=torch.bfloat16,
             device_map="cuda:0",  # or "mps" if on Apple Silicon
         )
-        self.colqwen2_processor = ColQwen2Processor.from_pretrained("vidore/colqwen2-v0.1")
-        self.qwen2_vl_model = Qwen2VLForConditionalGeneration.from_pretrained("Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True)
+        self.colqwen2_processor = ColQwen2Processor.from_pretrained(
+            "vidore/colqwen2-v0.1"
+        )
+        self.qwen2_vl_model = Qwen2VLForConditionalGeneration.from_pretrained(
+            "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
+        )
         self.qwen2_vl_model.to("cuda:0")
-        self.qwen2_vl_processor = AutoProcessor.from_pretrained("Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True)
-        
+        self.qwen2_vl_processor = AutoProcessor.from_pretrained(
+            "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
+        )
+
         self.pdf_embeddings = None
         self.images = None
         self.messages = []
 
-
     @modal.method()
     def index_pdf(self, images):
         self.images = images
-        batch_images = self.colqwen2_processor.process_images(images).to(self.colqwen2_model.device)
+        batch_images = self.colqwen2_processor.process_images(images).to(
+            self.colqwen2_model.device
+        )
         self.pdf_embeddings = self.colqwen2_model(**batch_images)
 
     @modal.method()
@@ -84,41 +102,40 @@ class Model:
         elif self.pdf_embeddings is None:
             return "Indexing PDF..."
 
-
         def get_relevant_image(message):
-            batch_queries = self.colqwen2_processor.process_queries([message]).to(self.colqwen2_model.device)
+            batch_queries = self.colqwen2_processor.process_queries(
+                [message]
+            ).to(self.colqwen2_model.device)
             query_embeddings = self.colqwen2_model(**batch_queries)
-            scores = self.colqwen2_processor.score_multi_vector(query_embeddings, self.pdf_embeddings)[0]
+            scores = self.colqwen2_processor.score_multi_vector(
+                query_embeddings, self.pdf_embeddings
+            )[0]
             max_index = max(range(len(scores)), key=lambda index: scores[index])
             return self.images[max_index]
-        
+
         def get_chatbot_message_with_image(message, image):
             return {
-                "role": "user", 
-                "content": [{
-                    "type": "image",
-                    "image": image
-                }, {
-                    "type": "text",
-                    "text": message
-                }]
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": message},
+                ],
             }
-    
+
         def append_to_messages(message, user_type="user"):
             self.messages.append(
                 {
-                    "role": user_type, 
-                    "content": {
-                        "type": "text",
-                        "text": message
-                    }
+                    "role": user_type,
+                    "content": {"type": "text", "text": message},
                 }
             )
 
         def generate_response(message, image):
             chatbot_message = get_chatbot_message_with_image(message, image)
             query = self.qwen2_vl_processor.apply_chat_template(
-                [chatbot_message, *self.messages], tokenize=False, add_generation_prompt=True
+                [chatbot_message, *self.messages],
+                tokenize=False,
+                add_generation_prompt=True,
             )
             image_inputs, _ = process_vision_info([chatbot_message])
             inputs = self.qwen2_vl_processor(
@@ -129,28 +146,42 @@ class Model:
             )
             inputs = inputs.to("cuda:0")
 
-            generated_ids = self.qwen2_vl_model.generate(**inputs, max_new_tokens=128)
+            generated_ids = self.qwen2_vl_model.generate(
+                **inputs, max_new_tokens=128
+            )
             generated_ids_trimmed = [
-                out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+                out_ids[len(in_ids) :]
+                for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
             ]
             output_text = self.qwen_processor.batch_decode(
-                generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+                generated_ids_trimmed,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=False,
             )[0]
             return output_text
-        
+
         relevant_image = get_relevant_image(message)
         output_text = generate_response(message, relevant_image)
         append_to_messages(message, user_type="user")
         append_to_messages(output_text, user_type="assistant")
         return output_text
 
+
 web_app = FastAPI()
 
-web_image = modal.Image.debian_slim().apt_install("poppler-utils").pip_install(
-    "gradio", "pillow", "gradio-pdf", "pdf2image"
+web_image = (
+    modal.Image.debian_slim()
+    .apt_install("poppler-utils")
+    .pip_install("gradio", "pillow", "gradio-pdf", "pdf2image")
 )
 
-@app.function(image=web_image, keep_warm=1, concurrency_limit=1, allow_concurrent_inputs=1000)
+
+@app.function(
+    image=web_image,
+    keep_warm=1,
+    concurrency_limit=1,
+    allow_concurrent_inputs=1000,
+)
 @modal.asgi_app()
 def ui():
     from gradio.routes import mount_gradio_app
@@ -167,7 +198,6 @@ def ui():
         images = convert_from_path(path)
         model.index_pdf.remote(images)
 
-
     with gr.Blocks(theme="soft") as demo:
         gr.Markdown("# Chat with PDF")
         with gr.Row():
@@ -181,5 +211,5 @@ def ui():
             with gr.Column(scale=1):
                 pdf = PDF(label="Upload a PDF")
                 pdf.upload(upload_pdf, pdf)
-    
+
     return mount_gradio_app(app=web_app, blocks=demo, path="/")

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -21,16 +21,15 @@
 import os
 
 import modal
-from fastapi import FastAPI
 
 MINUTES = 60  # seconds
 
 # ## Downloading the Model
 
-# VLMs for embedding and generation add another layer of simplification to RAG apps based on vector search:
-# we only need one model. Here, we use the Qwen2-VL-2B-Instruct model from Alibaba.
+# Vision-language models (VLMs) for embedding and generation add another layer of simplification 
+# to RAG apps based on vector search: we only need one model.
+# Here, we use the Qwen2-VL-2B-Instruct model from Alibaba.
 # The function below downloads the model from the Hugging Face Hub.
-
 
 def download_model(model_dir, model_name, model_revision):
     from huggingface_hub import snapshot_download
@@ -44,7 +43,6 @@ def download_model(model_dir, model_name, model_revision):
         ignore_patterns=["*.pt", "*.bin"],  # using safetensors
     )
     move_cache()
-
 
 # ## Building the image
 
@@ -74,8 +72,8 @@ with model_image.imports():
     from qwen_vl_utils import process_vision_info
     from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
 
-# We can also include other files our application needs in the container image.
-# Here, that's the model weights, which we download by executing our `download_model` function.
+# We can also include other files that our application needs in the container image.
+# Here, we we add the model weights to the image by executing our `download_model` function.
 
 model_image = model_image.run_function(
     download_model,
@@ -89,15 +87,13 @@ model_image = model_image.run_function(
 
 ## Defining a Chat with PDF application
 
-# Running an inference service on Modal is as easy as writing inference in Python.
-
-# We just need to wrap that in a Modal App
+# Running an inference service on Modal is as easy as writing an inference function in Python.
+# We just need to wrap that in a Modal App:
 
 app = modal.App("chat-with-pdf")
 
 # To allow concurrent users, each user chat session state is stored in a modal.Dict
 sessions = modal.Dict.from_name("colqwen-chat-sessions", create_if_missing=True)
-
 
 class Session:
     def __init__(self):
@@ -107,13 +103,14 @@ class Session:
 
 
 # Here we define our on-GPU ColQwen2 service, which runs document indexing and inference
+# It uses the [Modal @app.cls](https://modal.com/docs/guide/lifecycle-functions) feature to load the model on container start, and inference on request.
 @app.cls(
     image=model_image,
     gpu=modal.gpu.A100(size="80GB"),
     container_idle_timeout=10 * MINUTES,  # spin down when inactive
 )
 class Model:
-    @modal.build()
+    @modal.build() 
     @modal.enter()
     def load_models(self):
         self.colqwen2_model = ColQwen2.from_pretrained(
@@ -134,18 +131,28 @@ class Model:
 
     @modal.method()
     def index_pdf(self, session_id, images):
-        if session_id not in sessions:
-            sessions[session_id] = Session()
 
-        session = sessions[session_id]
+        # We store concurrent user chat sessions in a modal.Dict
+
+        # For simplicity, we assume that each session only runs one request at a time
+        # This assumption lets us fetch the session, and write to it later, without fear of race conditions
+
+        session = sessions.get(session_id)
+        if session is None:
+            session = Session()
+
         session.images = images
 
+        # Generated embeddings from the image(s)
         batch_images = self.colqwen2_processor.process_images(images).to(
             self.colqwen2_model.device
         )
         pdf_embeddings = self.colqwen2_model(**batch_images)
+
+        # Store the image embeddings in the session, for later RAG use
         session.pdf_embeddings = pdf_embeddings
-        # Update session state
+
+        # Write session state, including embeddings, back to the modal.Dict
         sessions[session_id] = session
 
     @modal.method()
@@ -154,25 +161,29 @@ class Model:
             sessions[session_id] = Session()
         session = sessions[session_id]
 
-        # nothing to chat about without a PDF!
+        # Nothing to chat about without a PDF!
         if session.images is None:
             return "Please upload a PDF first"
         elif session.pdf_embeddings is None:
             return "Indexing PDF..."
 
-        # retrieve the most relevant image from the PDF for the input query
+        # Retrieve the most relevant image from the PDF for the input query
         def get_relevant_image(message):
             batch_queries = self.colqwen2_processor.process_queries(
                 [message]
             ).to(self.colqwen2_model.device)
             query_embeddings = self.colqwen2_model(**batch_queries)
+
+            # This scores our query embedding against the image embeddings from index_pdf
             scores = self.colqwen2_processor.score_multi_vector(
                 query_embeddings, session.pdf_embeddings
             )[0]
+
+            # Return the best matching image
             max_index = max(range(len(scores)), key=lambda index: scores[index])
             return session.images[max_index]
 
-        # helper function to put message in the format chatbot
+        # Helper functions for chatbot formatting
         def get_chatbot_message_with_image(message, image):
             return {
                 "role": "user",
@@ -182,7 +193,6 @@ class Model:
                 ],
             }
 
-        # helper function add messages to the conversation history in chatbot format
         def append_to_messages(message, user_type="user"):
             session.messages.append(
                 {
@@ -191,7 +201,7 @@ class Model:
                 }
             )
 
-        # pass the query and retrieved image along with conversation history into the VLM for a response
+        # Pass the query and retrieved image along with conversation history into the VLM for a response
         def generate_response(message, image):
             chatbot_message = get_chatbot_message_with_image(message, image)
             query = self.qwen2_vl_processor.apply_chat_template(
@@ -222,12 +232,17 @@ class Model:
             )[0]
             return output_text
 
+        # RAG, Retrieval-Augmented Generation, is two steps:
+
+        # Retrieval of the most relevant image to answer the user's query
         relevant_image = get_relevant_image(message)
+
+        # Generation, passing in the query and the retrieved image
         output_text = generate_response(message, relevant_image)
+
+        # Update session state for future chats
         append_to_messages(message, user_type="user")
         append_to_messages(output_text, user_type="assistant")
-
-        # Update session state
         sessions[session_id] = session
 
         return output_text
@@ -238,16 +253,15 @@ class Model:
 # With the Gradio library, we can create a simple web interface around our class in Python,
 # then use Modal to host it for anyone to try out.
 
-# To deploy up your own, run
+# To deploy your own, run
 
 # ```bash
 # modal deploy chat_with_pdf_vision.py
 # ```
 
 # and navigate to the URL that appears in your teriminal.
-# If you’re editing the code, use `modal serve` instead to see changes live.
+# If you’re editing the code, use `modal serve` instead to see changes hot-reload.
 
-web_app = FastAPI()
 
 web_image = (
     modal.Image.debian_slim(python_version="3.12")
@@ -259,8 +273,6 @@ web_image = (
         "pdf2image==1.17.0",
     )
 )
-
-
 @app.function(
     image=web_image,
     keep_warm=1,
@@ -273,24 +285,32 @@ web_image = (
 @modal.asgi_app()
 def ui():
     import uuid
+
     import gradio as gr
+    from fastapi import FastAPI
     from gradio.routes import mount_gradio_app
     from gradio_pdf import PDF
     from pdf2image import convert_from_path
 
+    web_app = FastAPI()
+
+    # Since this Gradio app is running from its own container,
+    # allowing us to run the inference service via .remote() methods.
     model = Model()
 
     def upload_pdf(path, session_id):
-        if session_id == "":
+        if session_id == "" or session_id is None:
             # Generate session id if new client
             session_id = str(uuid.uuid4())
 
         images = convert_from_path(path)
+        # Call to our remote inference service to index the PDF
         model.index_pdf.remote(session_id, images)
 
         return session_id
 
     def respond_to_message(message, _, session_id):
+        # Call to our remote inference service to run RAG
         return model.respond_to_message.remote(session_id, message)
 
     with gr.Blocks(theme="soft") as demo:

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -1,6 +1,6 @@
-import modal
 import os
 
+import modal
 from fastapi import FastAPI
 
 MINUTES = 60  # seconds
@@ -51,10 +51,9 @@ app = modal.App("chat-with-pdf")
 
 with model_image.imports():
     import torch
-    from PIL import Image
     from colpali_engine.models import ColQwen2, ColQwen2Processor
-    from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
     from qwen_vl_utils import process_vision_info
+    from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
 
 
 @app.cls(
@@ -184,8 +183,8 @@ web_image = (
 )
 @modal.asgi_app()
 def ui():
-    from gradio.routes import mount_gradio_app
     import gradio as gr
+    from gradio.routes import mount_gradio_app
     from gradio_pdf import PDF
     from pdf2image import convert_from_path
 

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -279,7 +279,6 @@ web_image = (
 
 @app.function(
     image=web_image,
-    keep_warm=1,
     # gradio requires sticky sessions
     # so we limit the number of concurrent containers to 1
     # and allow it to scale to 100 concurrent inputs

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -9,7 +9,7 @@
 # Chat with PDF RAG app. The ColQwen2 model is based on [ColPali](https://huggingface.co/blog/manu/colpali) and the
 # [Qwen2-VL-2B-Instruct](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct) visual language model.
 #
-## Setup
+# ## Setup
 # First, we’ll import the libraries we need locally and define some constants.
 
 import os
@@ -76,7 +76,7 @@ model_image = (
 # Running an inference service on Modal is as easy as writing inference in Python.
 # The code below adds a modal Cls to an App that embeds the input PDFs and runs the VLM.
 
-# First we define a modal [App] (https://modal.com/docs/guide/apps#apps-stubs-and-entrypoints)
+# First we define a modal [App](https://modal.com/docs/guide/apps#apps-stubs-and-entrypoints)
 app = modal.App("chat-with-pdf")
 
 # We then import some packages we will need in the container
@@ -93,10 +93,11 @@ with model_image.imports():
         size="80GB"
     ),  # gpu config: we have two model instances so we use 80gb
     container_idle_timeout=10
-    * MINUTES,  # how much time the container should stay up for after it's done with it's request
+    * MINUTES,  # how much time the container should stay up for after it's done
 )
 class Model:
-    # We stack the build and enter decorators here to ensure that the weights downloaded in from_pretrained are cached in the image
+    # We stack the build and enter decorators here to ensure that the weights 
+    # downloaded in from_pretrained are cached in the image
     @modal.build()
     @modal.enter()
     def load_models(self):
@@ -168,7 +169,8 @@ class Model:
                 }
             )
 
-        # Pass the query and retrieved image along with conversation history into the VLM for a response
+        # Pass the query and retrieved image along with conversation 
+        # history into the VLM for a response
         def generate_response(message, image):
             chatbot_message = get_chatbot_message_with_image(message, image)
             query = self.qwen2_vl_processor.apply_chat_template(
@@ -206,7 +208,7 @@ class Model:
         return output_text
 
 
-## A hosted Gradio interface
+# ## A hosted Gradio interface
 # With the Gradio library by Hugging Face, we can create a simple web interface around our class, and use Modal to host it
 # for anyone to try out. To set up your own, run modal deploy chat_with_pdf_vision.py and navigate to the URL it prints out.
 # If you’re playing with the code, use modal serve instead to see changes live.
@@ -265,3 +267,5 @@ def ui():
                 pdf.upload(upload_pdf, pdf)
 
     return mount_gradio_app(app=web_app, blocks=demo, path="/")
+
+# And that's it!

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -1,6 +1,6 @@
 # ---
 # deploy: true
-# cmd: ["modal", "serve", "10_integrations/pushgateway.py"]
+# cmd: ["modal", "serve", "06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py"]
 # ---
 #
 # # Chat with PDF: RAG with ColQwen2

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -110,7 +110,6 @@ class Model:
 
         def generate_response(message, image):
             chatbot_message = get_chatbot_message_with_image(message, image)
-            print(chatbot_message, self.messages)
             query = self.qwen_processor.apply_chat_template(
                 [chatbot_message, *self.messages], tokenize=False, add_generation_prompt=True
             )
@@ -144,7 +143,6 @@ class Model:
         output_text = generate_response(message, relevant_image)
         append_to_messages(message, user_type="user")
         append_to_messages(output_text, user_type="assistant")
-        print("Response", type(output_text), output_text)
         return output_text
 
 web_app = FastAPI()

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -26,10 +26,11 @@ MINUTES = 60  # seconds
 
 # ## Downloading the Model
 
-# Vision-language models (VLMs) for embedding and generation add another layer of simplification 
+# Vision-language models (VLMs) for embedding and generation add another layer of simplification
 # to RAG apps based on vector search: we only need one model.
 # Here, we use the Qwen2-VL-2B-Instruct model from Alibaba.
 # The function below downloads the model from the Hugging Face Hub.
+
 
 def download_model(model_dir, model_name, model_revision):
     from huggingface_hub import snapshot_download
@@ -43,6 +44,7 @@ def download_model(model_dir, model_name, model_revision):
         ignore_patterns=["*.pt", "*.bin"],  # using safetensors
     )
     move_cache()
+
 
 # ## Building the image
 
@@ -95,6 +97,7 @@ app = modal.App("chat-with-pdf")
 # To allow concurrent users, each user chat session state is stored in a modal.Dict
 sessions = modal.Dict.from_name("colqwen-chat-sessions", create_if_missing=True)
 
+
 class Session:
     def __init__(self):
         self.images = None
@@ -110,7 +113,7 @@ class Session:
     container_idle_timeout=10 * MINUTES,  # spin down when inactive
 )
 class Model:
-    @modal.build() 
+    @modal.build()
     @modal.enter()
     def load_models(self):
         self.colqwen2_model = ColQwen2.from_pretrained(
@@ -131,7 +134,6 @@ class Model:
 
     @modal.method()
     def index_pdf(self, session_id, images):
-
         # We store concurrent user chat sessions in a modal.Dict
 
         # For simplicity, we assume that each session only runs one request at a time
@@ -273,6 +275,8 @@ web_image = (
         "pdf2image==1.17.0",
     )
 )
+
+
 @app.function(
     image=web_image,
     keep_warm=1,

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -159,9 +159,9 @@ class Model:
 
     @modal.method()
     def respond_to_message(self, session_id, message):
-        if session_id not in sessions:
-            sessions[session_id] = Session()
-        session = sessions[session_id]
+        session = sessions.get(session_id)
+        if session is None:
+            session = Session()
 
         # Nothing to chat about without a PDF!
         if session.images is None:

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -97,11 +97,14 @@ app = modal.App("chat-with-pdf")
 
 # To allow concurrent users, each user chat session state is stored in a modal.Dict
 sessions = modal.Dict.from_name("colqwen-chat-sessions", create_if_missing=True)
+
+
 class Session:
     def __init__(self):
         self.images = None
         self.messages = []
         self.pdf_embeddings = None
+
 
 # Here we define our on-GPU ColQwen2 service, which runs document indexing and inference
 @app.cls(
@@ -133,7 +136,6 @@ class Model:
     def index_pdf(self, session_id, images):
         if session_id not in sessions:
             sessions[session_id] = Session()
-
 
         session = sessions[session_id]
         session.images = images
@@ -270,7 +272,6 @@ web_image = (
 )
 @modal.asgi_app()
 def ui():
-    from functools import partial
     import uuid
     import gradio as gr
     from gradio.routes import mount_gradio_app
@@ -309,14 +310,6 @@ def ui():
                 pdf = PDF(
                     label="Upload a PDF",
                 )
-                pdf.upload(
-                    upload_pdf,
-                    [pdf, session_id],
-                    session_id
-                )
+                pdf.upload(upload_pdf, [pdf, session_id], session_id)
 
     return mount_gradio_app(app=web_app, blocks=demo, path="/")
-
-
-# if __name__ == "__main__":
-#     ui()

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -103,133 +103,132 @@ class Session:
         self.messages = []
         self.pdf_embeddings = None
 
-# # Here we define our on-GPU ColQwen2 service, which runs document indexing and inference
-# @app.cls(
-#     image=model_image,
-#     gpu=modal.gpu.A100(size="80GB"),
-#     container_idle_timeout=10 * MINUTES,  # spin down when inactive
-# )
-# class Model:
-#     @modal.build()
-#     @modal.enter()
-#     def load_models(self):
-#         self.colqwen2_model = ColQwen2.from_pretrained(
-#             "vidore/colqwen2-v0.1",
-#             torch_dtype=torch.bfloat16,
-#             device_map="cuda:0",
-#         )
-#         self.colqwen2_processor = ColQwen2Processor.from_pretrained(
-#             "vidore/colqwen2-v0.1"
-#         )
-#         self.qwen2_vl_model = Qwen2VLForConditionalGeneration.from_pretrained(
-#             "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
-#         )
-#         self.qwen2_vl_model.to("cuda:0")
-#         self.qwen2_vl_processor = AutoProcessor.from_pretrained(
-#             "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
-#         )
+# Here we define our on-GPU ColQwen2 service, which runs document indexing and inference
+@app.cls(
+    image=model_image,
+    gpu=modal.gpu.A100(size="80GB"),
+    container_idle_timeout=10 * MINUTES,  # spin down when inactive
+)
+class Model:
+    @modal.build()
+    @modal.enter()
+    def load_models(self):
+        self.colqwen2_model = ColQwen2.from_pretrained(
+            "vidore/colqwen2-v0.1",
+            torch_dtype=torch.bfloat16,
+            device_map="cuda:0",
+        )
+        self.colqwen2_processor = ColQwen2Processor.from_pretrained(
+            "vidore/colqwen2-v0.1"
+        )
+        self.qwen2_vl_model = Qwen2VLForConditionalGeneration.from_pretrained(
+            "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
+        )
+        self.qwen2_vl_model.to("cuda:0")
+        self.qwen2_vl_processor = AutoProcessor.from_pretrained(
+            "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
+        )
 
-#     @modal.method()
-#     def index_pdf(self, session_id, images):
-#         if session_id not in sessions:
-#             sessions[session_id] = Session()
+    @modal.method()
+    def index_pdf(self, session_id, images):
+        if session_id not in sessions:
+            sessions[session_id] = Session()
 
-#         session = sessions[session_id]
-#         session.images = images
 
-#         batch_images = self.colqwen2_processor.process_images(images).to(
-#             self.colqwen2_model.device
-#         )
-#         pdf_embeddings = self.colqwen2_model(**batch_images)
-#         session.pdf_embeddings = pdf_embeddings
-#         # Update session state
-#         sessions[session_id] = session
+        session = sessions[session_id]
+        session.images = images
 
-#     @modal.method()
-#     def respond_to_message(self, session_id, message):
-#         if session_id not in sessions:
-#             sessions[session_id] = Session()
-#         session = sessions[session_id]
+        batch_images = self.colqwen2_processor.process_images(images).to(
+            self.colqwen2_model.device
+        )
+        pdf_embeddings = self.colqwen2_model(**batch_images)
+        session.pdf_embeddings = pdf_embeddings
+        # Update session state
+        sessions[session_id] = session
 
-#         # nothing to chat about without a PDF!
-#         if session.images is None:
-#             return "Please upload a PDF first"
-#         elif session.pdf_embeddings is None:
-#             return "Indexing PDF..."
+    @modal.method()
+    def respond_to_message(self, session_id, message):
+        if session_id not in sessions:
+            sessions[session_id] = Session()
+        session = sessions[session_id]
 
-#         print("respond_to_message, session_id", session_id)
+        # nothing to chat about without a PDF!
+        if session.images is None:
+            return "Please upload a PDF first"
+        elif session.pdf_embeddings is None:
+            return "Indexing PDF..."
 
-#         # retrieve the most relevant image from the PDF for the input query
-#         def get_relevant_image(message):
-#             batch_queries = self.colqwen2_processor.process_queries(
-#                 [message]
-#             ).to(self.colqwen2_model.device)
-#             query_embeddings = self.colqwen2_model(**batch_queries)
-#             scores = self.colqwen2_processor.score_multi_vector(
-#                 query_embeddings, session.pdf_embeddings
-#             )[0]
-#             max_index = max(range(len(scores)), key=lambda index: scores[index])
-#             return session.images[max_index]
+        # retrieve the most relevant image from the PDF for the input query
+        def get_relevant_image(message):
+            batch_queries = self.colqwen2_processor.process_queries(
+                [message]
+            ).to(self.colqwen2_model.device)
+            query_embeddings = self.colqwen2_model(**batch_queries)
+            scores = self.colqwen2_processor.score_multi_vector(
+                query_embeddings, session.pdf_embeddings
+            )[0]
+            max_index = max(range(len(scores)), key=lambda index: scores[index])
+            return session.images[max_index]
 
-#         # helper function to put message in the format chatbot
-#         def get_chatbot_message_with_image(message, image):
-#             return {
-#                 "role": "user",
-#                 "content": [
-#                     {"type": "image", "image": image},
-#                     {"type": "text", "text": message},
-#                 ],
-#             }
+        # helper function to put message in the format chatbot
+        def get_chatbot_message_with_image(message, image):
+            return {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": message},
+                ],
+            }
 
-#         # helper function add messages to the conversation history in chatbot format
-#         def append_to_messages(message, user_type="user"):
-#             session.messages.append(
-#                 {
-#                     "role": user_type,
-#                     "content": {"type": "text", "text": message},
-#                 }
-#             )
+        # helper function add messages to the conversation history in chatbot format
+        def append_to_messages(message, user_type="user"):
+            session.messages.append(
+                {
+                    "role": user_type,
+                    "content": {"type": "text", "text": message},
+                }
+            )
 
-#         # pass the query and retrieved image along with conversation history into the VLM for a response
-#         def generate_response(message, image):
-#             chatbot_message = get_chatbot_message_with_image(message, image)
-#             query = self.qwen2_vl_processor.apply_chat_template(
-#                 [chatbot_message, *session.messages],
-#                 tokenize=False,
-#                 add_generation_prompt=True,
-#             )
-#             image_inputs, _ = process_vision_info([chatbot_message])
-#             inputs = self.qwen2_vl_processor(
-#                 text=[query],
-#                 images=image_inputs,
-#                 padding=True,
-#                 return_tensors="pt",
-#             )
-#             inputs = inputs.to("cuda:0")
+        # pass the query and retrieved image along with conversation history into the VLM for a response
+        def generate_response(message, image):
+            chatbot_message = get_chatbot_message_with_image(message, image)
+            query = self.qwen2_vl_processor.apply_chat_template(
+                [chatbot_message, *session.messages],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+            image_inputs, _ = process_vision_info([chatbot_message])
+            inputs = self.qwen2_vl_processor(
+                text=[query],
+                images=image_inputs,
+                padding=True,
+                return_tensors="pt",
+            )
+            inputs = inputs.to("cuda:0")
 
-#             generated_ids = self.qwen2_vl_model.generate(
-#                 **inputs, max_new_tokens=128
-#             )
-#             generated_ids_trimmed = [
-#                 out_ids[len(in_ids) :]
-#                 for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
-#             ]
-#             output_text = self.qwen2_vl_processor.batch_decode(
-#                 generated_ids_trimmed,
-#                 skip_special_tokens=True,
-#                 clean_up_tokenization_spaces=False,
-#             )[0]
-#             return output_text
+            generated_ids = self.qwen2_vl_model.generate(
+                **inputs, max_new_tokens=128
+            )
+            generated_ids_trimmed = [
+                out_ids[len(in_ids) :]
+                for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+            ]
+            output_text = self.qwen2_vl_processor.batch_decode(
+                generated_ids_trimmed,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=False,
+            )[0]
+            return output_text
 
-#         relevant_image = get_relevant_image(message)
-#         output_text = generate_response(message, relevant_image)
-#         append_to_messages(message, user_type="user")
-#         append_to_messages(output_text, user_type="assistant")
+        relevant_image = get_relevant_image(message)
+        output_text = generate_response(message, relevant_image)
+        append_to_messages(message, user_type="user")
+        append_to_messages(output_text, user_type="assistant")
 
-#         # Update session state
-#         sessions[session_id] = session
+        # Update session state
+        sessions[session_id] = session
 
-#         return output_text
+        return output_text
 
 
 # ## A hosted Gradio interface
@@ -278,26 +277,30 @@ def ui():
     from gradio_pdf import PDF
     from pdf2image import convert_from_path
 
-    # model = Model()
+    model = Model()
 
-    def upload_pdf(path):
-        pass
-        # print("upload_pdf received session_id", session_id)
-        # # do something with the pdf
-        # if session_id == "":
-        #     session_id = str(uuid.uuid4())
-        #     print("generated session_id", session_id)
-        # return session_id
+    def upload_pdf(path, session_id):
+        if session_id == "":
+            # Generate session id if new client
+            session_id = str(uuid.uuid4())
 
-    def echo(message, history):
-        return message
+        images = convert_from_path(path)
+        model.index_pdf.remote(session_id, images)
+
+        return session_id
+
+    def respond_to_message(message, _, session_id):
+        return model.respond_to_message.remote(session_id, message)
 
     with gr.Blocks(theme="soft") as demo:
+        session_id = gr.State("")
+
         gr.Markdown("# Chat with PDF")
         with gr.Row():
             with gr.Column(scale=1):
                 gr.ChatInterface(
-                    fn=echo,
+                    fn=respond_to_message,
+                    additional_inputs=[session_id],
                     retry_btn=None,
                     undo_btn=None,
                     clear_btn=None,
@@ -306,9 +309,12 @@ def ui():
                 pdf = PDF(
                     label="Upload a PDF",
                 )
-                pdf.upload(upload_pdf, pdf)
+                pdf.upload(
+                    upload_pdf,
+                    [pdf, session_id],
+                    session_id
+                )
 
-        # demo.launch()
     return mount_gradio_app(app=web_app, blocks=demo, path="/")
 
 

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -1,6 +1,5 @@
 # ---
 # deploy: true
-# cmd: ["modal", "serve", "06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py"]
 # ---
 
 # # Chat with PDF: RAG with ColQwen2
@@ -19,12 +18,42 @@
 # First, we’ll import the libraries we need locally and define some constants.
 
 import os
+from pathlib import Path
+from urllib.request import urlopen
+from uuid import uuid4
 
 import modal
 
 MINUTES = 60  # seconds
 
-# ## Downloading the Model
+# ## Setting up dependenices
+
+# In Modal, we define [container images](https://modal.com/docs/guide/custom-container) that run our serverless workloads.
+# We install the packages required for our application in those images.
+
+model_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git")
+    .pip_install(
+        [
+            "git+https://github.com/illuin-tech/colpali.git@782edcd50108d1842d154730ad3ce72476a2d17d",  # we pin the commit id
+            "hf_transfer==0.1.8",
+            "qwen-vl-utils==0.0.8",
+            "torchvision==0.19.1",
+        ]
+    )
+)
+
+# These dependencies are only installed remotely, so we can't import them locally.
+# Use the `.imports` context manager to import them only on Modal instead.
+
+with model_image.imports():
+    import torch
+    from colpali_engine.models import ColQwen2, ColQwen2Processor
+    from qwen_vl_utils import process_vision_info
+    from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
+
+# ## Downloading ColQwen2
 
 # Vision-language models (VLMs) for embedding and generation add another layer of simplification
 # to RAG apps based on vector search: we only need one model.
@@ -46,40 +75,12 @@ def download_model(model_dir, model_name, model_revision):
     move_cache()
 
 
-# ## Building the image
-
-# In Modal, we define [container images](https://modal.com/docs/guide/custom-container) that run our serverless workloads.
-# We install the packages required for our application in those images.
-
-model_image = (
-    modal.Image.debian_slim(python_version="3.12")
-    .apt_install("git")
-    .pip_install(
-        [
-            "git+https://github.com/illuin-tech/colpali.git@782edcd50108d1842d154730ad3ce72476a2d17d",  # we pin the commit id
-            "hf_transfer==0.1.8",
-            "qwen-vl-utils==0.0.8",
-            "torchvision==0.19.1",
-        ]
-    )
-    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
-)
-
-# These dependencies are only installed remotely, so we can't import them locally.
-# Use the `.imports` context manager to import them only on Modal instead.
-
-with model_image.imports():
-    import torch
-    from colpali_engine.models import ColQwen2, ColQwen2Processor
-    from qwen_vl_utils import process_vision_info
-    from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
-
 # We can also include other files that our application needs in the container image.
-# Here, we we add the model weights to the image by executing our `download_model` function.
+# Here, we add the model weights to the image by executing our `download_model` function.
 
-model_image = model_image.run_function(
+model_image = model_image.env({"HF_HUB_ENABLE_HF_TRANSFER": "1"}).run_function(
     download_model,
-    timeout=MINUTES * 20,
+    timeout=20 * MINUTES,
     kwargs={
         "model_dir": "/model-qwen2-VL-2B-Instruct",
         "model_name": "Qwen/Qwen2-VL-2B-Instruct",
@@ -87,14 +88,38 @@ model_image = model_image.run_function(
     },
 )
 
-## Defining a Chat with PDF application
+# ## Managing state with Modal Volumes and Dicts
 
-# Running an inference service on Modal is as easy as writing an inference function in Python.
-# We just need to wrap that in a Modal App:
+# Chat services are stateful:
+# the response to an incoming user message depends on past user messages in a session.
 
-app = modal.App("chat-with-pdf")
+# RAG apps add even more state:
+# the documents being retrieved from and the index over those documents,
+# e.g. the embeddings.
 
-# To allow concurrent users, each user chat session state is stored in a modal.Dict
+# Modal Functions are stateless in and of themselves.
+# They don't retain information from input to input.
+# That's what enables Modal Functions to automatically scale up and down
+# [based on the number of incoming requests](https://modal.com/docs/guide/cold-start).
+
+# ### Managing chat sessions with Modal Dicts
+
+# In this example, we use a [`modal.Dict`](https://modal.com/docs/guide/dicts-and-queues)
+# to store state information between Function calls.
+
+# Modal Dicts behave similarly to Python dictionaries,
+# but they are backed by remote storage and accessible to all of your Modal Functions.
+# They can contain any Python object
+# that can be serialized using [`cloudpickle`](https://github.com/cloudpipe/cloudpickle).
+
+# A Dict can hold a few gigabytes across keys of size up to 100 MiB,
+# so it works well for our chat session state, which is a few KiB per session,
+# and for our embeddings, with are a few hundred KiB per PDF page,
+# up to about 100,000 pages of PDFs.
+
+# At a larger scale, we'd need to replace this with a database, like Postgres,
+# or push more state to the client.
+
 sessions = modal.Dict.from_name("colqwen-chat-sessions", create_if_missing=True)
 
 
@@ -105,12 +130,44 @@ class Session:
         self.pdf_embeddings = None
 
 
-# Here we define our on-GPU ColQwen2 service, which runs document indexing and inference
-# It uses the [Modal @app.cls](https://modal.com/docs/guide/lifecycle-functions) feature to load the model on container start, and inference on request.
+# ### Storing PDFs on a Modal Volume
+
+# Images extracted from PDFs are larger than our session state or embeddings
+# -- low tens of MiB per page.
+
+# So we store them on a [Modal Volume](https://modal.com/docs/guide/volumes),
+# which can store terabytes (or more!) of data across tens of thousands of files.
+
+# Volumes behave like a remote file system:
+# we read and write from them much like a local file system.
+
+pdf_volume = modal.Volume.from_name("colqwen-chat-pdfs", create_if_missing=True)
+PDF_ROOT = Path("/vol/pdfs/")
+
+
+# ## Defining a Chat with PDF service
+
+# To deploy an autoscaling "Chat with PDF" vision-language model service on Modal,
+# we just need to wrap our Python logic in a [Modal App](https://modal.com/docs/guide/apps):
+
+# It uses [Modal `@app.cls`](https://modal.com/docs/guide/lifecycle-functions) decorators
+# to organize the "lifecycle" of the app:
+# to ensure all model files are downloaded (`@modal.build`)
+# to load the model on container start (`@modal.enter`)
+# and to run inference on request (`@modal.method`).
+
+# We include in the arguments to the `@app.cls` decorator
+# all the information about this service's infrastructure:
+# the container image, the remote storage, and the GPU requirements.
+
+app = modal.App("chat-with-pdf")
+
+
 @app.cls(
     image=model_image,
     gpu=modal.gpu.A100(size="80GB"),
     container_idle_timeout=10 * MINUTES,  # spin down when inactive
+    volumes={"/vol/pdfs/": pdf_volume},
 )
 class Model:
     @modal.build()
@@ -125,7 +182,7 @@ class Model:
             "vidore/colqwen2-v0.1"
         )
         self.qwen2_vl_model = Qwen2VLForConditionalGeneration.from_pretrained(
-            "Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True
+            "Qwen/Qwen2-VL-2B-Instruct", torch_dtype=torch.bfloat16
         )
         self.qwen2_vl_model.to("cuda:0")
         self.qwen2_vl_processor = AutoProcessor.from_pretrained(
@@ -133,28 +190,45 @@ class Model:
         )
 
     @modal.method()
-    def index_pdf(self, session_id, images):
+    def index_pdf(self, session_id, target: bytes | list):
         # We store concurrent user chat sessions in a modal.Dict
 
-        # For simplicity, we assume that each session only runs one request at a time
-        # This assumption lets us fetch the session, and write to it later, without fear of race conditions
+        # For simplicity, we assume that each user only runs one session at a time
 
         session = sessions.get(session_id)
         if session is None:
             session = Session()
 
-        session.images = images
+        if isinstance(target, bytes):
+            images = convert_pdf_to_images.remote(target)
+        else:
+            images = target
+
+        # Store images on a Volume for later retrieval
+        session_dir = PDF_ROOT / f"{session_id}"
+        session_dir.mkdir(exist_ok=True, parents=True)
+        for ii, image in enumerate(images):
+            filename = session_dir / f"{str(ii).zfill(3)}.jpg"
+            image.save(filename)
 
         # Generated embeddings from the image(s)
-        batch_images = self.colqwen2_processor.process_images(images).to(
-            self.colqwen2_model.device
-        )
-        pdf_embeddings = self.colqwen2_model(**batch_images)
+        BATCH_SZ = 4
+        pdf_embeddings = []
+        batches = [
+            images[i : i + BATCH_SZ] for i in range(0, len(images), BATCH_SZ)
+        ]
+        for batch in batches:
+            batch_images = self.colqwen2_processor.process_images(batch).to(
+                self.colqwen2_model.device
+            )
+            pdf_embeddings += list(
+                self.colqwen2_model(**batch_images).to("cpu")
+            )
 
-        # Store the image embeddings in the session, for later RAG use
+        # Store the image embeddings in the session, for later retrieval
         session.pdf_embeddings = pdf_embeddings
 
-        # Write session state, including embeddings, back to the modal.Dict
+        # Write embeddings back to the modal.Dict
         sessions[session_id] = session
 
     @modal.method()
@@ -163,96 +237,154 @@ class Model:
         if session is None:
             session = Session()
 
+        pdf_volume.reload()  # make sure we have the latest data
+
+        images = (PDF_ROOT / str(session_id)).glob("*.jpg")
+        images = list(sorted(images, key=lambda p: int(p.stem)))
+
         # Nothing to chat about without a PDF!
-        if session.images is None:
+        if not images:
             return "Please upload a PDF first"
         elif session.pdf_embeddings is None:
             return "Indexing PDF..."
 
-        # Retrieve the most relevant image from the PDF for the input query
-        def get_relevant_image(message):
-            batch_queries = self.colqwen2_processor.process_queries(
-                [message]
-            ).to(self.colqwen2_model.device)
-            query_embeddings = self.colqwen2_model(**batch_queries)
-
-            # This scores our query embedding against the image embeddings from index_pdf
-            scores = self.colqwen2_processor.score_multi_vector(
-                query_embeddings, session.pdf_embeddings
-            )[0]
-
-            # Return the best matching image
-            max_index = max(range(len(scores)), key=lambda index: scores[index])
-            return session.images[max_index]
-
-        # Helper functions for chatbot formatting
-        def get_chatbot_message_with_image(message, image):
-            return {
-                "role": "user",
-                "content": [
-                    {"type": "image", "image": image},
-                    {"type": "text", "text": message},
-                ],
-            }
-
-        def append_to_messages(message, user_type="user"):
-            session.messages.append(
-                {
-                    "role": user_type,
-                    "content": {"type": "text", "text": message},
-                }
-            )
-
-        # Pass the query and retrieved image along with conversation history into the VLM for a response
-        def generate_response(message, image):
-            chatbot_message = get_chatbot_message_with_image(message, image)
-            query = self.qwen2_vl_processor.apply_chat_template(
-                [chatbot_message, *session.messages],
-                tokenize=False,
-                add_generation_prompt=True,
-            )
-            image_inputs, _ = process_vision_info([chatbot_message])
-            inputs = self.qwen2_vl_processor(
-                text=[query],
-                images=image_inputs,
-                padding=True,
-                return_tensors="pt",
-            )
-            inputs = inputs.to("cuda:0")
-
-            generated_ids = self.qwen2_vl_model.generate(
-                **inputs, max_new_tokens=128
-            )
-            generated_ids_trimmed = [
-                out_ids[len(in_ids) :]
-                for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
-            ]
-            output_text = self.qwen2_vl_processor.batch_decode(
-                generated_ids_trimmed,
-                skip_special_tokens=True,
-                clean_up_tokenization_spaces=False,
-            )[0]
-            return output_text
-
         # RAG, Retrieval-Augmented Generation, is two steps:
 
-        # Retrieval of the most relevant image to answer the user's query
-        relevant_image = get_relevant_image(message)
+        # _Retrieval_ of the most relevant data to answer the user's query
+        relevant_image = self.get_relevant_image(message, session, images)
 
-        # Generation, passing in the query and the retrieved image
-        output_text = generate_response(message, relevant_image)
+        # _Generation_ based on the retrieved data
+        output_text = self.generate_response(message, session, relevant_image)
 
         # Update session state for future chats
-        append_to_messages(message, user_type="user")
-        append_to_messages(output_text, user_type="assistant")
+        append_to_messages(message, session, user_type="user")
+        append_to_messages(output_text, session, user_type="assistant")
         sessions[session_id] = session
 
         return output_text
 
+    # Retrieve the most relevant image from the PDF for the input query
+    def get_relevant_image(self, message, session, images):
+        import PIL
+
+        batch_queries = self.colqwen2_processor.process_queries([message]).to(
+            self.colqwen2_model.device
+        )
+        query_embeddings = self.colqwen2_model(**batch_queries)
+
+        # This scores our query embedding against the image embeddings from index_pdf
+        scores = self.colqwen2_processor.score_multi_vector(
+            query_embeddings, session.pdf_embeddings
+        )[0]
+
+        # Select the best matching image
+        max_index = max(range(len(scores)), key=lambda index: scores[index])
+        return PIL.Image.open(images[max_index])
+
+    # Pass the query and retrieved image along with conversation history into the VLM for a response
+    def generate_response(self, message, session, image):
+        chatbot_message = get_chatbot_message_with_image(message, image)
+        query = self.qwen2_vl_processor.apply_chat_template(
+            [chatbot_message, *session.messages],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        image_inputs, _ = process_vision_info([chatbot_message])
+        inputs = self.qwen2_vl_processor(
+            text=[query],
+            images=image_inputs,
+            padding=True,
+            return_tensors="pt",
+        )
+        inputs = inputs.to("cuda:0")
+
+        generated_ids = self.qwen2_vl_model.generate(
+            **inputs, max_new_tokens=128
+        )
+        generated_ids_trimmed = [
+            out_ids[len(in_ids) :]
+            for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+        ]
+        output_text = self.qwen2_vl_processor.batch_decode(
+            generated_ids_trimmed,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0]
+        return output_text
+
+
+# ## Loading PDFs as images
+
+# Vision-Language Models operate on images, not PDFs directly,
+# so we need to convert out PDFs into images first.
+
+# We separate this from our indexing and chatting logic --
+# we run on a different container with different dependencies.
+
+pdf_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("poppler-utils")
+    .pip_install("pdf2image==1.17.0")
+)
+
+
+@app.function(image=pdf_image)
+def convert_pdf_to_images(pdf_bytes):
+    from pdf2image import convert_from_bytes
+
+    images = convert_from_bytes(pdf_bytes, fmt="jpeg")
+    return images
+
+
+# ## Chatting with a PDF from the terminal
+
+# Before deploying in a UI, we can test our service from the terminal.
+
+# Just run
+# ```bash
+# modal run chat_with_pdf_vision.py
+# ```
+
+# and optionally pass in a path to or URL of a PDF with the `--pdf-path` argument
+# and specify a question with the `--question` argument.
+
+# Continue a previous chat by passing the session ID printed to the terminal at start
+# with the `--session-id` argument.
+
+
+@app.local_entrypoint()
+def main(question: str = None, pdf_path: str = None, session_id: str = None):
+    model = Model()
+    if session_id is None:
+        session_id = str(uuid4())
+        print("Starting a new session with id", session_id)
+
+        if pdf_path is None:
+            pdf_path = "https://arxiv.org/pdf/1706.03762"  # all you need
+
+        if pdf_path.startswith("http"):
+            pdf_bytes = urlopen(pdf_path).read()
+        else:
+            pdf_path = Path(pdf_path)
+            pdf_bytes = pdf_path.read_bytes()
+
+        print("Indexing PDF from", pdf_path)
+        model.index_pdf.remote(session_id, pdf_bytes)
+    else:
+        if pdf_path is not None:
+            raise ValueError("Start a new session to chat with a new PDF")
+        print("Resuming session with id", session_id)
+
+    if question is None:
+        question = "What is this document about?"
+
+    print("QUESTION:", question)
+    print(model.respond_to_message.remote(session_id, question))
+
 
 # ## A hosted Gradio interface
 
-# With the Gradio library, we can create a simple web interface around our class in Python,
+# With the [Gradio](https://gradio.app) library, we can create a simple web interface around our class in Python,
 # then use Modal to host it for anyone to try out.
 
 # To deploy your own, run
@@ -265,15 +397,11 @@ class Model:
 # If you’re editing the code, use `modal serve` instead to see changes hot-reload.
 
 
-web_image = (
-    modal.Image.debian_slim(python_version="3.12")
-    .apt_install("poppler-utils")
-    .pip_install(
-        "gradio==4.44.1",
-        "pillow==10.4.0",
-        "gradio-pdf==0.0.15",
-        "pdf2image==1.17.0",
-    )
+web_image = pdf_image.pip_install(
+    "gradio==4.44.1",
+    "pillow==10.4.0",
+    "gradio-pdf==0.0.15",
+    "pdf2image==1.17.0",
 )
 
 
@@ -281,7 +409,7 @@ web_image = (
     image=web_image,
     # gradio requires sticky sessions
     # so we limit the number of concurrent containers to 1
-    # and allow it to scale to 100 concurrent inputs
+    # and allow it to scale to 1000 concurrent inputs
     concurrency_limit=1,
     allow_concurrent_inputs=1000,
 )
@@ -336,3 +464,28 @@ def ui():
                 pdf.upload(upload_pdf, [pdf, session_id], session_id)
 
     return mount_gradio_app(app=web_app, blocks=demo, path="/")
+
+
+# ## Addenda
+
+# The remainder of this code consists of utility functions and boiler plate used in the
+# main code above.
+
+
+def get_chatbot_message_with_image(message, image):
+    return {
+        "role": "user",
+        "content": [
+            {"type": "image", "image": image},
+            {"type": "text", "text": message},
+        ],
+    }
+
+
+def append_to_messages(message, session, user_type="user"):
+    session.messages.append(
+        {
+            "role": user_type,
+            "content": {"type": "text", "text": message},
+        }
+    )

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -2,14 +2,20 @@
 # deploy: true
 # cmd: ["modal", "serve", "06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py"]
 # ---
-#
+
 # # Chat with PDF: RAG with ColQwen2
-#
+
 # In this example, we demonstrate how to use the the [ColQwen2](https://huggingface.co/vidore/colqwen2-v0.1) model to build a simple
-# Chat with PDF RAG app. The ColQwen2 model is based on [ColPali](https://huggingface.co/blog/manu/colpali) and the
-# [Qwen2-VL-2B-Instruct](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct) visual language model.
-#
+# "Chat with PDF" retrieval-augmented generation (RAG) app.
+# The ColQwen2 model is based on [ColPali](https://huggingface.co/blog/manu/colpali) but uses the
+# [Qwen2-VL-2B-Instruct](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct) vision-language model.
+# ColPali is in turn based on the late-interaction embedding approach pioneered in [ColBERT](https://dl.acm.org/doi/pdf/10.1145/3397271.3401075).
+
+# Vision-language models with high-quality embeddings obviate the need for complex pre-processing pipelines.
+# See [this blog post from Jo Bergum of Vespa](https://blog.vespa.ai/announcing-colbert-embedder-in-vespa/) for more.
+
 # ## Setup
+
 # First, we’ll import the libraries we need locally and define some constants.
 
 import os
@@ -20,10 +26,10 @@ from fastapi import FastAPI
 MINUTES = 60  # seconds
 
 # ## Downloading the Model
-#
-# Next, we download the model we want to serve. In this case, we're using the instruction-tuned Qwen2-VL-2B-Instruct model,
-# both as our visual language model, and as the backbone for the ColQwen2 model.
-# We use the function below to download the model from the Hugging Face Hub.
+
+# VLMs for embedding and generation add another layer of simplification to RAG apps based on vector search:
+# we only need one model. Here, we use the Qwen2-VL-2B-Instruct model from Alibaba.
+# The function below downloads the model from the Hugging Face Hub.
 
 
 def download_model(model_dir, model_name, model_revision):
@@ -41,12 +47,9 @@ def download_model(model_dir, model_name, model_revision):
 
 
 # ## Building the image
+
 # In Modal, we define [container images](https://modal.com/docs/guide/custom-container) that run our serverless workloads.
-# We define and install the packages required for our application.
-#
-# We want to create a Modal image which has the model weights pre-saved to a directory. The benefit of this is that the container no
-# longer has to re-download the model from Hugging Face - instead, it will take advantage of Modal's internal filesystem for
-# faster cold starts. We use the download function defined earlier to download the model.
+# We install the packages required for our application in those images.
 
 model_image = (
     modal.Image.debian_slim(python_version="3.12")
@@ -60,43 +63,46 @@ model_image = (
         ]
     )
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
-    .run_function(
-        download_model,
-        timeout=MINUTES * 20,
-        kwargs={
-            "model_dir": "/model-qwen2-VL-2B-Instruct",
-            "model_name": "Qwen/Qwen2-VL-2B-Instruct",
-            "model_revision": "aca78372505e6cb469c4fa6a35c60265b00ff5a4",
-        },
-    )
 )
 
-## Defining a Chat with PDF application
-#
-# Running an inference service on Modal is as easy as writing inference in Python.
-# The code below adds a modal Cls to an App that embeds the input PDFs and runs the VLM.
+# These dependencies are only installed remotely, so we can't import them locally.
+# Use the `.imports` context manager to import them only on Modal instead.
 
-# First we define a modal [App](https://modal.com/docs/guide/apps#apps-stubs-and-entrypoints)
-app = modal.App("chat-with-pdf")
-
-# We then import some packages we will need in the container
 with model_image.imports():
     import torch
     from colpali_engine.models import ColQwen2, ColQwen2Processor
     from qwen_vl_utils import process_vision_info
     from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
 
+# We can also include other files our application needs in the container image.
+# Here, that's the model weights, which we download by executing our `download_model` function.
+
+model_image = model_image.run_function(
+    download_model,
+    timeout=MINUTES * 20,
+    kwargs={
+        "model_dir": "/model-qwen2-VL-2B-Instruct",
+        "model_name": "Qwen/Qwen2-VL-2B-Instruct",
+        "model_revision": "aca78372505e6cb469c4fa6a35c60265b00ff5a4",
+    },
+)
+
+## Defining a Chat with PDF application
+
+# Running an inference service on Modal is as easy as writing inference in Python.
+
+# We just need to wrap that in
+
+app = modal.App("chat-with-pdf")
+
 
 @app.cls(
     image=model_image,
-    gpu=modal.gpu.A100(
-        size="80GB"
-    ),  # gpu config: we have two model instances so we use 80gb
-    container_idle_timeout=10
-    * MINUTES,  # how much time the container should stay up for after it's done
+    gpu=modal.gpu.A100(size="80GB"),
+    container_idle_timeout=10 * MINUTES,  # spin down when inactive
 )
 class Model:
-    # We stack the build and enter decorators here to ensure that the weights 
+    # we stack the build and enter decorators here to ensure that the weights
     # downloaded in from_pretrained are cached in the image
     @modal.build()
     @modal.enter()
@@ -104,7 +110,7 @@ class Model:
         self.colqwen2_model = ColQwen2.from_pretrained(
             "vidore/colqwen2-v0.1",
             torch_dtype=torch.bfloat16,
-            device_map="cuda:0",  # or "mps" if on Apple Silicon
+            device_map="cuda:0",
         )
         self.colqwen2_processor = ColQwen2Processor.from_pretrained(
             "vidore/colqwen2-v0.1"
@@ -131,13 +137,13 @@ class Model:
 
     @modal.method()
     def respond_to_message(self, message):
-        # Nothing to chat about without a PDF
+        # nothing to chat about without a PDF!
         if self.images is None:
             return "Please upload a PDF first"
         elif self.pdf_embeddings is None:
             return "Indexing PDF..."
 
-        # Retrieve the most relevant image from the PDF for the input query
+        # retrieve the most relevant image from the PDF for the input query
         def get_relevant_image(message):
             batch_queries = self.colqwen2_processor.process_queries(
                 [message]
@@ -149,7 +155,7 @@ class Model:
             max_index = max(range(len(scores)), key=lambda index: scores[index])
             return self.images[max_index]
 
-        # Helper function to put message in chatbot syntax
+        # helper function to put message in the format chatbot
         def get_chatbot_message_with_image(message, image):
             return {
                 "role": "user",
@@ -159,8 +165,7 @@ class Model:
                 ],
             }
 
-        # Helper function add messages to the conversation history in chatbot format
-        # We don't include the image for the history
+        # helper function add messages to the conversation history in chatbot format
         def append_to_messages(message, user_type="user"):
             self.messages.append(
                 {
@@ -169,8 +174,7 @@ class Model:
                 }
             )
 
-        # Pass the query and retrieved image along with conversation 
-        # history into the VLM for a response
+        # pass the query and retrieved image along with conversation history into the VLM for a response
         def generate_response(message, image):
             chatbot_message = get_chatbot_message_with_image(message, image)
             query = self.qwen2_vl_processor.apply_chat_template(
@@ -209,14 +213,23 @@ class Model:
 
 
 # ## A hosted Gradio interface
-# With the Gradio library by Hugging Face, we can create a simple web interface around our class, and use Modal to host it
-# for anyone to try out. To set up your own, run modal deploy chat_with_pdf_vision.py and navigate to the URL it prints out.
-# If you’re playing with the code, use modal serve instead to see changes live.
+
+# With the Gradio library, we can create a simple web interface around our class in Python,
+# then use Modal to host it for anyone to try out.
+
+# To deploy up your own, run
+
+# ```bash
+# modal deploy chat_with_pdf_vision.py
+# ```
+
+# and navigate to the URL that appears in your teriminal.
+# If you’re editing the code, use `modal serve` instead to see changes live.
 
 web_app = FastAPI()
 
 web_image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.12")
     .apt_install("poppler-utils")
     .pip_install(
         "gradio==4.44.1",
@@ -267,5 +280,3 @@ def ui():
                 pdf.upload(upload_pdf, pdf)
 
     return mount_gradio_app(app=web_app, blocks=demo, path="/")
-
-# And that's it!

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -1,0 +1,188 @@
+import modal
+import os
+
+from fastapi import FastAPI
+
+MINUTES = 60  # seconds
+
+def download_model(model_dir, model_name):
+    from huggingface_hub import snapshot_download
+    from transformers.utils import move_cache
+
+    os.makedirs(model_dir, exist_ok=True)
+    snapshot_download(
+        model_name,
+        local_dir= model_dir,
+        ignore_patterns=["*.pt", "*.bin"],  # using safetensors
+    )
+    move_cache()
+
+model_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git")
+    .pip_install([
+        "git+https://github.com/illuin-tech/colpali", 
+        "hf_transfer", 
+        "qwen-vl-utils",
+        "torchvision"
+    ])
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
+    .run_function(
+        download_model,
+        secrets=[modal.Secret.from_name("huggingface-secret", required_keys=["HF_TOKEN"])],
+        timeout=MINUTES * 20,
+        kwargs={"model_dir": "/model-qwen2-VL-2B-Instruct", "model_name": "Qwen/Qwen2-VL-2B-Instruct"},
+    )
+)
+
+
+app = modal.App("chat-with-pdf")
+
+with model_image.imports():
+    import torch
+    from PIL import Image
+    from colpali_engine.models import ColQwen2, ColQwen2Processor
+    from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
+    from qwen_vl_utils import process_vision_info
+
+
+@app.cls(
+    image=model_image,
+    gpu=modal.gpu.A100(size="80GB"),
+    container_idle_timeout=10 * MINUTES,
+    allow_concurrent_inputs=4,
+)
+class Model:
+    @modal.enter()
+    def load_model(self):
+        self.colpali_model = ColQwen2.from_pretrained(
+            "vidore/colqwen2-v0.1",
+            torch_dtype=torch.bfloat16,
+            device_map="cuda:0",  # or "mps" if on Apple Silicon
+        )
+        self.colpali_processor = ColQwen2Processor.from_pretrained("vidore/colqwen2-v0.1")
+        self.qwen_model = Qwen2VLForConditionalGeneration.from_pretrained("Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True)
+        self.qwen_model.to("cuda:0")
+        self.qwen_processor = AutoProcessor.from_pretrained("Qwen/Qwen2-VL-2B-Instruct", trust_remote_code=True)
+        
+        self.pdf_embeddings = None
+        self.images = None
+        self.messages = []
+
+
+    @modal.method()
+    def index_pdf(self, images):
+        self.images = images
+        batch_images = self.colpali_processor.process_images(images).to(self.colpali_model.device)
+        self.pdf_embeddings = self.colpali_model(**batch_images)
+
+    @modal.method()
+    def respond_to_message(self, message):
+        def get_relevant_image(message):
+            batch_queries = self.colpali_processor.process_queries([message]).to(self.colpali_model.device)
+            query_embeddings = self.colpali_model(**batch_queries)
+            scores = self.colpali_processor.score_multi_vector(query_embeddings, self.pdf_embeddings)[0]
+            max_index = max(range(len(scores)), key=lambda index: scores[index])
+            return self.images[max_index]
+        
+        def get_chatbot_message_with_image(message, image):
+            return {
+                "role": "user", 
+                "content": [{
+                    "type": "image",
+                    "image": image
+                }, {
+                    "type": "text",
+                    "text": message
+                }]
+            }
+    
+        def append_to_messages(message, user_type="user"):
+            self.messages.append(
+                {
+                    "role": user_type, 
+                    "content": {
+                        "type": "text",
+                        "text": message
+                    }
+                }
+            )
+
+        def generate_response(message, image):
+            chatbot_message = get_chatbot_message_with_image(message, image)
+            print(chatbot_message, self.messages)
+            query = self.qwen_processor.apply_chat_template(
+                [chatbot_message, *self.messages], tokenize=False, add_generation_prompt=True
+            )
+            image_inputs, _ = process_vision_info([chatbot_message])
+            inputs = self.qwen_processor(
+                text=[query],
+                images=image_inputs,
+                padding=True,
+                return_tensors="pt",
+            )
+            inputs = inputs.to("cuda:0")
+
+            generated_ids = self.qwen_model.generate(**inputs, max_new_tokens=128)
+            generated_ids_trimmed = [
+                out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+            ]
+            output_text = self.qwen_processor.batch_decode(
+                generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+            )[0]
+            return output_text
+
+
+
+        if self.images is None:
+            return "Please upload a PDF first"
+        elif self.pdf_embeddings is None:
+            return "Indexing PDF..."
+
+        relevant_image = get_relevant_image(message)
+        
+        output_text = generate_response(message, relevant_image)
+        append_to_messages(message, user_type="user")
+        append_to_messages(output_text, user_type="assistant")
+        print("Response", type(output_text), output_text)
+        return output_text
+
+web_app = FastAPI()
+
+web_image = modal.Image.debian_slim().apt_install("poppler-utils").pip_install(
+    "gradio", "pillow", "gradio-pdf", "pdf2image"
+)
+
+@app.function(image=web_image, keep_warm=1, concurrency_limit=1, allow_concurrent_inputs=1000)
+@modal.asgi_app()
+def ui():
+    from gradio.routes import mount_gradio_app
+    import gradio as gr
+    from gradio_pdf import PDF
+    from pdf2image import convert_from_path
+
+    model = Model()
+
+    def respond_to_message(message, _):
+        return model.respond_to_message.remote(message)
+
+    def upload_pdf(path):
+        images = convert_from_path(path)
+        model.index_pdf.remote(images)
+
+
+    with gr.Blocks(theme="soft") as demo:
+        gr.Markdown("# Chat with PDF")
+        with gr.Row():
+            with gr.Column(scale=1):
+                gr.ChatInterface(
+                    fn=respond_to_message,
+                    retry_btn=None,
+                    undo_btn=None,
+                    clear_btn=None,
+                )
+            with gr.Column(scale=1):
+                pdf = PDF(label="Upload a PDF")
+                pdf.upload(upload_pdf, pdf)
+    
+    return mount_gradio_app(app=web_app, blocks=demo, path="/")


### PR DESCRIPTION

<img width="1862" alt="Screenshot 2024-09-30 at 11 03 15 AM" src="https://github.com/user-attachments/assets/5f0f9ae4-67dd-42f1-99ca-1c2cfc933f22">


Adds a chat with RAG example using the following things:
- ColQwen2 to index the docs
- Qwen2-VL as a VLM
- Gradio chatUI and PDF upload UI

Some things I would do if I wanted people to actually use this in prod. Curious which of these people think is worth doing

- Optimize the cold start (takes 2 mins now on average)

- Optimize the inference time for the chat (currently ~10s). Would try vllm, but there's an issue with VLLM and the `transformers` version that `ColQwen2` needs, so I'd have to build vllm from source, which would increase build time?

- Try to make the app use less memory (I currently need an 80gb A100, largely because though the underlying model is the same, I couldn't find a clean way to use the same underlying object for the model, and so I end up having 2 model objects)

### Type of Change

- [x] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
