### PR TITLE
Update comfy example to emphasize how to iterate & avoid redownloading weights

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -43,8 +43,6 @@
 #
 # ## Setup
 #
-# First, we define the environment we need to run ComfyUI using [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli). This handy tool manages the installation of ComfyUI, its dependencies, models, and custom nodes.
-
 
 import json
 import subprocess
@@ -54,25 +52,84 @@ from typing import Dict
 
 import modal
 
+# ## Building up the environment
+#
+# ComfyUI setups can be complex, with a lot of custom nodes and models to manage.
+# We'll use [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) to manage the installation of ComfyUI, its dependencies, models, and custom nodes.
+#
+# We start from a base image and specify all of our dependencies.
+# We'll call out the interesting ones as they come up below.
+# Note that these dependencies are not installed locally
+# they are only installed in the remote environment where our app runs,
+# and they are only installed when you first deploy or run the app or make changes to the image,
+# on subsequent runs, the image will be cached and reused.
+
+
 image = (  # build up a Modal Image to run ComfyUI, step by step
     modal.Image.debian_slim(  # start from basic Linux with Python
         python_version="3.11"
     )
     .apt_install("git")  # install git to clone ComfyUI
-    .pip_install("comfy-cli==1.1.8")  # install comfy-cli
+    .pip_install("comfy-cli==1.2.3")  # install comfy-cli
     .run_commands(  # use comfy-cli to install the ComfyUI repo and its dependencies
         "comfy --skip-prompt install --nvidia"
     )
-    .run_commands(  # download the flux models
-        "comfy --skip-prompt model download --url https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp8_e4m3fn.safetensors --relative-path models/clip",
-        "comfy --skip-prompt model download --url https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors --relative-path models/clip",
-        "comfy --skip-prompt model download --url https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors --relative-path models/vae",
-        "comfy --skip-prompt model download --url https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/flux1-schnell.safetensors --relative-path models/unet",
+)
+
+# ### Downloading models
+#
+# We'll download the Flux models using `comfy-cli`.
+# You can find other models on [Hugging Face](https://huggingface.co/).
+# ComfyUI will look for these models in the `models` subdirectory under specific subdirectories
+# (e.g. `vae`, `unet`, `clip`, etc.), so we need to download them into the correct location.
+#
+# You can run multiple commands using comma separated commands in `.run_commands()`.
+# But here we opt to split them up to allow for more granular layer caching in the Modal Image.
+# By appending a model install using `.run_commands(...)` at the end of this build step we ensure
+# that the previous steps remain un changed and will be cached, avoiding unnecessary re-runs.
+
+image = (
+    image.run_commands(
+        "comfy --skip-prompt model download --url https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp8_e4m3fn.safetensors --relative-path models/clip"
     )
-    .run_commands(  # download a custom node
+    .run_commands(
+        "comfy --skip-prompt model download --url https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors --relative-path models/clip"
+    )
+    .run_commands(
+        "comfy --skip-prompt model download --url https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors --relative-path models/vae"
+    )
+    .run_commands(
+        "comfy --skip-prompt model download --url https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/flux1-schnell.safetensors --relative-path models/unet"
+    )
+    # Add .run_commands(...) calls for any other models you want to download
+)
+
+# ### Downloading custom nodes
+#
+# We'll download custom nodes using `comfy-cli` too.
+# Alternatively, you can install them by cloning the git repositories to your /root/comfy/ComfyUI/custom_nodes
+# directory and installing the required dependencies manually.
+# Similarly to models, we opt to split the custom node installation into separate `.run_commands(...)` calls
+# to allow for more granular layer caching.
+
+image = (
+    image.run_commands(  # download a custom node
         "comfy node install image-resize-comfyui"
     )
-    # can layer additional models and custom node downloads as needed
+    # Add .run_commands(...) calls for any other custom nodes you want to download
+)
+
+# ### Adding more dependencies
+#
+# To add more dependencies, models or custom nodes without having to rebuild the entire image
+# it's recommended to append them at the end of your image build rather than modifying previous steps.
+# This allows you to cache all previous steps and only build the new steps when you make changes to the image.
+
+image = (
+    image  # Add any additional steps here
+    # .run_commands(...)
+    # .pip_install(...)
+    # .apt_install(...)
 )
 
 app = modal.App(name="example-comfyui", image=image)
@@ -185,98 +242,4 @@ class ComfyUI:
 # - To decrease inference latency, you can process multiple inputs in parallel by setting `allow_concurrent_inputs=1`, which will run each input on its own container. This will reduce overall response time, but will cost you more money. See our [Scaling ComfyUI](https://modal.com/blog/scaling-comfyui) blog post for more details.
 # - If you're noticing long startup times for the ComfyUI server (e.g. >30s), this is likely due to too many custom nodes being loaded in. Consider breaking out your deployments into one App per unique combination of models and custom nodes.
 # - For those who prefer to run a ComfyUI workflow directly as a Python script, see [this blog post](https://modal.com/blog/comfyui-prototype-to-production).
-
-# ### Store models in a volume
-
-# We can also store the models in a volume to avoid downloading them when we update earlier steps in the image.
-# As a side effect this allows you to cache models between apps as well.
-# And here we use huggingface to download models, allowing us to download models that require a token.
-
-# ```python
-# COMFY_PATH = "/root/comfy/ComfyUI"
-# COMFY_MODELS_PATH = f"{COMFY_PATH}/models"
-
-# custom_nodes_to_install = [
-#     "image-resize-comfyui",
-# ]
-
-
-# models_to_download = [
-#     {
-#         "repo_id": "black-forest-labs/FLUX.1-dev",
-#         "filename": "ae.safetensors",
-#         "revision": "main",
-#         "local_dir": f"{COMFY_MODELS_PATH}/vae",
-#     },
-# ]
-
-# models_vol = modal.Volume.from_name("comfyui-models", create_if_missing=True)
-# volumes = {COMFY_MODELS_PATH: models_vol}
-
-# huggingface_secret = modal.Secret.from_name("my-huggingface-secret")
-# secrets = [huggingface_secret]
-
-
-# def install_nodes(nodes):
-#     print("Installing nodes...")
-#     for node in nodes:
-#         print(f"Installing node {node}...")
-#         subprocess.run(f"comfy node install {node}", shell=True, check=True)
-#     print("Finished installing nodes!")
-
-
-# def download_models(model_configs):
-#     # Opting to download models using the hf_hub_download
-#     # since comfy cli doesn't support downloading
-#     # models that require a huggingface token
-#     # hf_hub_download also has a build in cache
-#     # so it won't download the same model twice
-#     from huggingface_hub import hf_hub_download
-
-#     print("Downloading models...")
-#     for model_config in model_configs:
-#         print(
-#             f"Downloading {model_config['filename']} from {model_config['repo_id']}..."
-#         )
-
-#         hf_hub_download(
-#             repo_id=model_config["repo_id"],
-#             filename=model_config["filename"],
-#             revision=model_config["revision"],
-#             local_dir=model_config["local_dir"],
-#         )
-
-#     print("Finished downloading models!")
-
-
-# image = (
-#     modal.Image.debian_slim(python_version="3.11")
-#     .apt_install("git")
-#     .pip_install("comfy-cli==1.2.3", "huggingface_hub", "hf-transfer")
-#     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
-#     .run_commands("comfy --skip-prompt install --nvidia")
-#     # We delete the models directory
-#     # since we are going to mount a volume of models into it
-#     .run_commands(f"rm -rf {COMFY_MODELS_PATH}")
-#     # We use a custom function to install the nodes
-#     # since we need to mount a volume of models into the container
-#     .run_function(
-#         install_nodes,
-#         args=[custom_nodes_to_install],
-#         volumes=volumes,  # In case the nodes need access to the models
-#         secrets=secrets,
-#     )
-#     # We always want to download the models last
-#     # since we cache them in the volume anyway
-#     # and this allows us to not rebuild any other step in the image
-#     # whenever we update our model
-#     .run_function(
-#         download_models,
-#         args=[models_to_download],
-#         volumes=volumes,
-#         # Some models need a huggingface token to download
-#         secrets=secrets,
-#         force_build=True,
-#     )
-# )
-# ```
+# - Currently `comfy-cli` doesn't support downloading models that require a huggingface token. Instead, you can use `huggingface_hub` library to download them.

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -52,16 +52,16 @@ from typing import Dict
 
 import modal
 
-# ## Building up the environment
+# ### Building up the environment
 #
 # ComfyUI setups can be complex, with a lot of custom nodes and models to manage.
 # We'll use [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) to manage the installation of ComfyUI, its dependencies, models, and custom nodes.
 #
 # We start from a base image and specify all of our dependencies.
 # We'll call out the interesting ones as they come up below.
+#
 # Note that these dependencies are not installed locally
-# they are only installed in the remote environment where our app runs,
-# and they are only installed when you first deploy or run the app or make changes to the image,
+# they are only installed once in the remote environment where our app runs,
 # on subsequent runs, the image will be cached and reused.
 
 
@@ -76,17 +76,16 @@ image = (  # build up a Modal Image to run ComfyUI, step by step
     )
 )
 
-# ### Downloading models
+# #### Downloading models
 #
 # We'll download the Flux models using `comfy-cli`.
-# You can find other models on [Hugging Face](https://huggingface.co/).
 # ComfyUI will look for these models in the `models` subdirectory under specific subdirectories
 # (e.g. `vae`, `unet`, `clip`, etc.), so we need to download them into the correct location.
 #
 # You can run multiple commands using comma separated commands in `.run_commands()`.
 # But here we opt to split them up to allow for more granular layer caching in the Modal Image.
 # By appending a model install using `.run_commands(...)` at the end of this build step we ensure
-# that the previous steps remain un changed and will be cached, avoiding unnecessary re-runs.
+# that the previous steps remain un-changed and will be cached, avoiding unnecessary re-runs.
 
 image = (
     image.run_commands(
@@ -104,11 +103,12 @@ image = (
     # Add .run_commands(...) calls for any other models you want to download
 )
 
-# ### Downloading custom nodes
+# #### Downloading custom nodes
 #
 # We'll download custom nodes using `comfy-cli` too.
-# Alternatively, you can install them by cloning the git repositories to your /root/comfy/ComfyUI/custom_nodes
-# directory and installing the required dependencies manually.
+# (alternatively, you can install them by cloning the git repositories to your `/root/comfy/ComfyUI/custom_nodes`
+# directory and installing the required dependencies manually.)
+#
 # Similarly to models, we opt to split the custom node installation into separate `.run_commands(...)` calls
 # to allow for more granular layer caching.
 
@@ -119,7 +119,7 @@ image = (
     # Add .run_commands(...) calls for any other custom nodes you want to download
 )
 
-# ### Adding more dependencies
+# #### Adding more dependencies
 #
 # To add more dependencies, models or custom nodes without having to rebuild the entire image
 # it's recommended to append them at the end of your image build rather than modifying previous steps.
@@ -132,12 +132,17 @@ image = (
     # .apt_install(...)
 )
 
-app = modal.App(name="example-comfyui", image=image)
+# #### Create the app
+#
+# We create the app and specify the image we built above.
 
+app = modal.App(name="example-comfyui", image=image)
 
 # ## Running ComfyUI interactively and as an API on Modal
 #
 # To run ComfyUI interactively, simply wrap the `comfy launch` command in a Modal Function and serve it as a web server.
+
+
 @app.function(
     allow_concurrent_inputs=10,
     concurrency_limit=1,

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -60,9 +60,9 @@ import modal
 # We start from a base image and specify all of our dependencies.
 # We'll call out the interesting ones as they come up below.
 #
-# Note that these dependencies are not installed locally
-# they are only installed once in the remote environment where our app runs,
-# on subsequent runs, the image will be cached and reused.
+# Note that these dependencies are not installed locally.
+# They are only installed in the remote environment where our app runs.
+# This happens the first time. On subsequent runs, the cached image will be reused.
 
 
 image = (  # build up a Modal Image to run ComfyUI, step by step
@@ -106,8 +106,8 @@ image = (
 # #### Downloading custom nodes
 #
 # We'll download custom nodes using `comfy-cli` too.
-# (alternatively, you can install them by cloning the git repositories to your `/root/comfy/ComfyUI/custom_nodes`
-# directory and installing the required dependencies manually.)
+# Alternatively, you can install them by cloning the git repositories to your `/root/comfy/ComfyUI/custom_nodes`
+# directory and installing the required dependencies manually.
 #
 # Similarly to models, we opt to split the custom node installation into separate `.run_commands(...)` calls
 # to allow for more granular layer caching.

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -193,7 +193,6 @@ class ComfyUI:
 # COMFY_MODELS_PATH = f"{COMFY_PATH}/models"
 
 # custom_nodes_to_install = [
-#     "ComfyUI_bnb_nf4_fp4_Loaders",
 #     "image-resize-comfyui",
 # ]
 
@@ -201,7 +200,7 @@ class ComfyUI:
 # models_to_download = [
 #     {
 #         "repo_id": "black-forest-labs/FLUX.1-dev",
-#         "filename": "ae.safetensors",  # high ram usage
+#         "filename": "ae.safetensors",
 #         "revision": "main",
 #         "local_dir": f"{COMFY_MODELS_PATH}/vae",
 #     },
@@ -255,6 +254,8 @@ class ComfyUI:
 #     # We delete the models directory
 #     # since we are going to mount a volume of models into it
 #     .run_commands(f"rm -rf {COMFY_MODELS_PATH}")
+#     # We use a custom function to install the nodes
+#     # since we need to mount a volume of models into the container
 #     .run_function(
 #         install_nodes,
 #         args=[custom_nodes_to_install],

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -188,6 +188,10 @@ class ComfyUI:
 
 # ### Store models in a volume
 
+# We can also store the models in a volume to avoid downloading them when we update earlier steps in the image.
+# As a side effect this allows you to cache models between apps as well.
+# And here we use huggingface to download models, allowing us to download models that require a token.
+
 # ```python
 # COMFY_PATH = "/root/comfy/ComfyUI"
 # COMFY_MODELS_PATH = f"{COMFY_PATH}/models"


### PR DESCRIPTION
~Basically adding parts of [this gist](https://gist.github.com/kramstrom/a3784d8246948db647e7e66df980d090) as further improvements to our comfy example. It does mainly two things:~
~- store model weights on a volume so that they can be re-used across different apps and allows you to change your image however you want it without having to re-download everything~
~- it changes the model downloading to use huggingface helpers instead which allows you to pass in a huggingface token and download protected models~


~Not sure if these fit best as inline code here or if the gist should be its own example / guide / blog post or scrapped completely and just remain as a gist.~

Updated the example instead to split up the image building steps into multiple & explain each step more thoroughly and how users should add new models and custom nodes without having to rebuild the whole image (which is why users want to store them on volumes in the first place)

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
