### PR TITLE
FIX minor bug in stable_diffusion_xl.py

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_diffusion_xl.py
@@ -157,7 +157,7 @@ def main(prompt: str = "Unicorns and leprechauns sign a peace treaty"):
     if not dir.exists():
         dir.mkdir(exist_ok=True, parents=True)
 
-    output_path = dir / "output.png"
+    output_path = dir / "output.jpg"
     print(f"Saving it to {output_path}")
     with open(output_path, "wb") as f:
         f.write(image_bytes)


### PR DESCRIPTION
The `inference` function saves the PIL image with format jpeg. The `web_inference` function sets an `image/jpeg` content type. The `main` cli entrypoint saves these *bytes* as a png. Doesn't actually matter in almost every case since file name isn't really used in python for inferring format, or in general. But this fixes it for clarity

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

