### PR TITLE
partial rewrite of hp sweep example

### DIFF
--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -293,10 +293,7 @@ def log_evals(result, step, t_last, val_writer, train_writer):
     return result
 
 
-def save_checkpoint(
-    checkpoint,
-    checkpoint_path,
-):
+def save_checkpoint(checkpoint, checkpoint_path):
     torch.save(checkpoint, checkpoint_path)
     volume.commit()
 

--- a/06_gpu_and_ml/hyperparameter-sweep/model.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/model.py
@@ -89,9 +89,16 @@ class Dataset(object):
             losses = torch.zeros(self.n_eval_steps)
             for k in range(self.n_eval_steps):
                 xb, yb = self.get_batch(split)
-                logits, loss = model.forward(xb, yb)  # Modal: Why need forward?
+                logits, loss = model.forward(xb, yb)
                 losses[k] = loss
             out[split] = losses.mean()
+        torch_input = torch.tensor(self.encode("HAMLET:\n"), dtype=torch.long)
+        torch_input = torch_input.view(1, len(torch_input))  # add batch dim
+        torch_input = torch_input.to(self.device)
+        out["sample"] = "".join(
+            self.decode(model.generate(torch_input, 100)[0].tolist())
+        )
+
         model.train()
         return out
 


### PR DESCRIPTION
Some improvements, but still needs some more love fyi @ShariqM

- Re-organizes most of the training code. But the training is still pretty complex in a way that distracts from the core point. Maybe we want to separate those into modules we can import, like we do with the model?

- The logging of node info in messages is nice, but passing it around as `prepend_logs` is annoying and  made it hard to abstract the training code. I moved it into the `L.basicConfig` call because I couldn't find another way to handle it. But that config is global in the Python process, which means 1) when we call `train_model.remote` again to train the final model, we get that node's initial rank back and 2) we actually don't always end up with 8 nodes (if checkpoints are fast enough that containers get reused).

- Adds logging of output text during training. You really want to be able to look at model outputs to get an intuitive sense of quality.

Like this:
<img width="1155" alt="Screenshot 2024-10-02 at 7 53 25 PM" src="https://github.com/user-attachments/assets/6fd432e5-9689-4efb-84af-72941a1f82b6">

- But I ended up needing to replicate the generation logic. I think we could re-jigger the interface for the model to make it easier to use in multiple ways -- there should be methods based on tensors, on lists of tokens, and on strings.

- Relatedly, the "encode"/"decode" logic could probably live in a small Tokenizer class.

- Splits up the images -- one for training and inference, one for TensorBoard, and one for the Gradio UI. Descriptions should probably still get moved to where they are used.

- Adds a model for the requests to `web_generate` so that the swagger docs look nicer.