### PR TITLE
Update Tailscale example to use global SOCKS5 Proxy

### DIFF
--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -20,7 +20,7 @@ image = (
     modal.Image.debian_slim()
     .apt_install("curl")
     .run_commands("curl -fsSL https://tailscale.com/install.sh | sh")
-    .pip_install("requests", "PySocks")
+    .pip_install("requests==2.32.3", "PySocks==1.7.1")
     .copy_local_file("./entrypoint.sh", "/root/entrypoint.sh")
     .dockerfile_commands(
         "RUN chmod a+x /root/entrypoint.sh",

--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -17,7 +17,7 @@ import modal
 # Install Tailscale and copy custom entrypoint script ([entrypoint.sh](https://github.com/modal-labs/modal-examples/blob/main/10_integrations/tailscale/entrypoint.sh)). The script must be
 # executable.
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.11")
     .apt_install("curl")
     .run_commands("curl -fsSL https://tailscale.com/install.sh | sh")
     .pip_install("requests==2.32.3", "PySocks==1.7.1")


### PR DESCRIPTION
Updates Tailscale example to patch the Python socket library to use the Tailscale SOCKS5 proxy. This generalizes the example to other uses other than `requests`.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
