### PR TITLE
switch to a higher param count, lower quant model

### DIFF
--- a/06_gpu_and_ml/llm-serving/download_llama.py
+++ b/06_gpu_and_ml/llm-serving/download_llama.py
@@ -5,8 +5,8 @@ import modal
 
 MODELS_DIR = "/llamas"
 
-DEFAULT_NAME = "neuralmagic/Llama-3.2-3B-Instruct-quantized.w8a8"
-DEFAULT_REVISION = "1c42cac61b517e84efa30e3e90f00076045d5a89"
+DEFAULT_NAME = "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
+DEFAULT_REVISION = "a7c09948d9a632c2c840722f519672cd94af885d"
 
 volume = modal.Volume.from_name("llamas", create_if_missing=True)
 

--- a/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
@@ -25,7 +25,7 @@ class WebsiteUser(locust.HttpUser):
     @locust.task
     def chat_completion(self):
         payload = {
-            "model": "Llama-3.2-3B-Instruct-quantized.w8a8",
+            "model": "Meta-Llama-3.1-8B-Instruct-quantized.w4a16",
             "messages": messages,
         }
 


### PR DESCRIPTION
The new w4a16 quants from Neural Magic are supported in vLLM and give us roughly the same performance and storage size for an 8B model as we had for a w8a8 quant of a 3B model.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)