### PR TITLE
Update comfyclient url arg

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyclient.py
+++ b/06_gpu_and_ml/comfyui/comfyclient.py
@@ -10,19 +10,18 @@ import time
 
 import requests
 
-OUTPUT_DIR = pathlib.Path("/tmp/comfyui")
+OUTPUT_DIR = pathlib.Path("./output")
 OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
 
 
 def main(args: argparse.Namespace):
-    url = f"https://{args.modal_workspace}--example-comfyui-comfyui-api{'-dev' if args.dev else ''}.modal.run/"
     data = {
         "prompt": args.prompt,
     }
-    print(f"Sending request to {url} with prompt: {data['prompt']}")
+    print(f"Sending request to {args.url} with prompt: {data['prompt']}")
     print("Waiting for response...")
     start_time = time.time()
-    res = requests.post(url, json=data)
+    res = requests.post(args.url, json=data)
     if res.status_code == 200:
         end_time = time.time()
         print(
@@ -33,7 +32,7 @@ def main(args: argparse.Namespace):
         print(f"saved to '{filename}'")
     else:
         if res.status_code == 404:
-            print(f"Workflow API not found at {url}")
+            print(f"Workflow API not found at {args.url}")
         res.raise_for_status()
 
 
@@ -41,21 +40,16 @@ def parse_args(arglist: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--modal-workspace",
+        "--url",
         type=str,
         required=True,
-        help="Name of the Modal workspace with the deployed app. Run `modal profile current` to check.",
+        help="URL of the deployed ComfyUI app.",
     )
     parser.add_argument(
         "--prompt",
         type=str,
         required=True,
         help="Prompt for the image generation model.",
-    )
-    parser.add_argument(
-        "--dev",
-        action="store_true",
-        help="use this flag when running the ComfyUI server in development mode with `modal serve`",
     )
 
     return parser.parse_args(arglist[1:])

--- a/06_gpu_and_ml/comfyui/comfyclient.py
+++ b/06_gpu_and_ml/comfyui/comfyclient.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["python", "06_gpu_and_ml/comfyui/comfyclient.py", "--modal-workspace", "modal-labs", "--prompt", "Spider-Man visits Yosemite, rendered by Blender, trending on artstation"]
+# cmd: ["python", "06_gpu_and_ml/comfyui/comfyclient.py", "--url", "https://modal-labs--example-comfyui-ui.modal.run", "--prompt", "Spider-Man visits Yosemite, rendered by Blender, trending on artstation"]
 # output-directory: "/tmp/comfyui"
 # ---
 
@@ -10,7 +10,7 @@ import time
 
 import requests
 
-OUTPUT_DIR = pathlib.Path("./output")
+OUTPUT_DIR = pathlib.Path("/tmp/comfyui")
 OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
 
 

--- a/06_gpu_and_ml/comfyui/comfyclient.py
+++ b/06_gpu_and_ml/comfyui/comfyclient.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["python", "06_gpu_and_ml/comfyui/comfyclient.py", "--url", "https://modal-labs--example-comfyui-ui.modal.run", "--prompt", "Spider-Man visits Yosemite, rendered by Blender, trending on artstation"]
+# cmd: ["python", "06_gpu_and_ml/comfyui/comfyclient.py", "--url", "https://modal-labs--example-comfyui-comfyui-api.modal.run", "--prompt", "Spider-Man visits Yosemite, rendered by Blender, trending on artstation"]
 # output-directory: "/tmp/comfyui"
 # ---
 


### PR DESCRIPTION
The way the `comfyclient.py` helper file for the comfy example builds the url is incorrect as it doesn't take the environment into consideration. We could change it to do that as well but IMO it's just confusing having to pass workspace / environment / dev etc instead of just the url directly.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
