### PR TITLE
fixes to message ordering

### DIFF
--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -285,7 +285,7 @@ class Model:
     def generate_response(self, message, session, image):
         chatbot_message = get_chatbot_message_with_image(message, image)
         query = self.qwen2_vl_processor.apply_chat_template(
-            [chatbot_message, *session.messages],
+            [*session.messages, chatbot_message],
             tokenize=False,
             add_generation_prompt=True,
         )
@@ -299,7 +299,7 @@ class Model:
         inputs = inputs.to("cuda:0")
 
         generated_ids = self.qwen2_vl_model.generate(
-            **inputs, max_new_tokens=128
+            **inputs, max_new_tokens=512
         )
         generated_ids_trimmed = [
             out_ids[len(in_ids) :]


### PR DESCRIPTION
### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

I edited the chatbot message history (and max tokens) to assist in my Peanut squirrel video 

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
