### PR TITLE
Fix errors in text-to-pokemon example

### DIFF
--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/config.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/config.py
@@ -199,6 +199,7 @@ image = (
         "colorgram.py",
         "diffusers~=0.11.1",
         "ftfy",
+        "huggingface_hub~=0.21.1",
         "torch",
         "transformers",
         "scipy",

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Callout.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/Callout.svelte
@@ -40,10 +40,6 @@
         margin-right: 0.5em;
     }
 
-    .callout p {
-        margin: 0;
-    }
-
     .callout {
         display: inline-flex;
         align-items: center;

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/PrefillPrompt.svelte
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/frontend/src/lib/components/PrefillPrompt.svelte
@@ -8,7 +8,7 @@
     export let highlighted;
 </script>
 
-<li class="autocomplete-items" class:autocomplete-active={highlighted} on:click>
+<li class="autocomplete-items" class:autocomplete-active={highlighted} on:click on:keyup>
     {@html itemLabel}
 </li>
 

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -152,7 +152,6 @@ def fastapi_app():
 @app.function(
     image=inpaint.cv_image,
     volumes={config.CACHE_DIR: volume},
-    interactive=False,
 )
 def inpaint_new_pokemon_name(card_image: bytes, prompt: str) -> bytes:
     """


### PR DESCRIPTION
This fixes some errors encountered in the `text-to-pokemon` example.

Pin `huggingface_hub` dependency to fix this dependency issue:

> ImportError("cannot import name 'cached_download' from 'huggingface_hub' ...)

Remove the deprecated `interactive=False` attribute:

> TypeError: _App.function() got an unexpected keyword argument 'interactive'

And some minor changes to the svelte code:

> [..] frontend/src/lib/components/PrefillPrompt.svelte:11:0 A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.
> [..] frontend/src/lib/components/Callout.svelte:43:4 Unused CSS selector ".callout p"

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`