### PR TITLE
Restructure multi-image examples to hide fastapi import

### DIFF
--- a/07_web_endpoints/chatbot_spa.py
+++ b/07_web_endpoints/chatbot_spa.py
@@ -18,10 +18,7 @@ import uuid
 from pathlib import Path
 from typing import Optional, Tuple
 
-import fastapi
 import modal
-from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
 
 assets_path = Path(__file__).parent / "chatbot_spa"
 app = modal.App("example-chatbot-spa")
@@ -61,6 +58,10 @@ with gpu_image.imports():
 )
 @modal.asgi_app()
 def transformer():
+    import fastapi
+    from fastapi.responses import JSONResponse
+    from fastapi.staticfiles import StaticFiles
+
     app = fastapi.FastAPI()
 
     @app.post("/chat")

--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -238,9 +238,6 @@ def main(
 # To set up your own, run `modal deploy cloud_bucket_mount_loras.py` and navigate to the URL it prints out.
 # If you're playing with the code, use `modal serve` instead to see changes live.
 
-from fastapi import FastAPI
-
-web_app = FastAPI()
 web_image = modal.Image.debian_slim().pip_install(
     "fastapi[standard]==0.115.4", "gradio~=4.29.0", "pillow~=10.2.0"
 )
@@ -262,6 +259,7 @@ def ui():
     import io
 
     import gradio as gr
+    from fastapi import FastAPI
     from gradio.routes import mount_gradio_app
     from PIL import Image
 
@@ -314,7 +312,7 @@ def ui():
         allow_flagging="never",
     )
 
-    return mount_gradio_app(app=web_app, blocks=iface, path="/")
+    return mount_gradio_app(app=FastAPI(), blocks=iface, path="/")
 
 
 def as_slug(name):


### PR DESCRIPTION
### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

Follow-up to https://github.com/modal-labs/modal-examples/pull/951. A few examples were still failing with the 2024.10 Image Builder because they had multiple images and imported `fastapi` in global scope, so the imports failed when running on the images without it.