### PR TITLE
moves class definition into loop, it's slower

### DIFF
--- a/06_gpu_and_ml/torch_profiling.py
+++ b/06_gpu_and_ml/torch_profiling.py
@@ -82,12 +82,12 @@ def underutilize(scale=1):
         scale * 100, scale * 100, device="cuda"
     )
 
-    class Record:  # 🐌 1: creating a Python object in the hot loop
-        def __init__(self, value):
-            self.value = value
-
     for ii in range(10):
         x = x @ x
+
+        class Record:  # 🐌 1: heavy Python work in the hot loop
+            def __init__(self, value):
+                self.value = value
 
         records.append(Record(ii))
 


### PR DESCRIPTION
Move the `class Record` definition into the matmul loop -- it takes longer.

That was the original intent, cf. the text on optimization in "Improving the performance". I moved it out while measuring the difference and forgot to put it back.