### PR TITLE
enables environment variable configuration in frontmatter

### DIFF
--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -2,7 +2,7 @@
 # cmd: ["modal", "run", "13_sandboxes.codelangchain.agent", "--question", "Use gpt2 and transformers to generate text"]
 # tags: ["featured", "use-case-sandboxed-code-execution"]
 # pytest: false
-# env: {MODAL_AUTOMOUNT: True}
+# env: {"MODAL_AUTOMOUNT": "True"}
 # ---
 
 # # Build a coding agent with Modal Sandboxes and LangGraph

--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -2,6 +2,7 @@
 # cmd: ["modal", "run", "13_sandboxes.codelangchain.agent", "--question", "Use gpt2 and transformers to generate text"]
 # tags: ["featured", "use-case-sandboxed-code-execution"]
 # pytest: false
+# env: {MODAL_AUTOMOUNT: True}
 # ---
 
 # # Build a coding agent with Modal Sandboxes and LangGraph

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -34,6 +34,9 @@ class Example(BaseModel):
     cli_args: Optional[list] = None  # Full command line args to run it
     stem: Optional[str] = None  # stem of path
     tags: Optional[list[str]] = None  # metadata tags for the example
+    env: Optional[
+        dict[str, str]
+    ] = None  # environment variables for the example
 
 
 _RE_NEWLINE = re.compile(r"\r?\n")
@@ -119,6 +122,7 @@ def gather_example_files(
                 cmd = metadata.get("cmd", ["modal", "run", repo_filename])
                 args = metadata.get("args", [])
                 tags = metadata.get("tags", [])
+                env = metadata.get("env", dict())
                 yield Example(
                     type=ExampleType.MODULE,
                     filename=filename_abs,
@@ -128,6 +132,7 @@ def gather_example_files(
                     cli_args=(cmd + args),
                     stem=Path(filename_abs).stem,
                     tags=tags,
+                    env=env,
                 )
             elif ext in [".png", ".jpeg", ".jpg", ".gif", ".mp4"]:
                 yield Example(


### PR DESCRIPTION
This will allow customization of Modal environment variables.

In this PR, I add `MODAL_AUTOMOUNT` for the `codelangchain/agent` example. I intend to use this to migrate the `MODAL_ENVIRONMENT` for examples incrementally.