### PR TITLE
Bump the version of the tensorflow image in our tensorflow example

### DIFF
--- a/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
+++ b/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
@@ -28,8 +28,8 @@ import time
 import modal
 
 dockerhub_image = modal.Image.from_registry(
-    "tensorflow/tensorflow:2.12.0-gpu",
-).pip_install("protobuf==3.20.*")
+    "tensorflow/tensorflow:2.15.0-gpu",
+)
 
 app = modal.App("example-tensorflow-tutorial", image=dockerhub_image)
 


### PR DESCRIPTION
This example runs on Python 3.8, which we're about to drop support for.

I picked an arbitrary "newer but not too new" version which we seem to be able to run the example to completion on. My depth of knowledge is shallow here though! The code doesn't crash and the loss goes down; what more can you ask for? 

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

