### PR TITLE
Use the Node version specified in nvmrc to build

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: modal/.nvmrc
 
       - name: Install node packages
         run: npm ci --include=dev


### PR DESCRIPTION
We're updating from Node 18 to Node 22 LTS. Using the `.nvmrc` file to keep this step consistent and avoid having to change it in multiple places in the future.

This won't work until https://github.com/modal-labs/modal/pull/17482 is deployed.