### PR TITLE
stop slandering H100s

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -151,7 +151,7 @@ CONVERSION_SCRIPT_URL = f"https://raw.githubusercontent.com/NVIDIA/TensorRT-LLM/
 # NVIDIA's Ada Lovelace/Hopper chips, like the 4090, L40S, and H100,
 # are capable of native calculations in 8bit floating point numbers, so we choose that as our quantization format (`qformat`).
 # These GPUs are capable of twice as many floating point operations per second in 8bit as in 16bit --
-# about a trillion per second on an H100.
+# about two quadrillion per second on an H100 SXM.
 
 N_GPUS = 1  # Heads up: this example has not yet been tested with multiple GPUs
 GPU_CONFIG = modal.gpu.H100(count=N_GPUS)


### PR DESCRIPTION
Messed up my SI prefixes -- peta is _quadrillion_, not trillion.

For the record: the [H100 datasheet](https://resources.nvidia.com/en-us-tensor-core/nvidia-tensor-core-gpu-datasheet) from NVIDIA reports ~4 petaFLOPS "with sparsity". The rule of thumb is to cut in half for the much more typical dense case, cf Stas Bekman's ML Engineering notes.