### PR TITLE
remove deployment from apps that don't need it

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["modal", "serve", "06_gpu_and_ml/comfyui/comfyapp.py"]
-# deploy: true
 # ---
 #
 # # Run Flux on ComfyUI interactively and as an API

--- a/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
+++ b/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["modal", "serve", "06_gpu_and_ml/controlnet/controlnet_gradio_demos.py"]
-# deploy: false
 # tags: ["use-case-image-video-3d", "featured"]
 # ---
 #

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # cmd: ["modal", "run", "06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py", "--n-steps", "200", "--n-steps-before-checkpoint", "50", "--n-steps-before-eval", "50"]
 # ---
 

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -1,7 +1,3 @@
-# ---
-# deploy: true
-# ---
-
 # # Chat with PDF: RAG with ColQwen2
 
 # In this example, we demonstrate how to use the the [ColQwen2](https://huggingface.co/vidore/colqwen2-v0.1) model to build a simple

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # tags: ["use-case-lm-inference", "use-case-image-video-3d"]
 # ---
 # # Run LLaVA-Next on SGLang for Visual QA

--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -1,4 +1,5 @@
 # ---
+# deploy: true
 # tags: ["use-case-lm-inference"]
 # ---
 

--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # tags: ["use-case-lm-inference"]
 # ---
 

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # cmd: ["modal", "serve", "06_gpu_and_ml/llm-serving/vllm_inference.py"]
 # pytest: false
 # tags: ["use-case-lm-inference", "featured"]

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -16,7 +16,7 @@
 #
 # ## Live demo
 #
-# [Take a look at the deployed app](https://modal-labs-example-webcam-object-detection-fastapi-app.modal.run/).
+# [Take a look at the deployed app](https://modal-labs--example-webcam-object-detection-fastapi-app.modal.run/).
 #
 # A couple of caveats:
 # * This is not optimized for latency: every prediction takes about 1s, and

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -2,7 +2,6 @@
 # output-directory: "/tmp/stable-diffusion"
 # args: ["--prompt", "A 1600s oil painting of the New York City skyline"]
 # tags: ["use-case-image-video-3d"]
-# deploy: true
 # ---
 
 # # Run Stable Diffusion 3.5 Large Turbo as a CLI, API, and web UI

--- a/07_web_endpoints/count_faces.py
+++ b/07_web_endpoints/count_faces.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # cmd: ["modal", "serve", "07_web_endpoints/count_faces.py"]
 # ---
 

--- a/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
+++ b/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
@@ -1,5 +1,6 @@
 # ---
 # cmd: ["modal", "serve", "07_web_endpoints.fasthtml-checkboxes.fasthtml_checkboxes"]
+# deploy: true
 # mypy: ignore-errors
 # ---
 

--- a/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
+++ b/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # cmd: ["modal", "serve", "07_web_endpoints.fasthtml-checkboxes.fasthtml_checkboxes"]
 # mypy: ignore-errors
 # ---

--- a/07_web_endpoints/fasthtml_app.py
+++ b/07_web_endpoints/fasthtml_app.py
@@ -1,5 +1,4 @@
 # ---
-# deploy: true
 # cmd: ["modal", "serve", "07_web_endpoints/fasthtml_app.py"]
 # ---
 

--- a/10_integrations/streamlit/serve_streamlit.py
+++ b/10_integrations/streamlit/serve_streamlit.py
@@ -82,5 +82,5 @@ def run():
 # modal deploy serve_streamlit.py
 # ```
 #
-# If successful, this will print a URL for your app, that you can navigate to from
+# If successful, this will print a URL for your app that you can navigate to from
 # your browser 🎉 .


### PR DESCRIPTION
I got in the habit of adding this flag just so that there'd be a deployment available, but it doesn't meaningfully improve testing or monitoring in most cases and it clutters up our `main` environment.

A few small typo fixes are also included in this PR.