### PR TITLE
removes unused 'tags' tag

### DIFF
--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -1,6 +1,5 @@
 # ---
 # lambda-test: false
-# tags: ["featured"]
 # ---
 # # Run cron jobs in the cloud to search Hacker News
 

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -1,6 +1,5 @@
 # ---
 # output-directory: "/tmp/render"
-# tags: ["use-case-image-video-3d"]
 # ---
 # # Render a video with Blender on many GPUs or CPUs in parallel
 #

--- a/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
+++ b/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["modal", "serve", "06_gpu_and_ml/controlnet/controlnet_gradio_demos.py"]
-# tags: ["use-case-image-video-3d", "featured"]
 # ---
 #
 # # Play with the ControlNet demos

--- a/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
+++ b/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
@@ -1,6 +1,5 @@
 # ---
 # deploy: true
-# tags: ["use-case-image-video-3d", "use-case-finetuning", "featured"]
 # ---
 
 # # Create a character LoRA for Flux with Hugging Face and Gradio

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -1,8 +1,3 @@
-# ---
-# runtimes: ["runc", "gvisor"]
-# tags: ["use-case-finetuning", "use-case-lm-inference"]
-# ---
-#
 # # Finetuning Flan-T5
 #
 # Example by [@anishpdalal](https://github.com/anishpdalal)

--- a/06_gpu_and_ml/langchains/potus_speech_qanda.py
+++ b/06_gpu_and_ml/langchains/potus_speech_qanda.py
@@ -1,7 +1,6 @@
 # ---
 # deploy: true
 # args: ["--query", "How many oil barrels were released from reserves?"]
-# tags: ["featured"]
 # ---
 
 # # Retrieval-augmented generation (RAG) for question-answering with LangChain

--- a/06_gpu_and_ml/llm-serving/llama_cpp.py
+++ b/06_gpu_and_ml/llm-serving/llama_cpp.py
@@ -1,6 +1,3 @@
-# ---
-# tags: ["use-case-lm-inference"]
-# ---
 # # Run `llama.cpp` on Modal
 
 # [`llama.cpp`](https://github.com/ggerganov/llama.cpp) is a C++ library for running LLM inference.

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -1,6 +1,3 @@
-# ---
-# tags: ["use-case-lm-inference", "use-case-image-video-3d"]
-# ---
 # # Run LLaVA-Next on SGLang for Visual QA
 #
 # Vision-Language Models (VLMs) are like LLMs with eyes:

--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -1,6 +1,5 @@
 # ---
 # deploy: true
-# tags: ["use-case-lm-inference"]
 # ---
 
 # # Serverless TensorRT-LLM (LLaMA 3 8B)

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -1,7 +1,6 @@
 # ---
 # cmd: ["modal", "serve", "06_gpu_and_ml/llm-serving/vllm_inference.py"]
 # pytest: false
-# tags: ["use-case-lm-inference", "featured"]
 # ---
 
 # # Run OpenAI-compatible LLM inference with LLaMA 3.1-8B and vLLM

--- a/06_gpu_and_ml/llm-structured/instructor_generate.py
+++ b/06_gpu_and_ml/llm-structured/instructor_generate.py
@@ -1,6 +1,5 @@
 # ---
 # output-directory: "/tmp/instructor_generate"
-# tags: ["use-case-lm-inference"]
 # ---
 
 # # Structured Data Extraction using `instructor`

--- a/06_gpu_and_ml/llm-structured/outlines_generate.py
+++ b/06_gpu_and_ml/llm-structured/outlines_generate.py
@@ -1,6 +1,3 @@
-# ---
-# tags: ["use-case-lm-inference"]
-# ---
 # # Enforcing JSON outputs on LLMs
 
 # [Outlines](https://github.com/outlines-dev/outlines) is a tool that lets you control the generation of language models to make their output more predictable.

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -1,7 +1,6 @@
 # ---
 # cmd: ["modal", "serve", "06_gpu_and_ml/obj_detection_webcam/webcam.py"]
 # deploy: true
-# tags: ["use-case-image-video-3d", "featured"]
 # ---
 # # Real-time object detection via webcam
 #

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -1,7 +1,6 @@
 # ---
 # output-directory: "/tmp/flux"
 # args: ["--no-compile"]
-# tags: ["use-case-image-video-3d", "featured"]
 # ---
 
 # # Run Flux fast on H100s with `torch.compile`

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -1,6 +1,5 @@
 # ---
 # output-directory: "/tmp/stable-diffusion"
-# tags: ["use-case-image-video-3d"]
 # ---
 
 # # Transform images with SDXL Turbo

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -1,7 +1,6 @@
 # ---
 # output-directory: "/tmp/stable-diffusion"
 # args: ["--prompt", "A 1600s oil painting of the New York City skyline"]
-# tags: ["use-case-image-video-3d"]
 # ---
 
 # # Run Stable Diffusion 3.5 Large Turbo as a CLI, API, and web UI

--- a/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
+++ b/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
@@ -1,7 +1,5 @@
 # ---
 # args: ["--just-run"]
-# runtimes: ["runc", "gvisor"]
-# tags: ["use-case-image-video-3d"]
 # ---
 # # TensorFlow tutorial
 #

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -1,6 +1,5 @@
 # ---
 # args: ["--no-quick-check"]
-# tags: ["use-case-image-video-3d", "use-case-finetuning"]
 # ---
 # # Fine-tune open source YOLO models for object detection
 #

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -1,6 +1,5 @@
 # ---
 # deploy: true
-# tags: ["use-case-image-video-3d", "use-case-job-queues-batch", "featured"]
 # ---
 #
 # # Document OCR job queue

--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -1,7 +1,6 @@
 # ---
 # output-directory: "/tmp/stable-diffusion-xl"
 # deploy: true
-# tags: ["use-case-image-video-3d"]
 # ---
 # # LoRAs Galore: Create a LoRA Playground with Modal, Gradio, and S3
 #

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -1,7 +1,5 @@
 # ---
 # deploy: true
-# runtimes: ["runc", "gvisor"]
-# tags: ["use-case-job-queues-batch"]
 # ---
 # # Publish interactive datasets with Datasette
 #

--- a/10_integrations/dbt/dbt_duckdb.py
+++ b/10_integrations/dbt/dbt_duckdb.py
@@ -1,6 +1,5 @@
 # ---
 # deploy: true
-# tags: ["use-case-job-queues-batch"]
 # ---
 # # Build your own data warehouse with DuckDB, DBT, and Modal
 #

--- a/10_integrations/s3_bucket_mount.py
+++ b/10_integrations/s3_bucket_mount.py
@@ -1,6 +1,5 @@
 # ---
 # output-directory: "/tmp/s3_bucket_mount"
-# tags: ["use-case-job-queues-batch", "featured"]
 # ---
 # # Analyze NYC yellow taxi data with DuckDB on Parquet files from S3
 #

--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["modal", "run", "13_sandboxes.codelangchain.agent", "--question", "Use gpt2 and transformers to generate text"]
-# tags: ["featured", "use-case-sandboxed-code-execution"]
 # pytest: false
 # env: {"MODAL_AUTOMOUNT": "True"}
 # ---

--- a/13_sandboxes/jupyter_sandbox.py
+++ b/13_sandboxes/jupyter_sandbox.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["python", "13_sandboxes/jupyter_sandbox.py"]
-# tags: ["use-case-sandboxed-code-execution"]
 # pytest: false
 # ---
 

--- a/13_sandboxes/safe_code_execution.py
+++ b/13_sandboxes/safe_code_execution.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["python", "13_sandboxes/safe_code_execution.py"]
-# tags: ["use-case-sandboxed-code-execution"]
 # pytest: false
 # ---
 

--- a/13_sandboxes/simple_code_interpreter.py
+++ b/13_sandboxes/simple_code_interpreter.py
@@ -1,6 +1,5 @@
 # ---
 # cmd: ["python", "13_sandboxes/simple_code_interpreter.py"]
-# tags: ["use-case-sandboxed-code-execution"]
 # pytest: false
 # ---
 


### PR DESCRIPTION
and removes a few stray `runtimes` tags that we don't need anymore, since all examples are run in `gvisor`.