### PR TITLE
write whitespace in markdown as blank lines, not empty comments

### DIFF
--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -1,13 +1,14 @@
 # ---
 # lambda-test: false
 # ---
+
 # # Run cron jobs in the cloud to search Hacker News
 
 # In this example, we use Modal to deploy a cron job that periodically queries Hacker News for
 # new posts matching a given search term, and posts the results to Slack.
 
 # ## Import and define the app
-#
+
 # Let's start off with imports, and defining a Modal app.
 
 import os
@@ -23,12 +24,12 @@ app = modal.App("example-hn-bot")
 slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 
 # ## Defining the function and importing the secret
-#
+
 # Our Slack bot will need access to a bot token. We can use Modal's [Secrets](/secrets) interface to accomplish this.
 # To quickly create a Slack bot secret, navigate to the [create secret](/secrets/create) page, select the Slack secret template
 # from the list options, and follow the instructions in the "Where to find the credentials?" panel.
 # Name your secret `hn-bot-slack`, so that the code in this example still works.
-#
+
 # Now, we define the function `post_to_slack`, which simply instantiates the Slack client using our token,
 # and then uses it to post a message to a given channel name.
 
@@ -44,7 +45,7 @@ async def post_to_slack(message: str):
 
 
 # ## Searching Hacker News
-#
+
 # We are going to use Algolia's [Hacker News Search API](https://hn.algolia.com/api) to query for posts
 # matching a given search term in the past X days. Let's define our search term and query period.
 
@@ -82,11 +83,11 @@ def search_hackernews():
 
 
 # ## Test running
-#
+
 # We can now test run our scheduled function as follows: `modal run hackernews_alerts.py::app.search_hackernews`
 
 # ## Defining the schedule and deploying
-#
+
 # Let's define a function that will be called by Modal every day
 
 

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -1,23 +1,24 @@
 # ---
 # output-directory: "/tmp/render"
 # ---
+
 # # Render a video with Blender on many GPUs or CPUs in parallel
-#
+
 # This example shows how you can render an animated 3D scene using
 # [Blender](https://www.blender.org/)'s Python interface.
-#
+
 # You can run it on CPUs to scale out on one hundred containers
 # or run it on GPUs to get higher throughput per node.
 # Even for this simple scene, GPUs render 10x faster than CPUs.
-#
+
 # The final render looks something like this:
-#
+
 # <center>
 # <video controls autoplay loop muted>
 # <source src="https://modal-public-assets.s3.amazonaws.com/modal-blender-video.mp4" type="video/mp4">
 # </video>
 # </center>
-#
+
 # ## Defining a Modal app
 
 from pathlib import Path
@@ -41,9 +42,9 @@ rendering_image = (
 )
 
 # ## Rendering a single frame
-#
+
 # We define a function that renders a single frame. We'll scale this function out on Modal later.
-#
+
 # Functions in Modal are defined along with their hardware and their dependencies.
 # This function can be run with GPU acceleration or without it, and we'll use a global flag in the code to switch between the two.
 
@@ -86,7 +87,7 @@ def render(blend_file: bytes, frame_number: int = 0) -> bytes:
 
 
 # ### Rendering with acceleration
-#
+
 # We can configure the rendering process to use GPU acceleration with NVIDIA CUDA.
 # We select the [Cycles rendering engine](https://www.cycles-renderer.org/), which is compatible with CUDA,
 # and then activate the GPU.
@@ -123,7 +124,7 @@ def configure_rendering(ctx, with_gpu: bool):
 
 
 # ## Combining frames into a video
-#
+
 # Rendering 3D images is fun, and GPUs can make it faster, but rendering 3D videos is better!
 # We add another function to our app, running on a different, simpler container image
 # and different hardware, to combine the frames into a video.
@@ -160,19 +161,19 @@ def combine(frames_bytes: list[bytes], fps: int = FPS) -> bytes:
 
 
 # ## Rendering in parallel in the cloud from the comfort of the command line
-#
+
 # With these two functions defined, we need only a few more lines to run our rendering at scale on Modal.
-#
+
 # First, we need a function that coordinates our functions to `render` frames and `combine` them.
 # We decorate that function with `@app.local_entrypoint` so that we can run it with `modal run blender_video.py`.
-#
+
 # In that function, we use `render.map` to map the `render` function over the range of frames,
 # so that the logo will spin in the final video.
-#
+
 # We collect the bytes from each frame into a `list` locally and then send it to `combine` with `.remote`.
-#
+
 # The bytes for the video come back to our local machine, and we write them to a file.
-#
+
 # The whole rendering process (for 4 seconds of 1080p 60 FPS video) takes about five minutes to run on 10 A10G GPUs,
 # with a per-frame latency of about 10 seconds, and about five minutes to run on 100 CPUs, with a per-frame latency of about one minute.
 

--- a/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
+++ b/06_gpu_and_ml/controlnet/controlnet_gradio_demos.py
@@ -1,20 +1,20 @@
 # ---
 # cmd: ["modal", "serve", "06_gpu_and_ml/controlnet/controlnet_gradio_demos.py"]
 # ---
-#
+
 # # Play with the ControlNet demos
-#
+
 # This example allows you to play with all 10 demonstration Gradio apps from the new and amazing ControlNet project.
 # ControlNet provides a minimal interface allowing users to use images to constrain StableDiffusion's generation process.
 # With ControlNet, users can easily condition the StableDiffusion image generation with different spatial contexts
 # including a depth maps, segmentation maps, scribble drawings, and keypoints!
-#
+
 # <center>
 # <video controls>
 # <source src="https://user-images.githubusercontent.com/12058921/222927911-3ab52dd1-f2ee-4fb8-97e8-dafbf96ed5c5.mp4" type="video/mp4">
 # </video>
 # </center>
-#
+
 # ## Imports and config preamble
 
 import importlib
@@ -29,7 +29,7 @@ from fastapi import FastAPI
 # The demos each depend on their own custom pretrained StableDiffusion model, and these models are 5-6GB each.
 # We can only run one demo at a time, so this module avoids downloading the model and 'detector' dependencies for
 # all 10 demos and instead uses the demo configuration object to download only what's necessary for the chosen demo.
-#
+
 # Even just limiting our dependencies setup to what's required for one demo, the resulting container image is *huge*.
 
 
@@ -127,7 +127,7 @@ demos = [
 demos_map: dict[str, DemoApp] = {d.name: d for d in demos}
 
 # ## Pick a demo, any demo
-#
+
 # Simply by changing the `DEMO_NAME` below, you can change which ControlNet demo app is setup
 # and run by this Modal script.
 
@@ -135,21 +135,21 @@ DEMO_NAME = "scribble2image"  # Change this value to change the active demo app.
 selected_demo = demos_map[DEMO_NAME]
 
 # ## Setting up the dependencies
-#
+
 # ControlNet requires *a lot* of dependencies which could be fiddly to setup manually, but Modal's programmatic
 # container image building Python APIs handle this complexity straightforwardly and automatically.
-#
+
 # To run any of the 10 demo apps, we need the following:
-#
+
 # 1. a base Python 3 Linux image (we use Debian Slim)
 # 2. a bunch of third party PyPi packages
 # 3. `git`, so that we can download the ControlNet source code (there's no `controlnet` PyPi package)
 # 4. some image process Linux system packages, including `ffmpeg`
 # 5. and demo specific pre-trained model and detector `.pth` files
-#
+
 # That's a lot! Fortunately, the code below is already written for you that stitches together a working container image
 # ready to produce remarkable ControlNet images.
-#
+
 # **Note:** a ControlNet model pipeline is [now available in Huggingface's `diffusers` package](https://huggingface.co/blog/controlnet). But this does not contain the demo apps.
 
 
@@ -248,7 +248,7 @@ app = modal.App(name="example-controlnet", image=image)
 web_app = FastAPI()
 
 # ## Serving the Gradio web UI
-#
+
 # Each ControlNet gradio demo module exposes a `block` Gradio interface running in queue-mode,
 # which is initialized in module scope on import and served on `0.0.0.0`. We want the block interface object,
 # but the queueing and launched webserver aren't compatible with Modal's serverless web endpoint interface,
@@ -305,9 +305,9 @@ def run():
 
 
 # ## Have fun!
-#
+
 # Serve your chosen demo app with `modal serve controlnet_gradio_demos.py`. If you don't have any images ready at hand,
 # try one that's in the `06_gpu_and_ml/controlnet/demo_images/` folder.
-#
+
 # StableDiffusion was already impressive enough, but ControlNet's ability to so accurately and intuitively constrain
 # the image generation process is sure to put a big, dumb grin on your face.

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -1,19 +1,18 @@
 # # Finetuning Flan-T5
-#
+
 # Example by [@anishpdalal](https://github.com/anishpdalal)
-#
+
 # [Flan-T5](https://huggingface.co/docs/transformers/model_doc/flan-t5) is a highly versatile model that's been instruction-tuned to
 # perform well on a variety of text-based tasks such as question answering and summarization. There are smaller model variants available which makes
 # Flan-T5 a great base model to use for finetuning on a specific instruction dataset with just a single GPU. In this example, we'll
 # finetune Flan-T5 on the [Extreme Sum ("XSum")](https://huggingface.co/datasets/xsum) dataset to summarize news articles.
 
 # ## Defining dependencies
-#
+
 # The example uses the `dataset` package from HuggingFace to load the xsum dataset. It also uses the `transformers`
 # and `accelerate` packages with a PyTorch backend to finetune and serve the model. Finally, we also
 # install `tensorboard` and serve it via a web app. All packages are installed into a Debian Slim base image
 # using the `pip_install` function.
-#
 
 from pathlib import Path
 
@@ -36,12 +35,12 @@ app = modal.App(name="example-news-summarizer", image=image)
 output_vol = modal.Volume.from_name("finetune-volume", create_if_missing=True)
 
 # ### Handling preemption
-#
+
 # As this finetuning job is long-running it's possible that it experiences a preemption.
 # The training code is robust to pre-emption events by periodically saving checkpoints and restoring
 # from checkpoint on restart. But it's also helpful to observe in logs when a preemption restart has occurred,
 # so we track restarts with a `modal.Dict`.
-#
+
 # See the [guide on preemptions](/docs/guide/preemption#preemption) for more details on preemption handling.
 
 restart_tracker_dict = modal.Dict.from_name(
@@ -62,7 +61,7 @@ def track_restarts(restart_tracker: modal.Dict) -> int:
 
 
 # ## Finetuning Flan-T5 on XSum dataset
-#
+
 # Each row in the dataset has a `document` (input news article) and `summary` column.
 
 
@@ -189,10 +188,11 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
 
 
 # ## Monitoring Finetuning with Tensorboard
-#
+
 # Tensorboard is an application for visualizing training loss. In this example we
 # serve it as a Modal WSGI app.
-#
+
+
 @app.function(volumes={VOL_MOUNT_PATH: output_vol})
 @modal.wsgi_app()
 def monitor():
@@ -260,17 +260,17 @@ def main():
 
 
 # ## Run via the CLI
-# Invoke model finetuning use the provided command below
-#
+
+# Trigger model finetuning using the following command:
+
 # ```bash
 # modal run --detach flan_t5_finetune.py::finetune --num-train-epochs=1 --size-percentage=10
 # View the tensorboard logs at https://<username>--example-news-summarizer-monitor-dev.modal.run
 # ```
-#
-# Invoke finetuned model inference via local entrypoint
-#
+
+# Then, you can invoke inference via the `local_entrypoint` with this command:
+
 # ```bash
 # modal run flan_t5_finetune.py
 # World number one Tiger Woods missed the cut at the US Open as he failed to qualify for the final round of the event in Los Angeles.
 # ```
-#

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -1,18 +1,18 @@
 # # Run LLaVA-Next on SGLang for Visual QA
-#
+
 # Vision-Language Models (VLMs) are like LLMs with eyes:
 # they can generate text based not just on other text,
 # but on images as well.
-#
+
 # This example shows how to run a VLM on Modal using the
 # [SGLang](https://github.com/sgl-project/sglang) library.
-#
+
 # Here's a sample inference, with the image rendered directly in the terminal:
-#
+
 # ![Sample output answering a question about a photo of the Statue of Liberty](https://modal-public-assets.s3.amazonaws.com/sgl_vlm_qa_sol.png)
-#
+
 # ## Setup
-#
+
 # First, we'll import the libraries we need locally
 # and define some constants.
 
@@ -27,7 +27,7 @@ import requests
 # VLMs are generally larger than LLMs with the same cognitive capability.
 # LLMs are already hard to run effectively on CPUs, so we'll use a GPU here.
 # We find that inference for a single input takes about 3-4 seconds on an A10G.
-#
+
 # You can customize the GPU type and count using the `GPU_TYPE` and `GPU_COUNT` environment variables.
 # If you want to see the model really rip, try an `"a100-80gb"` or an `"h100"`
 # on a large batch.
@@ -89,14 +89,14 @@ vlm_image = (
 )
 
 # ## Defining a Visual QA service
-#
+
 # Running an inference service on Modal is as easy as writing inference in Python.
-#
+
 # The code below adds a modal `Cls` to an `App` that runs the VLM.
-#
+
 # We define a method `generate` that takes a URL for an image URL and a question
 # about the image as inputs and returns the VLM's answer.
-#
+
 # By decorating it with `@modal.web_endpoint`, we expose it as an HTTP endpoint,
 # so it can be accessed over the public internet from any client.
 
@@ -188,15 +188,15 @@ class Model:
 
 # Now, we can send this Modal Function a POST request with an image and a question
 # and get back an answer.
-#
+
 # The code below will start up the inference service
 # so that it can be run from the terminal as a one-off,
 # like a local script would be, using `modal run`:
-#
+
 # ```bash
 # modal run sgl_vlm.py
 # ```
-#
+
 # By default, we hit the endpoint twice to demonstrate how much faster
 # the inference is once the server is running.
 
@@ -224,21 +224,21 @@ def main(image_url=None, question=None, twice=True):
 
 
 # ## Deployment
-#
+
 # To set this up as a long-running, but serverless, service, we can deploy it to Modal:
-#
+
 # ```bash
 # modal deploy sgl_vlm.py
 # ```
-#
+
 # And then send requests from anywhere. See the [docs](https://modal.com/docs/guide/webhook-urls)
 # for details on the `web_url` of the function, which also appears in the terminal output
 # when running `modal deploy`.
-#
+
 # You can also find interactive documentation for the endpoint at the `/docs` route of the web endpoint URL.
 
 # ## Addenda
-#
+
 # The rest of the code in this example is just utility code.
 
 warnings.filterwarnings(  # filter warning from the terminal image library

--- a/06_gpu_and_ml/llm-structured/outlines_generate.py
+++ b/06_gpu_and_ml/llm-structured/outlines_generate.py
@@ -19,7 +19,7 @@
 # In this guide, we will show how you can use Outlines to enforce a JSON schema on the output of Mistral-7B.
 
 # ## Build image
-#
+
 #  First, you'll want to build an image and install the relevant Python dependencies:
 # `outlines` and a Hugging Face inference stack.
 
@@ -37,7 +37,7 @@ outlines_image = modal.Image.debian_slim(python_version="3.11").pip_install(
 )
 
 # ## Download the model
-#
+
 # Next, we download the Mistral 7B model from Hugging Face.
 # We do this as part of the definition of our Modal Image so that
 # we don't need to download it every time our inference function is run.

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -2,30 +2,31 @@
 # cmd: ["modal", "serve", "06_gpu_and_ml/obj_detection_webcam/webcam.py"]
 # deploy: true
 # ---
+
 # # Real-time object detection via webcam
-#
+
 # This example creates a web endpoint that uses a Huggingface model for object detection.
-#
+
 # The web endpoint takes an image from their webcam, and sends it to a Modal web endpoint.
 # The Modal web endpoint in turn calls a Modal function that runs the actual model.
-#
+
 # If you run this, it will look something like this:
 #
 # ![webcam](./webcam.png)
-#
+
 # ## Live demo
-#
+
 # [Take a look at the deployed app](https://modal-labs--example-webcam-object-detection-fastapi-app.modal.run/).
-#
+
 # A couple of caveats:
 # * This is not optimized for latency: every prediction takes about 1s, and
 #   there's an additional overhead on the first prediction since the containers
 #   have to be started and the model initialized.
 # * This doesn't work on iPhone unfortunately due to some issues with HTML5
 #   webcam components
-#
+
 # ## Code
-#
+
 # Starting with imports:
 
 import base64
@@ -38,7 +39,7 @@ import modal
 # which is a package Huggingface uses for all their models, but also
 # [Pillow](https://python-pillow.org/) which lets us work with images from Python,
 # and a system font for drawing.
-#
+
 # This example uses the `facebook/detr-resnet-50` pre-trained model, which is downloaded
 # once at image build time using the `@build` hook and saved into the image. 'Baking'
 # models into the `modal.Image` at build time provided the fastest cold start.
@@ -60,16 +61,18 @@ image = (
 
 
 # ## Prediction function
-#
+
 # The object detection function has a few different features worth mentioning:
-#
+
 # * There's a container initialization step in the method decorated with `@enter()`,
 #   which runs on every container start. This lets us load the model only once per
 #   container, so that it's reused for subsequent function calls.
+
 # * Above we stored the model in the container image. This lets us download the model only
 #   when the image is (re)built, and not everytime the function is called.
+
 # * We're running it on multiple CPUs for extra performance
-#
+
 # Note that the function takes an image and returns a new image.
 # The input image is from the webcam
 # The output image is an image with all the bounding boxes and labels on them,
@@ -152,13 +155,13 @@ class ObjectDetection:
 
 
 # ## Defining the web interface
-#
+
 # To keep things clean, we define the web endpoints separate from the prediction
 # function. This will introduce a tiny bit of extra latency (every web request
 # triggers a Modal function call which will call another Modal function) but in
 # practice the overhead is much smaller than the overhead of running the prediction
 # function etc.
-#
+
 # We also serve a static html page which contains some tiny bit of Javascript to
 # capture the webcam feed and send it to Modal.
 
@@ -194,9 +197,9 @@ def fastapi_app():
 
 
 # ## Running this locally
-#
+
 # You can run this as an ephemeral app, by running
-#
+
 # ```shell
 # modal serve webcam.py
 # ```

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -84,8 +84,10 @@ with flux_image.imports():
 
 # 1. We run any setup that can be persisted to disk in methods decorated with `@build`.
 # In this example, that includes downloading the model weights.
+
 # 2. We run any additional setup, like moving the model to the GPU, in methods decorated with `@enter`.
 # We do our model optimizations in this step. For details, see the section on `torch.compile` below.
+
 # 3. We run the actual inference in methods decorated with `@method`.
 
 MINUTES = 60  # seconds

--- a/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
+++ b/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
@@ -2,21 +2,21 @@
 # args: ["--just-run"]
 # ---
 # # TensorFlow tutorial
-#
+
 # This is essentially a version of the
 # [image classification example in the TensorFlow documentation](https://www.tensorflow.org/tutorials/images/classification)
 # running inside Modal on a GPU.
 # If you run this script, it will also create an TensorBoard URL you can go to to watch the model train and review the results:
-#
+
 # ![tensorboard](./tensorboard.png)
-#
+
 # ## Setting up the dependencies
-#
+
 # Configuring a system to properly run GPU-accelerated TensorFlow can be challenging.
 # Luckily, Modal makes it easy to stand on the shoulders of giants and
 # [use a pre-built Docker container image](https://modal.com/docs/guide/custom-container#use-an-existing-container-image-with-from_registry) from a registry like Docker Hub.
 # We recommend TensorFlow's [official base Docker container images](https://hub.docker.com/r/tensorflow/tensorflow), which come with `tensorflow` and its matching CUDA libraries already installed.
-#
+
 # If you want to install TensorFlow some other way, check out [their docs](https://www.tensorflow.org/install) for options and instructions.
 # GPU-enabled containers on Modal will always have NVIDIA drivers available, but you will need to add higher-level tools like CUDA and cuDNN yourself.
 # See the [Modal guide on customizing environments](https://modal.com/docs/guide/custom-container) for options we support.
@@ -32,11 +32,11 @@ dockerhub_image = modal.Image.from_registry(
 app = modal.App("example-tensorflow-tutorial", image=dockerhub_image)
 
 # ## Logging data to TensorBoard
-#
+
 # Training ML models takes time. Just as we need to monitor long-running systems like databases or web servers for issues,
 # we also need to monitor the training process of our ML models. TensorBoard is a tool that comes with TensorFlow that helps you visualize
 # the state of your ML model training. It is packaged as a web server.
-#
+
 # We want to run the web server for TensorBoard at the same time as we are training the TensorFlow model.
 # The easiest way to do this is to set up a shared filesystem between the training and the web server.
 
@@ -46,15 +46,17 @@ fs = modal.NetworkFileSystem.from_name(
 logdir = "/tensorboard"
 
 # ## Training function
-#
+
 # This is basically the same code as [the official example](https://www.tensorflow.org/tutorials/images/classification) from the TensorFlow docs.
 # A few Modal-specific things are worth pointing out:
-#
+
 # * We set up the shared storage with TensorBoard in the arguments to `app.function`
+
 # * We also annotate this function with `gpu="T4"` to make sure it runs on a GPU
+
 # * We put all the TensorFlow imports inside the function body.
 #   This makes it possible to run this example even if you don't have TensorFlow installed on your local computer -- a key benefit of Modal!
-#
+
 # You may notice some warnings in the logs about certain CPU performance optimizations (NUMA awareness and AVX/SSE instruction set support) not being available.
 # While these optimizations can be important for some workloads, especially if you are running ML models on a CPU, they are not critical for most cases.
 
@@ -140,15 +142,15 @@ def train():
 
 
 # ## Running TensorBoard
-#
+
 # TensorBoard is compatible with a Python web server standard called [WSGI](https://www.fullstackpython.com/wsgi-servers.html),
 # the same standard used by [Flask](https://flask.palletsprojects.com/).
 # Modal [speaks WSGI too](https://modal.com/docs/guide/webhooks#wsgi), so it's straightforward to run TensorBoard in a Modal app.
-#
+
 # The WSGI app isn't exposed directly through the TensorBoard library, but we can build it
 # the same way it's built internally --
 # [see the TensorBoard source code for details](https://github.com/tensorflow/tensorboard/blob/0c5523f4b27046e1ca7064dd75347a5ee6cc7f79/tensorboard/program.py#L466-L476).
-#
+
 # Note that the TensorBoard server runs in a different container.
 # This container shares the same log directory containing the logs from the training.
 # The server does not need GPU support.
@@ -174,12 +176,12 @@ def tensorboard_app():
 
 
 # ## Local entrypoint code
-#
+
 # Let's kick everything off.
 # Everything runs in an ephemeral "app" that gets destroyed once it's done.
 # In order to keep the TensorBoard web server running, we sleep in an infinite loop
 # until the user hits ctrl-c.
-#
+
 # The script will take a few minutes to run, although each epoch is quite fast since it runs on a GPU.
 # The first time you run it, it might have to build the image, which can take an additional few minutes.
 

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -1,16 +1,20 @@
 # ---
 # args: ["--no-quick-check"]
 # ---
+
 # # Fine-tune open source YOLO models for object detection
-#
+
 # Example by [@Erik-Dunteman](https://github.com/erik-dunteman) and [@AnirudhRahul](https://github.com/AnirudhRahul/).
 
 # The popular "You Only Look Once" (YOLO) model line provides high-quality object detection in an economical package.
 # In this example, we use the [YOLOv10](https://docs.ultralytics.com/models/yolov10/) model, released on May 23, 2024.
-#
+
 # We will:
+
 # - Download two custom datasets from the [Roboflow](https://roboflow.com/) computer vision platform: a dataset of birds and a dataset of bees
+
 # - Fine-tune the model on those datasets, in parallel, using the [Ultralytics package](https://docs.ultralytics.com/)
+
 # - Run inference with the fine-tuned models on single images and on streaming frames
 
 # For commercial use, be sure to consult the [Ultralytics software license options](https://docs.ultralytics.com/#yolo-licenses-how-is-ultralytics-yolo-licensed),
@@ -53,15 +57,18 @@ app = modal.App("yolo-finetune", image=image, volumes={volume_path: volume})
 
 
 # ## Download a dataset
-#
+
 # We'll be downloading our data from the [Roboflow](https://roboflow.com/) computer vision platform, so to follow along you'll need to:
+
 # - Create a free account on [Roboflow](https://app.roboflow.com/)
+
 # - [Generate a Private API key](https://app.roboflow.com/settings/api)
+
 # - Set up a Modal [Secret](https://modal.com/docs/guide/secrets) called `roboflow-api-key` in the Modal UI [here](https://modal.com/secrets),
 # setting the `ROBOFLOW_API_KEY` to the value of your API key.
-#
+
 # You're also free to bring your own dataset with a config in YOLOv10-compatible yaml format.
-#
+
 # We'll be training on the medium size model, but you're free to experiment with [other model sizes](https://docs.ultralytics.com/models/yolov10/#model-variants).
 
 
@@ -155,9 +162,9 @@ def train(
 
 
 # ## Run inference on single inputs and on streams
-#
+
 # We demonstrate two different ways to run inference -- on single images and on a stream of images.
-#
+
 # The images we use for inference are loaded from the test set, which was added to our Volume when we downloaded the dataset.
 # Each image read takes ~50ms, and inference can take ~5ms, so the disk read would be our biggest bottleneck if we just looped over the image paths.
 # To avoid it, we parallelize the disk reads across many workers using Modal's [`.map`](https://modal.com/docs/guide/scale),
@@ -246,16 +253,16 @@ class Inference:
 
 
 # ## Running the example
-#
+
 # We'll kick off our parallel training jobs and run inference from the command line.
-#
+
 # ```bash
 # modal run finetune_yolo.py
 # ```
-#
+
 # This runs the training in `quick_check` mode, useful for debugging the pipeline and getting a feel for it.
 # To do a longer run that actually meaningfully improves performance, use:
-#
+
 # ```bash
 # modal run finetune_yolo.py --no-quick-check
 # ```
@@ -337,7 +344,7 @@ def main(quick_check: bool = True, inference_only: bool = False):
 
 
 # ## Addenda
-#
+
 # The rest of the code in this example is utility code.
 
 warnings.filterwarnings(  # filter warning from the terminal image library

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -1,25 +1,25 @@
 # ---
 # deploy: true
 # ---
-#
+
 # # Document OCR job queue
-#
+
 # This tutorial shows you how to use Modal as an infinitely scalable job queue
 # that can service async tasks from a web app. For the purpose of this tutorial,
 # we've also built a [React + FastAPI web app on Modal](https://modal.com/docs/examples/doc_ocr_webapp)
 # that works together with it, but note that you don't need a web app running on Modal
 # to use this pattern. You can submit async tasks to Modal from any Python
 # application (for example, a regular Django app running on Kubernetes).
-#
+
 # Our job queue will handle a single task: running OCR transcription for images.
 # We'll make use of a pre-trained Document Understanding model using the
 # [`donut`](https://github.com/clovaai/donut) package. Try
 # it out for yourself [here](https://modal-labs--example-doc-ocr-webapp-wrapper.modal.run/).
-#
+
 # ![receipt parser frontend](./receipt_parser_frontend_2.jpg)
 
 # ## Define an App
-#
+
 # Let's first import `modal` and define a [`App`](https://modal.com/docs/reference/modal.App).
 # Later, we'll use the name provided for our `App` to find it from our web app, and submit tasks to it.
 
@@ -30,7 +30,7 @@ import modal
 app = modal.App("example-doc-ocr-jobs")
 
 # ## Model cache
-#
+
 # `donut` downloads the weights for pre-trained models to a local directory, if those weights don't already exist.
 # To decrease start-up time, we want this download to happen just once, even across separate function invocations.
 # To accomplish this, we use the [`Image.run_function`](https://modal.com/docs/reference/modal.Image#run_function) method,
@@ -63,7 +63,7 @@ image = (
 )
 
 # ## Handler function
-#
+
 # Now let's define our handler function. Using the [@app.function()](https://modal.com/docs/reference/modal.App#function)
 # decorator, we set up a Modal [Function](https://modal.com/docs/reference/modal.Function) that uses GPUs,
 # runs on a [custom container image](https://modal.com/docs/guide/custom-container),
@@ -101,28 +101,28 @@ def parse_receipt(image: bytes):
 
 
 # ## Deploy
-#
+
 # Now that we have a function, we can publish it by deploying the app:
-#
+
 # ```shell
 # modal deploy doc_ocr_jobs.py
 # ```
-#
+
 # Once it's published, we can [look up](https://modal.com/docs/guide/trigger-deployed-functions) this function
 # from another Python process and submit tasks to it:
-#
+
 # ```python
 # fn = modal.Function.lookup("example-doc-ocr-jobs", "parse_receipt")
 # fn.spawn(my_image)
 # ```
-#
+
 # Modal will auto-scale to handle all the tasks queued, and
 # then scale back down to 0 when there's no work left. To see how you could use this from a Python web
 # app, take a look at the [receipt parser frontend](https://modal.com/docs/examples/doc_ocr_webapp)
 # tutorial.
 
 # ## Run manually
-#
+
 # We can also trigger `parse_receipt` manually for easier debugging:
 # `modal run doc_ocr_jobs::app.main`
 # To try it out, you can find some

--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -2,21 +2,22 @@
 # output-directory: "/tmp/stable-diffusion-xl"
 # deploy: true
 # ---
+
 # # LoRAs Galore: Create a LoRA Playground with Modal, Gradio, and S3
-#
+
 # This example shows how to mount an S3 bucket in a Modal app using [`CloudBucketMount`](https://modal.com/docs/reference/modal.CloudBucketMount).
 # We will download a bunch of LoRA adapters from the [HuggingFace Hub](https://huggingface.co/models) into our S3 bucket
 # then read from that bucket, on the fly, when doing inference.
-#
+
 # By default, we use the [IKEA instructions LoRA](https://huggingface.co/ostris/ikea-instructions-lora-sdxl) as an example,
 # which produces the following image when prompted to generate "IKEA instructions for building a GPU rig for deep learning":
-#
+
 # ![IKEA instructions for building a GPU rig for deep learning](./ikea-instructions-for-building-a-gpu-rig-for-deep-learning.png)
-#
+
 # By the end of this example, we've deployed a "playground" app where anyone with a browser can try
 # out these custom models. That's the power of Modal: custom, autoscaling AI applications, deployed in seconds.
 # You can try out our deployment [here](https://modal-labs--loras-galore-ui.modal.run).
-#
+
 # ## Basic setup
 
 import io
@@ -28,7 +29,7 @@ import modal
 
 # You will need to have an S3 bucket and AWS credentials to run this example. Refer to the documentation
 # for the detailed [IAM permissions](https://modal.com/docs/guide/cloud-bucket-mounts#iam-permissions) those credentials will need.
-#
+
 # After you are done creating a bucket and configuring IAM settings,
 # you now need to create a [Modal Secret](https://modal.com/docs/guide/secrets). Navigate to the "Secrets" tab and
 # click on the AWS card, then fill in the fields with the AWS key and secret created
@@ -61,6 +62,7 @@ with image.imports():
 # We attach the S3 bucket to all the Modal functions in this app by mounting it on the filesystem they see,
 # passing a `CloudBucketMount` to the `volumes` dictionary argument. We can read and write to this mounted bucket
 # (almost) as if it were a local directory.
+
 app = modal.App(
     "loras-galore",
     image=image,
@@ -74,10 +76,12 @@ app = modal.App(
 
 
 # ## Acquiring LoRA weights
-#
+
 # `search_loras()` will use the Hub API to search for LoRAs. We limit LoRAs
 # to a maximum size to avoid downloading very large model weights.
 # We went with 800 MiB, but feel free to adapt to what works best for you.
+
+
 @app.function()
 def search_loras(limit: int, max_model_size: int = 1024 * 1024 * 1024):
     api = huggingface_hub.HfApi()
@@ -145,12 +149,14 @@ def download_lora(repository_id: str) -> Optional[str]:
 
 
 # ## Inference with LoRAs
-#
+
 # We define a `StableDiffusionLoRA` class to organize our inference code.
 # We load Stable Diffusion XL 1.0 as a base model, then, when doing inference,
 # we load whichever LoRA the user specifies from the S3 bucket.
 # For more on the decorators we use on the methods below to speed up building and booting,
 # check out the [container lifecycle hooks guide](https://modal.com/docs/guide/lifecycle-hooks).
+
+
 @app.cls(gpu="a10g")  # A10G GPUs are great for inference
 class StableDiffusionLoRA:
     pipe_id = "stabilityai/stable-diffusion-xl-base-1.0"
@@ -190,12 +196,14 @@ class StableDiffusionLoRA:
 
 
 # ## Try it locally!
-#
+
 # To use our inference code from our local command line, we add a `local_entrypoint` to our `app`.
 # Run it using `modal run cloud_bucket_mount_loras.py`, and pass `--help`
 # to see the available options.
-#
+
 # The inference code will run on our machines, but the results will be available on yours.
+
+
 @app.local_entrypoint()
 def main(
     limit: int = 100,

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -1,21 +1,25 @@
 # ---
 # deploy: true
 # ---
+
 # # Publish interactive datasets with Datasette
-#
+
 # ![Datasette user interface](./covid_datasette_ui.png)
-#
+
 # This example shows how to serve a Datasette application on Modal. The published dataset
 # is COVID-19 case data from Johns Hopkins University which is refreshed daily.
-# Try it out for yourself at [here](https://modal-labs--example-covid-datasette-ui.modal.run).
-#
+# Try it out for yourself [here](https://modal-labs--example-covid-datasette-ui.modal.run).
+
 # Some Modal features it uses:
+
 # * Volumes: a persisted volume lets us store and grow the published dataset over time.
+
 # * Scheduled functions: the underlying dataset is refreshed daily, so we schedule a function to run daily.
+
 # * Web endpoints: exposes the Datasette application for web browser interaction and API requests.
-#
+
 # ## Basic setup
-#
+
 # Let's get started writing code.
 # For the Modal container image we need a few Python packages,
 # including `GitPython`, which we'll use to download the dataset.
@@ -39,7 +43,7 @@ datasette_image = (
 )
 
 # ## Persistent dataset storage
-#
+
 # To separate database creation and maintenance from serving, we'll need the underlying
 # database file to be stored persistently. To achieve this we use a [`Volume`](/docs/guide/volumes).
 
@@ -54,11 +58,11 @@ DB_PATH = pathlib.Path(VOLUME_DIR, DB_FILENAME)
 
 
 # ## Getting a dataset
-#
+
 # Johns Hopkins has been publishing up-to-date COVID-19 pandemic data on GitHub since early February 2020, and
 # as of late September 2022 daily reporting is still rolling in. Their dataset is what this example will use to
 # show off Modal and Datasette's capabilities.
-#
+
 # The full git repository size for the dataset is over 6GB, but we only need to shallow clone around 300MB.
 
 
@@ -98,7 +102,7 @@ def download_dataset(cache=True):
 
 
 # ## Data munging
-#
+
 # This dataset is no swamp, but a bit of data cleaning is still in order. The following two
 # functions read a handful of `.csv` files and clean the data, before inserting it into
 # SQLite.
@@ -157,12 +161,12 @@ def load_report(filepath):
 
 
 # ## Inserting into SQLite
-#
+
 # With the CSV processing out of the way, we're ready to create an SQLite DB and feed data into it.
 # Importantly, the `prep_db` function mounts the same volume used by `download_dataset()`, and
 # rows are batch inserted with progress logged after each batch, as the full COVID-19 has millions
 # of rows and does take some time to be fully inserted.
-#
+
 # A more sophisticated implementation would only load new data instead of performing a full refresh,
 # but we're keeping things simple for this example!
 
@@ -215,7 +219,7 @@ def prep_db():
 
 
 # ## Keep it fresh
-#
+
 # Johns Hopkins commits new data to the dataset repository every day, so we set up
 # a [scheduled](/docs/guide/cron) function to automatically refresh the database
 # every 24 hours.
@@ -229,7 +233,7 @@ def refresh_db():
 
 
 # ## Web endpoint
-#
+
 # Hooking up the SQLite database to a Modal webhook is as simple as it gets.
 # The Modal `@asgi_app` decorator wraps a few lines of code: one `import` and a few
 # lines to instantiate the `Datasette` instance and return its app server.
@@ -250,12 +254,12 @@ def ui():
 
 
 # ## Publishing to the web
-#
+
 # Run this script using `modal run covid_datasette.py` and it will create the database.
-#
+
 # You can then use `modal serve covid_datasette.py` to create a short-lived web URL
 # that exists until you terminate the script.
-#
+
 # When publishing the interactive Datasette app you'll want to create a persistent URL.
 # Just run `modal deploy covid_datasette.py`.
 

--- a/10_integrations/dbt/dbt_duckdb.py
+++ b/10_integrations/dbt/dbt_duckdb.py
@@ -1,22 +1,25 @@
 # ---
 # deploy: true
 # ---
+
 # # Build your own data warehouse with DuckDB, DBT, and Modal
-#
+
 # This example contains a minimal but capable [data warehouse](https://en.wikipedia.org/wiki/Data_warehouse).
 # It's comprised of the following:
-#
+
 # - [DuckDB](https://duckdb.org) as the warehouse's [OLAP](https://en.wikipedia.org/wiki/Online_analytical_processing) database engine
+
 # - [AWS S3](https://aws.amazon.com/s3/) as the data storage provider
+
 # - [DBT](https://docs.getdbt.com/docs/introduction) as the data transformation tool
-#
+
 # Meet your new serverless cloud data warehouse, powered by Modal!
-#
+
 # ## Configure Modal, S3, and DBT
-#
+
 # The only thing in the source code that you must update is the S3 bucket name.
 # AWS S3 bucket names are globally unique, and the one in this source is used by us to host this example.
-#
+
 # Update the `BUCKET_NAME` variable below and also any references to the original value
 # within `sample_proj_duckdb_s3/models/`. The AWS IAM policy below also includes the bucket
 # name and that must be updated.
@@ -60,10 +63,10 @@ app = modal.App(name="example-dbt-duckdb-s3", image=dbt_image)
 # Most of the DBT code and configuration is taken directly from the classic
 # [Jaffle Shop](https://github.com/dbt-labs/jaffle_shop) demo and modified to support
 # using `dbt-duckdb` with an S3 bucket.
-#
+
 # The DBT `profiles.yml` configuration is taken from
 # [the `dbt-duckdb` docs](https://github.com/jwills/dbt-duckdb#configuring-your-profile).
-#
+
 # Here we mount all this local code and configuration into the Modal Function
 # so that it will be available when we run DBT on Modal.
 
@@ -84,11 +87,11 @@ s3_secret = modal.Secret.from_name("modal-examples-aws-user")
 # Below we will use the provided credentials in a Modal Function to create an S3 bucket and
 # populate it with `.parquet` data, so be sure to provide credentials for a user
 # with permission to create S3 buckets and read & write data from them.
-#
+
 # The policy required for this example is the following.
 # Not that you *must* update the bucket name listed in the policy to your
 # own bucket name.
-#
+
 # ```json
 # {
 #     "Statement": [
@@ -107,21 +110,21 @@ s3_secret = modal.Secret.from_name("modal-examples-aws-user")
 # ```
 
 # ## Upload seed data
-#
+
 # In order to provide source data for DBT to ingest and transform,
 # we have the below `create_source_data` function which creates an AWS S3 bucket and
 # populates it with Parquet files based off the CSV data in the `seeds/` directory.
-#
+
 # You can kick it off by running this script on Modal:
-#
+
 # ```bash
 # modal run dbt_duckdb.py
 # ```
-#
+
 # This script also runs the full data warehouse setup, and the whole process takes a minute or two.
 # We'll walk through the rest of the steps below. See the `app.local_entrypoint`
 # below for details.
-#
+
 # Note that this is not the typical way that `seeds/` data is used, but it's useful for this
 # demonstration. See [the DBT docs](https://docs.getdbt.com/docs/build/seeds) for more info.
 
@@ -157,12 +160,12 @@ def create_source_data():
 
 
 # ## Run DBT on the cloud with Modal
-#
+
 # Modal makes it easy to run Python code in the cloud.
 # And DBT is a Python tool, so it's easy to run DBT with Modal:
 # below, we import the `dbt` library's `dbtRunner` to pass commands from our
 # Python code, running on Modal, the same way we'd pass commands on a command line.
-#
+
 # Note that this Modal Function has access to our AWS Secret,
 # the `mount`ed local files with our DBT project and profiles,
 # and a remote Modal Volume that acts as a distributed file system.
@@ -182,11 +185,11 @@ def run(command: str) -> None:
 
 
 # You can run this Modal Function from the command line with
-#
+
 # `modal run dbt_duckdb.py::run --command run`
-#
+
 # A successful run will log something like the following:
-#
+
 # ```
 # 03:41:04  Running with dbt=1.5.0
 # 03:41:05  Found 5 models, 8 tests, 0 snapshots, 0 analyses, 313 macros, 0 operations, 3 seed files, 3 sources, 0 exposures, 0 metrics, 0 groups
@@ -209,16 +212,16 @@ def run(command: str) -> None:
 # 03:41:08
 # 03:41:08  Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5
 # ```
-#
+
 # Look for the `'materialized='external'` DBT config in the SQL templates
 # to see how `dbt-duckdb` is able to write back the transformed data to AWS S3!
-#
+
 # After running the `run` command and seeing it succeed, check what's contained
 # under the bucket's `out/` key prefix. You'll see that DBT has run the transformations
 # defined in `sample_proj_duckdb_s3/models/` and produced output `.parquet` files.
 
 # ## Serve fresh data documentation with FastAPI and Modal
-#
+
 # DBT also automatically generates [rich, interactive data docs](https://docs.getdbt.com/docs/collaborate/explore-projects).
 # You can serve these docs on Modal.
 # Just define a simple [FastAPI](https://fastapi.tiangolo.com/) app:
@@ -243,15 +246,16 @@ def serve_dbt_docs():
 
 
 # And deploy that app to Modal with
+
 # ```bash
 # modal deploy dbt_duckdb.py
 # # ...
 # # Created web function serve_dbt_docs => <output-url>
 # ```
-#
+
 # If you navigate to the output URL, you should see something like
 # [![example dbt docs](./dbt_docs.png)](https://modal-labs--example-dbt-duckdb-s3-serve-dbt-docs.modal.run)
-#
+
 # You can also check out our instance of the docs [here](https://modal-labs--example-dbt-duckdb-s3-serve-dbt-docs.modal.run).
 # The app will be served "serverlessly" -- it will automatically scale up or down
 # during periods of increased or decreased usage, and you won't be charged at all
@@ -259,10 +263,10 @@ def serve_dbt_docs():
 
 
 # ## Schedule daily updates
-#
+
 # The following `daily_build` function [runs on a schedule](https://modal.com/docs/guide/cron)
 # to keep the DuckDB data warehouse up-to-date. It is also deployed by the same `modal deploy` command for the docs app.
-#
+
 # The source data for this warehouse is static,
 # so the daily executions don't really "update" anything, just re-build. But this example could be extended
 # to have sources which continually provide new data across time.

--- a/10_integrations/s3_bucket_mount.py
+++ b/10_integrations/s3_bucket_mount.py
@@ -1,23 +1,24 @@
 # ---
 # output-directory: "/tmp/s3_bucket_mount"
 # ---
+
 # # Analyze NYC yellow taxi data with DuckDB on Parquet files from S3
-#
+
 # This example shows how to use Modal for a classic data science task: loading table-structured data into cloud stores,
 # analyzing it, and plotting the results.
-#
+
 # In particular, we'll load public NYC taxi ride data into S3 as Parquet files,
 # then run SQL queries on it with DuckDB.
-#
+
 # We'll mount the S3 bucket in a Modal app with [`CloudBucketMount`](https://modal.com/docs/reference/modal.CloudBucketMount).
 # We will write to and then read from that bucket, in each case using
 # Modal's [parallel execution features](https://modal.com/docs/guide/scale) to handle many files at once.
-#
+
 # ## Basic setup
-#
+
 # You will need to have an S3 bucket and AWS credentials to run this example. Refer to the documentation
 # for the exact [IAM permissions](https://modal.com/docs/guide/cloud-bucket-mounts#iam-permissions) your credentials will need.
-#
+
 # After you are done creating a bucket and configuring IAM settings,
 # you now need to create a [`Secret`](https://modal.com/docs/guide/secrets) to share
 # the relevant AWS credentials with your Modal apps.
@@ -40,24 +41,26 @@ secret = modal.Secret.from_name(
 MOUNT_PATH: Path = Path("/bucket")
 YELLOW_TAXI_DATA_PATH: Path = MOUNT_PATH / "yellow_taxi"
 
-
 # The dependencies installed above are not available locally. The following block instructs Modal
 # to only import them inside the container.
+
 with image.imports():
     import duckdb
     import requests
 
 
 # ## Download New York City's taxi data
-#
+
 # NYC makes data about taxi rides publicly available. The city's [Taxi & Limousine Commission (TLC)](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page)
 # publishes files in the Parquet format. Files are organized by year and month.
-#
+
 # We are going to download all available files and store them in an S3 bucket. We do this by
 # attaching a `modal.CloudBucketMount` with the S3 bucket name and its respective credentials.
 # The files in the bucket will then be available at `MOUNT_PATH`.
-#
+
 # As we'll see below, this operation can be massively sped up by running it in parallel on Modal.
+
+
 @app.function(
     volumes={
         MOUNT_PATH: modal.CloudBucketMount(
@@ -85,10 +88,12 @@ def download_data(year: int, month: int) -> str:
 
 
 # ## Analyze data with DuckDB
-#
+
 # [DuckDB](https://duckdb.org/) is an analytical database with rich support for Parquet files.
 # It is also very fast. Below, we define a Modal Function that aggregates yellow taxi trips
 # within a month (each file contains all the rides from a specific month).
+
+
 @app.function(
     volumes={
         MOUNT_PATH: modal.CloudBucketMount(
@@ -122,10 +127,12 @@ def aggregate_data(path: str) -> list[tuple[datetime, int]]:
 
 
 # ## Plot daily taxi rides
-#
+
 # Finally, we want to plot our results.
 # The plot created shows the number of yellow taxi rides per day in NYC.
 # This function runs remotely, on Modal, so we don't need to install plotting libraries locally.
+
+
 @app.function()
 def plot(dataset) -> bytes:
     import io
@@ -157,7 +164,7 @@ def plot(dataset) -> bytes:
 
 
 # ## Run everything
-#
+
 # The `@app.local_entrypoint()` defines what happens when we run our Modal program locally.
 # We invoke it from the CLI by calling `modal run s3_bucket_mount.py`.
 # We first call `download_data()` and `starmap` (named because it's kind of like `map(*args)`)
@@ -166,12 +173,14 @@ def plot(dataset) -> bytes:
 # Parquet file paths. Then, we call `aggregate_data()` with `map` on that list. These files are
 # also read from our S3 bucket. So one function writes files to S3 and the other
 # reads files from S3 in; both run across many files in parallel.
-#
+
 # Finally, we call `plot` to generate the following figure:
 #
 # ![Number of NYC yellow taxi trips by weekday, 2018-2023](./nyc_yellow_taxi_trips_s3_mount.png)
-#
+
 # This program should run in less than 30 seconds.
+
+
 @app.local_entrypoint()
 def main():
     # List of tuples[year, month].


### PR DESCRIPTION
This style looks cleaner to me -- it breaks up the long comments in a way that is visually similar to the effect of the whitespace once the contents are actually rendered.

I've been making this change piecemeal, as I update examples. I've been happy so far and so am editing some of our top examples (e.g. featured examples) to use this format.