### PR TITLE
speed up blender with L40S

### DIFF
--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -9,7 +9,7 @@
 
 # You can run it on CPUs to scale out on one hundred containers
 # or run it on GPUs to get higher throughput per node.
-# Even for this simple scene, GPUs render 10x faster than CPUs.
+# Even for this simple scene, GPUs render >10x faster than CPUs.
 
 # The final render looks something like this:
 

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -61,7 +61,7 @@ WITH_GPU = True  # try changing this to False to run rendering massively in para
 
 
 @app.function(
-    gpu="A10G" if WITH_GPU else None,
+    gpu="L40S" if WITH_GPU else None,
     # default limits on Modal free tier
     concurrency_limit=10 if WITH_GPU else 100,
     image=rendering_image,
@@ -174,8 +174,8 @@ def combine(frames_bytes: list[bytes], fps: int = FPS) -> bytes:
 
 # The bytes for the video come back to our local machine, and we write them to a file.
 
-# The whole rendering process (for 4 seconds of 1080p 60 FPS video) takes about five minutes to run on 10 A10G GPUs,
-# with a per-frame latency of about 10 seconds, and about five minutes to run on 100 CPUs, with a per-frame latency of about one minute.
+# The whole rendering process (for four seconds of 1080p 60 FPS video) takes about three minutes to run on 10 L40S GPUs,
+# with a per-frame latency of about six seconds, and about five minutes to run on 100 CPUs, with a per-frame latency of about one minute.
 
 
 @app.local_entrypoint()


### PR DESCRIPTION
at roughly the same cost (and still under a dollar), run the blender rendering in ~3 minutes instead of ~5 with the new L40S GPUs