### PR TITLE
Migrate examples away from `@modal.build`

### DIFF
--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -12,7 +12,21 @@ from contextlib import asynccontextmanager
 
 import modal
 
-image = modal.Image.debian_slim().pip_install("sentence-transformers==3.2.0")
+MODEL_PATH = "/model.bge"
+
+
+def download_model():
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer("BAAI/bge-small-en-v1.5")
+    model.save(MODEL_PATH)
+
+
+image = (
+    modal.Image.debian_slim()
+    .pip_install("sentence-transformers==3.2.0")
+    .run_function(download_model)
+)
 
 app = modal.App("gpu-packing", image=image)
 
@@ -48,11 +62,6 @@ class Server:
     def __init__(self, n_models=10):
         self.model_pool = ModelPool()
         self.n_models = n_models
-
-    @modal.build()
-    def download(self):
-        model = SentenceTransformer("BAAI/bge-small-en-v1.5")
-        model.save("/model.bge")
 
     @modal.enter()
     async def load_models(self):

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -149,9 +149,7 @@ def download_model():
 
 # It uses [Modal `@app.cls`](https://modal.com/docs/guide/lifecycle-functions) decorators
 # to organize the "lifecycle" of the app:
-# to ensure all model files are downloaded (`@modal.build`)
-# to load the model on container start (`@modal.enter`)
-# and to run inference on request (`@modal.method`).
+# loading the model on container start (`@modal.enter`) and running inference on request (`@modal.method`).
 
 # We include in the arguments to the `@app.cls` decorator
 # all the information about this service's infrastructure:

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -90,7 +90,7 @@ with image.imports():
 # Otherwise, the model weights will be downloaded for the first inference
 # and cached to the Volume when the first container exits.
 
-cache_volume = modal.Volume.from_name("huggingface-hub-cache")
+cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 
 
 @app.function(image=image, volumes={MODEL_DIR: cache_volume})

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -40,8 +40,8 @@ import modal
 # [Pillow](https://python-pillow.org/) which lets us work with images from Python,
 # and a system font for drawing.
 
-# This example uses the `facebook/detr-resnet-50` pre-trained model, which is downloaded
-# once at image build time using the `@build` hook and saved into the image.
+# This example uses the `facebook/detr-resnet-50` pre-trained model,
+# which we'll cache to a Volume for fast cold starts.
 
 MODEL_REPO_ID = "facebook/detr-resnet-50"
 MODEL_DIR = "/cache"

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -43,19 +43,21 @@ import modal
 # This example uses the `facebook/detr-resnet-50` pre-trained model, which is downloaded
 # once at image build time using the `@build` hook and saved into the image.
 
-model_repo_id = "facebook/detr-resnet-50"
+MODEL_REPO_ID = "facebook/detr-resnet-50"
+MODEL_DIR = "/cache"
 
 
 app = modal.App("example-webcam-object-detection")
 image = (
     modal.Image.debian_slim(python_version="3.12")
     .pip_install(
-        "huggingface-hub==0.16.4",
+        "huggingface-hub==0.27.1",
         "Pillow",
         "timm",
         "transformers",
     )
     .apt_install("fonts-freefont-ttf")
+    .env({"HF_HUB_CACHE": MODEL_DIR})
 )
 
 
@@ -66,9 +68,6 @@ image = (
 # * There's a container initialization step in the method decorated with `@enter()`,
 #   which runs on every container start. This lets us load the model only once per
 #   container, so that it's reused for subsequent function calls.
-
-# * Above we stored the model in the container image. This lets us download the model only
-#   when the image is (re)built, and not everytime the function is called.
 
 # * We're running it on multiple CPUs for extra performance
 
@@ -86,21 +85,29 @@ with image.imports():
     from transformers import DetrForObjectDetection, DetrImageProcessor
 
 
-@app.cls(image=image)
-class ObjectDetection:
-    @modal.build()
-    def download_model(self):
-        snapshot_download(repo_id=model_repo_id, cache_dir="/cache")
+# We'll store the model weights in a Volume and provide a function that you can
+# `modal run` against to download the model weights prior to deploying the App.
+# Otherwise, the model weights will be downloaded for the first inference
+# and cached to the Volume when the first container exits.
 
+cache_volume = modal.Volume.from_name("huggingface-hub-cache")
+
+
+@app.function(image=image, volumes={MODEL_DIR: cache_volume})
+def download_model():
+    loc = snapshot_download(repo_id=MODEL_REPO_ID)
+    print(f"Saved model to {loc}")
+
+
+@app.cls(image=image, volumes={MODEL_DIR: cache_volume})
+class ObjectDetection:
     @modal.enter()
     def load_model(self):
         self.feature_extractor = DetrImageProcessor.from_pretrained(
-            model_repo_id,
-            cache_dir="/cache",
+            MODEL_REPO_ID,
         )
         self.model = DetrForObjectDetection.from_pretrained(
-            model_repo_id,
-            cache_dir="/cache",
+            MODEL_REPO_ID,
         )
 
     @modal.method()

--- a/06_gpu_and_ml/openai_whisper/batched_whisper.py
+++ b/06_gpu_and_ml/openai_whisper/batched_whisper.py
@@ -71,9 +71,9 @@ def download_model():
 
 # The inference function is best represented using Modal's [class syntax](https://modal.com/docs/guide/lifecycle-functions).
 
-# We define a `@modal.build` method to download the model and a `@modal.enter` method to load the model.
-# `build` downloads the model from HuggingFace just once when our app is first run or deployed
-# and `enter` loads the model into memory just once when our inference function is first invoked.
+# We define a `@modal.enter` method to load the model when the container starts, before it picks up any inputs.
+# The weights will be loaded from the Hugging Face cache volume so that we don't need to download them when
+# we start a new container.
 
 # We also define a `transcribe` method that uses the `@modal.batched` decorator to enable dynamic batching.
 # This allows us to invoke the function with individual audio samples, and the function will automatically batch them

--- a/06_gpu_and_ml/openai_whisper/batched_whisper.py
+++ b/06_gpu_and_ml/openai_whisper/batched_whisper.py
@@ -41,9 +41,7 @@ image = (
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1", "HF_HUB_CACHE": MODEL_DIR})
 )
 
-model_cache = modal.Volume.from_name(
-    "huggingface-hub-cache", create_if_missing=True
-)
+model_cache = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 app = modal.App(
     "example-whisper-batched-inference",
     image=image,

--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -189,7 +189,7 @@ def main(
     x_point=250,
     y_point=200,
 ):
-    with volume.batch_upload(force=True) as batch:
+    with video_vol.batch_upload(force=True) as batch:
         batch.put_file(input_video, "input.mp4")
 
     model = Model()

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -24,6 +24,9 @@ from io import BytesIO
 from pathlib import Path
 
 import modal
+from synthetic_monitoring.benchmarks.image import CACHE_DIR
+
+CACHE_DIR = "/cache"
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
@@ -35,10 +38,19 @@ image = (
         "safetensors~=0.4.1",  # Enables safetensor format as opposed to using unsafe pickle format
         "transformers~=4.35.2",  # This is needed for `import torch`
     )
-    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})  # allow faster model downloads
+    .env(
+        {
+            "HF_HUB_ENABLE_HF_TRANSFER": "1",  # Allows faster model downloads
+            "HF_HUB_CACHE_DIR": CACHE_DIR,  # Points the Hugging Face cache to a Volume
+        }
+    )
 )
 
-app = modal.App("image-to-image", image=image)
+cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
+
+app = modal.App(
+    "image-to-image", image=image, volumes={CACHE_DIR: cache_volume}
+)
 
 with image.imports():
     import torch
@@ -52,9 +64,8 @@ with image.imports():
 
 # The Modal `Cls` defined below contains all the logic to download, set up, and run SDXL Turbo.
 
-# The [container lifecycle](https://modal.com/docs/guide/lifecycle-functions#container-lifecycle-beta) decorators
-# `@build` and `@enter` ensure we download the model when building our container image and load it into memory
-# when we start up a new instance of our `Cls`.
+# The [container lifecycle](https://modal.com/docs/guide/lifecycle-functions#container-lifecycle-beta) decorator
+# (`@modal.enter()`) ensures that the model is loaded into memory when a container starts, before it picks up any inputs.
 
 # The `inference` method runs the actual model inference. It takes in an image as a collection of `bytes` and a string `prompt` and returns
 # a new image (also as a collection of `bytes`).
@@ -62,20 +73,25 @@ with image.imports():
 # To avoid excessive cold-starts, we set the `container_idle_timeout` to 240 seconds, meaning once a GPU has loaded the model it will stay
 # online for 4 minutes before spinning down.
 
+# We also provide a function that will download the model weights to the cache Volume ahead of time.
+# You can run this function directly with `modal run`. Otherwise, the weights will be cached after the
+# first container cold start.
+
+
+@app.function()
+def download_models():
+    # Ignore files that we don't need to speed up download time.
+    ignore = [
+        "*.bin",
+        "*.onnx_data",
+        "*/diffusion_pytorch_model.safetensors",
+    ]
+
+    snapshot_download("stabilityai/sdxl-turbo", ignore_patterns=ignore)
+
 
 @app.cls(gpu=modal.gpu.A10G(), container_idle_timeout=240)
 class Model:
-    @modal.build()
-    def download_models(self):
-        # Ignore files that we don't need to speed up download time.
-        ignore = [
-            "*.bin",
-            "*.onnx_data",
-            "*/diffusion_pytorch_model.safetensors",
-        ]
-
-        snapshot_download("stabilityai/sdxl-turbo", ignore_patterns=ignore)
-
     @modal.enter()
     def enter(self):
         self.pipe = AutoPipelineForImage2Image.from_pretrained(

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -24,7 +24,6 @@ from io import BytesIO
 from pathlib import Path
 
 import modal
-from synthetic_monitoring.benchmarks.image import CACHE_DIR
 
 CACHE_DIR = "/cache"
 

--- a/misc/trellis3d.py
+++ b/misc/trellis3d.py
@@ -105,16 +105,19 @@ trellis_image = (
 
 app = modal.App(name="example-trellis-3d")
 
+cache_dir = "/cache"
+cache_vol = modal.Volume.from_name("hf-hub-cache")
+
 
 @app.cls(
-    image=trellis_image,
+    image=trellis_image.env({"HF_HUB_CACHE_DIR": cache_dir}),
     gpu=modal.gpu.L4(count=1),
     timeout=1 * HOURS,
     container_idle_timeout=1 * MINUTES,
+    volumes={cache_dir: cache_vol},
 )
 class Model:
     @modal.enter()
-    @modal.build()
     def initialize(self):
         import sys
 


### PR DESCRIPTION
Updating the examples to avoid using `@modal.build`.

I ended up using a few different patterns here. Most are oriented around mounting a `modal.Volume` at a location that aligns with the `HF_HUB_CACHE_DIR`. In some examples I added a separate target function for pre-caching the model, although I didn't do that everywhere. For a couple with smaller models, I just moved the `build` method to a standalone function passed to `Image.run_function`.

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)
