### PR TITLE
Update trtllm_llama.py

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -57,7 +57,7 @@ import modal
 import pydantic  # for typing, used later
 
 tensorrt_image = modal.Image.from_registry(
-    "nvidia/cuda:12.4.1-devel-ubuntu22.04",
+    "nvidia/cuda:12.5.1-devel-ubuntu22.04",
     add_python="3.10",  # TRT-LLM requires Python 3.10
 ).entrypoint([])  # remove verbose logging by base image on entry
 
@@ -68,7 +68,7 @@ tensorrt_image = modal.Image.from_registry(
 tensorrt_image = tensorrt_image.apt_install(
     "openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget"
 ).pip_install(
-    "tensorrt_llm==0.14.0",
+    "tensorrt_llm==0.16.0",
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )
@@ -144,7 +144,7 @@ tensorrt_image = (  # update the image by downloading the model we're using
 # We use a quantization script provided by the TensorRT-LLM team.
 # This script takes a few minutes to run.
 
-GIT_HASH = "b0880169d0fb8cd0363049d91aa548e58a41be07"
+GIT_HASH = "42a7b0922fc9e095f173eab9a7efa0bcdceadd0d"
 CONVERSION_SCRIPT_URL = f"https://raw.githubusercontent.com/NVIDIA/TensorRT-LLM/{GIT_HASH}/examples/quantization/quantize.py"
 
 # NVIDIA's Ada Lovelace/Hopper chips, like the 4090, L40S, and H100,


### PR DESCRIPTION
I ran into following exception when trying out the example. Fixing that with latest CUDA image and latest TensorRT-LLM package.

Error:
Step 2: RUN python /root/convert.py --model_dir=/root/model/model_input --output_dir=/root/model/model_ckpt --tp_size=1 --dtype=float16 --qformat=fp8 --kv_cache_dtype=fp8 --calib_size=512
AttributeError: module 'pynvml' has no attribute '__version__'
Terminating task due to error: failed to run builder command "python /root/convert.py --model_dir=/root/model/model_input --output_dir=/root/model/model_ckpt --tp_size=1 --dtype=float16 --qformat=fp8 --kv_cache_dtype=fp8 --calib_size=512": container exit status: 1
Runner failed with exception: task exited with failure, status = exit status: 1
Stopping app - uncaught exception raised locally: RemoteError('Image build for im-Pf6HdxV8HNda62wDKk62ih failed with the exception:\ntask exited with failure, status = exit status: 1').

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
