### PR TITLE
update custom node name

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -68,7 +68,7 @@ image = (  # build up a Modal Image to run ComfyUI, step by step
     )
     .apt_install("git")  # install git to clone ComfyUI
     .pip_install("fastapi[standard]==0.115.4")  # install web dependencies
-    .pip_install("comfy-cli==1.2.7")  # install comfy-cli
+    .pip_install("comfy-cli==1.3.5")  # install comfy-cli
     .run_commands(  # use comfy-cli to install the ComfyUI repo and its dependencies
         "comfy --skip-prompt install --nvidia"
     )
@@ -82,7 +82,7 @@ image = (  # build up a Modal Image to run ComfyUI, step by step
 # We'll use `comfy-cli` to download custom nodes, in this case the popular WAS Node Suite pack.
 image = (
     image.run_commands(  # download a custom node
-        "comfy node install was-node-suite-comfyui"
+        "comfy node install pr-was-node-suite-comfyui-47064894"
     )
     # Add .run_commands(...) calls for any other custom nodes you want to download
 )


### PR DESCRIPTION
The name of the third-party custom node changed, which broke the example; moving forward should consult [this registry](https://registry.comfy.org/nodes/pr-was-node-suite-comfyui-47064894) to find the correct name. Guessing it has to do with [introducing versioning](https://blog.comfy.org/p/launching-comfyui-registry) in the comfy registry

I also updated comfy-cli for good measure.

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/80a9ea52-e82b-4923-8b25-70ce6c460c22" />


### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
