### PR TITLE
add barrier before process group cleanup

### DIFF
--- a/14_clusters/simple_torch_cluster_script.py
+++ b/14_clusters/simple_torch_cluster_script.py
@@ -87,6 +87,7 @@ def init_processes(backend):
         dist.init_process_group(backend, rank=WORLD_RANK, world_size=WORLD_SIZE)
         yield
     finally:
+        dist.barrier()  # ensure any async work is done before cleaning up
         # Remove this if it causes program to hang. ref: https://github.com/pytorch/pytorch/issues/75097.
         dist.destroy_process_group()
 


### PR DESCRIPTION
iiuc not necessary because our ops are all sync but good to include in case users take this code and run more complex scripts with it

cc @thecodingwizard