### PR TITLE
Migrate object lookups in example scripts

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -55,7 +55,7 @@ MODEL_REVISION = "a7c09948d9a632c2c840722f519672cd94af885d"
 # [examples repository](https://github.com/modal-labs/modal-examples).
 
 try:
-    volume = modal.Volume.lookup("llamas", create_if_missing=False)
+    volume = modal.Volume.from_name("llamas", create_if_missing=False).hydrate()
 except modal.exception.NotFoundError:
     raise Exception("Download models first with modal run download_llama.py")
 

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -145,7 +145,7 @@ def parse_receipt(image: bytes) -> str:
 # from another Python process and submit tasks to it:
 
 # ```python
-# fn = modal.Function.lookup("example-doc-ocr-jobs", "parse_receipt")
+# fn = modal.Function.from_name("example-doc-ocr-jobs", "parse_receipt")
 # fn.spawn(my_image)
 # ```
 

--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -49,7 +49,7 @@ web_app = fastapi.FastAPI()
 
 @web_app.post("/parse")
 async def parse(request: fastapi.Request):
-    parse_receipt = modal.Function.lookup(
+    parse_receipt = modal.Function.from_name(
         "example-doc-ocr-jobs", "parse_receipt"
     )
 

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference.py
@@ -100,9 +100,9 @@ def dbt_run() -> None:
 
     # Remember to either deploy the llama dependency app in your environment
     # first, or change this to use another web endpoint you have:
-    ref = modal.Function.lookup(
+    ref = modal.Function.from_name(
         "example-trtllm-Meta-Llama-3-8B-Instruct", "generate_web"
-    )
+    ).hydrate()
 
     res = dbtRunner().invoke(
         ["run", "--vars", f"{{'inference_url': '{ref.web_url}'}}"]


### PR DESCRIPTION
We're deprecating `.lookup` methods on Modal objects to streamline object creation. `.from_name` should now be the One Way To Do It. I have updated the examples accordingly. There were a couple cases where the examples demonstrated a pattern that couldn't be solved with a simple name substitution and required explicitly hydrating the object.

Part of CLI-96

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
