### PR TITLE
Fix Huggingface Cache environment variable

### DIFF
--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -62,7 +62,7 @@ cache_dir = "/cache"
 
 
 @app.cls(
-    image=image.env({"HF_HUB_CACHE_DIR": cache_dir}),
+    image=image.env({"HF_HUB_CACHE": cache_dir}),
     volumes={"/root/videos": video_vol, cache_dir: cache_vol},
     gpu="A100",
 )

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -57,7 +57,7 @@ flux_image = (
         f"git+https://github.com/huggingface/diffusers.git@{diffusers_commit_sha}",
         "numpy<2",
     )
-    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1", "HF_HUB_CACHE_DIR": "/cache"})
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1", "HF_HUB_CACHE": "/cache"})
 )
 
 # Later, we'll also use `torch.compile` to increase the speed further.

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -40,7 +40,7 @@ image = (
     .env(
         {
             "HF_HUB_ENABLE_HF_TRANSFER": "1",  # Allows faster model downloads
-            "HF_HUB_CACHE_DIR": CACHE_DIR,  # Points the Hugging Face cache to a Volume
+            "HF_HUB_CACHE": CACHE_DIR,  # Points the Hugging Face cache to a Volume
         }
     )
 )

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -58,7 +58,7 @@ image = (
     .env(
         {
             "HF_HUB_ENABLE_HF_TRANSFER": "1",  # faster downloads
-            "HF_HUB_CACHE_DIR": CACHE_DIR,
+            "HF_HUB_CACHE": CACHE_DIR,
         }
     )
 )

--- a/misc/trellis3d.py
+++ b/misc/trellis3d.py
@@ -110,7 +110,7 @@ cache_vol = modal.Volume.from_name("hf-hub-cache")
 
 
 @app.cls(
-    image=trellis_image.env({"HF_HUB_CACHE_DIR": cache_dir}),
+    image=trellis_image.env({"HF_HUB_CACHE": cache_dir}),
     gpu=modal.gpu.L4(count=1),
     timeout=1 * HOURS,
     container_idle_timeout=1 * MINUTES,


### PR DESCRIPTION
While testing one of the examples, I noticed that the local huggingface cache was not being used. While reviewing the code, I noticed a typo where the environment variables `HF_HUB_CACHE_DIR` was being set but, [according to the docs](https://huggingface.co/docs/huggingface_hub/en/guides/manage-cache#understand-caching), the correct environment variable is `HF_HUB_CACHE`.

Figured I'd send along a PR so that it helps others.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Outside contributors

You're great! Thanks for your contribution.
