### PR TITLE
remove automount environment var in agent example

### DIFF
--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -1,7 +1,6 @@
 # ---
 # cmd: ["modal", "run", "13_sandboxes.codelangchain.agent", "--question", "Use gpt2 and transformers to generate text"]
 # pytest: false
-# env: {"MODAL_AUTOMOUNT": "True"}
 # ---
 
 # # Build a coding agent with Modal Sandboxes and LangGraph


### PR DESCRIPTION
This example is failing in monitoring in a way that I can't replicate in any other environment. I suspect it's because we have automount turned on.

That's actually not necessary, since the contents of `./src` are pulled up without it. When we run in "module mode", i.e. with `modal run 13_sandboxes.codelangchain.agent`, we pull up the everything from `13_sandboxes` onto the image in `/root`.

I wasn't able to reconstruct _why_ we added explicit automounting here. It could be that client behavior there has changed and that's why it's no longer necessary?

I'm not positive that this will fix the failures, but they also aren't user-facing, so I'm pushing this up and waiting a bit to see what the synmon results show.