### PR TITLE
update the vllm oai client script to accept/detect modal environments

### DIFF
--- a/06_gpu_and_ml/llm-serving/openai_compatible/client.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/client.py
@@ -60,6 +60,12 @@ def main():
         help="The workspace where the LLM server app is hosted, defaults to your current Modal workspace",
     )
     parser.add_argument(
+        "--environment",
+        type=str,
+        default=None,
+        help="The environment in your Modal workspace where the LLM server app is hosted, defaults to your current environment",
+    )
+    parser.add_argument(
         "--app-name",
         type=str,
         default="example-vllm-openai-compatible",
@@ -125,7 +131,13 @@ def main():
 
     workspace = args.workspace or modal.config._profile
 
-    client.base_url = f"https://{workspace}--{args.app_name}-{args.function_name}.modal.run/v1"
+    environment = args.environment or modal.config.config["environment"]
+
+    prefix = workspace + (f"-{environment}" if environment else "")
+
+    client.base_url = (
+        f"https://{prefix}--{args.app_name}-{args.function_name}.modal.run/v1"
+    )
 
     if args.model:
         model_id = args.model


### PR DESCRIPTION
We construct the web url using information about the vLLM deployment provided by the user or their Modal configuration, but we weren't looking at environments. That lead to a surprising error for @shariqm-modal when his client hit the deployment in the `main` environment of the `modal-labs` workspace, which had been deployed with proxy authorization.

I think there might be a better way to figure out URLs with the `.web_url` attribute of `Function`, but I'm not 100% sure how to handle `serve`, so pushing this fix instead.