### PR TITLE
update whisper pod transcript for re-deploy

### DIFF
--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/README.md
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/README.md
@@ -2,7 +2,7 @@
 
 This is a complete application that uses [OpenAI Whisper](https://github.com/openai/whisper) to transcribe podcasts. Modal spins up 100-300 containers for a single transcription run, so hours of audio can be transcribed on-demand in a few minutes.
 
-You can find the app here: https://modal-labs--whisper-pod-transcriber-fastapi-app.modal.run/
+You can find our deployment of the app [here](https://modal-labs-examples--whisper-pod-transcriber-fastapi-app.modal.run/).
 
 ## Architecture
 

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/frontend/index.html
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/frontend/index.html
@@ -16,7 +16,7 @@
     </script>
     <a
       class="github-corner"
-      href="https://github.com/modal-labs/modal-examples/tree/main/06_gpu_and_ml/whisper_pod_transcriber"
+      href="https://github.com/modal-labs/modal-examples/tree/main/06_gpu_and_ml/openai_whisper/pod_transcriber"
       target="_blank"
       id="fork-corner"
       title="Fork me on GitHub"

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/frontend/src/routes/episode.tsx
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/frontend/src/routes/episode.tsx
@@ -197,7 +197,7 @@ function TranscribeProgress({
           <span className="modal-barloader rotate-[60deg]"></span>
         </div>
         <span className="pt-1">
-          <strong>{containerCount} Modal containers running…</strong>
+          <strong>Running on Modal…</strong>
         </span>
       </div>
       <ProgressBar

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -31,6 +31,7 @@ app_image = (
         "loguru==0.6.0",
         "torchaudio==2.1.0",
         "fastapi[standard]==0.115.4",
+        "numpy<2",
     )
     .apt_install("ffmpeg")
     .pip_install("ffmpeg-python")


### PR DESCRIPTION
The Whisper pod-transcriber app went down because it was running an old client.

This PR makes the changes needed to re-deploy. A few URLs are changed because we now deploy examples into the `examples` environment. Numpy released a new major version in the interim, so we pin below it.

Also, the container counting logic wan't working, so I dropped it.