### PR TITLE
codemod force build

### DIFF
--- a/.github/workflows/force-build-example.yml
+++ b/.github/workflows/force-build-example.yml
@@ -24,6 +24,10 @@ jobs:
           fetch-depth: 1
       - uses: ./.github/actions/setup
 
-      - name: Run a random example with MODAL_FORCE_BUILD set
+      - name: Add force build to all Image builds
         run: |
-          MODAL_FORCE_BUILD=1 python3 -m internal.run_example
+          find . -name "*.py" | LOGLEVEL=DEBUG xargs python3 internal/add_force_build.py
+
+      - name: Run a random example
+        run: |
+          python3 -m internal.run_example

--- a/internal/add_force_build.py
+++ b/internal/add_force_build.py
@@ -130,63 +130,27 @@ def extract_attr_chain(node):
         return []
 
 
-def main(
-    input_file: str, in_place: bool = False, output_file: Optional[str] = None
-) -> int:
-    """Main function to process Python files and add force_build=True.
+def main(files: list[str]) -> int:
+    """Adds force_build=True to each file in a list of files.
 
     Args:
-        input_file: Path to input Python file
-        in_place: Whether to modify the file in place
-        output_file: Path to output file (if not in_place)
+        files: Paths to input Python files
 
     Returns:
         int: Exit code (0 for success, 1 for failure)
     """
-    try:
-        source = read_source(input_file)
-        new_source = transform_source(source)
-        out_path = input_file if in_place else output_file
-        write_source(new_source, out_path)
-        return 0
-    except Exception as e:
-        logger.error(f"Failed to process {input_file}: {e}")
-        return 1
-
-
-def get_args():
-    """Parse command line arguments.
-
-    Returns:
-        argparse.Namespace: Parsed command line arguments
-    """
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Add force_build=True to modal.Image method calls."
-    )
-    parser.add_argument("input_file", help="Path to the input Python file")
-    parser.add_argument("--output_file", help="Path for the output Python file")
-    parser.add_argument(
-        "--in-place",
-        action="store_true",
-        help="Modify the file in place instead of writing to a separate output file",
-    )
-    return parser.parse_args()
+    for file in files:
+        try:
+            source = read_source(file)
+            new_source = transform_source(source)
+            write_source(new_source, file)
+        except Exception as e:
+            logger.error(f"Failed to process {file}: {e}")
+            return 1
+    return 0
 
 
 def read_source(input_file: str) -> str:
-    """Read source code from a file.
-
-    Args:
-        input_file: Path to the input file
-
-    Returns:
-        str: Source code content
-
-    Raises:
-        FileNotFoundError: If the input file doesn't exist
-    """
     try:
         return Path(input_file).read_text()
     except Exception as e:
@@ -224,12 +188,6 @@ def transform_source(source: str) -> str:
 
 
 def write_source(source: str, output_path: str) -> None:
-    """Write transformed source to output file.
-
-    Args:
-        source: Transformed source code
-        output_path: Path to write the output
-    """
     try:
         Path(output_path).write_text(source)
         logger.info(f"Successfully wrote output to {output_path}")
@@ -239,5 +197,7 @@ def write_source(source: str, output_path: str) -> None:
 
 
 if __name__ == "__main__":
-    args = get_args()
-    sys.exit(main(**vars(args)))
+    assert len(sys.argv) > 1, (
+        "USAGE: add_force_build.py some_file.py path/to/other_file.py ..."
+    )
+    sys.exit(main(sys.argv[1:]))

--- a/internal/add_force_build.py
+++ b/internal/add_force_build.py
@@ -15,7 +15,6 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 log_level = os.environ.get("LOGLEVEL", "INFO").upper()
 logging.basicConfig(

--- a/internal/add_force_build.py
+++ b/internal/add_force_build.py
@@ -1,0 +1,155 @@
+import sys
+from pathlib import Path
+
+import libcst as cst
+import libcst.matchers as m
+import modal
+
+# These are the Image construction methods that we want to add force_build to.
+
+# NOTE: these methods are in lexical order
+TARGET_METHODS = {
+    "apt_install",
+    "dockerfile_commands",
+    "from_aws_ecr",
+    "from_dockerfile",
+    "from_gcp_artifact_registry",
+    "from_registry",
+    "micromamba_install",
+    "pip_install",
+    "pip_install_private_repos",
+    "pip_install_from_requirements",
+    "pip_install_from_pyproject",
+    "poetry_install_from_file",
+    "run_commands",
+    "run_function",
+}
+
+image_methods = set(dir(modal.Image))
+assert (image_methods & TARGET_METHODS) == TARGET_METHODS, (
+    f"Unknown modal.Image method(s): {TARGET_METHODS - image_methods}"
+)
+
+# DO NOT add any of the methods that construct a base image,
+# since this will trigger a rebuild of that image and all dependent images
+base_image_methods = {"debian_slim", "micromamba"}
+assert (base_image_methods & TARGET_METHODS) == set(), (
+    f"Cannot force build base image method(s): {base_image_methods & TARGET_METHODS}"
+)
+
+
+class ForceBuildTransformer(cst.CSTTransformer):
+    """Adds force_build to targeted Image method calls."""
+
+    def __init__(self):
+        self.image_vars = set()
+
+    def is_modal_image_expr(self, expr: cst.BaseExpression) -> bool:
+        """
+        Recursively check whether `expr` ultimately originates from a modal.Image.
+        """
+        if isinstance(expr, cst.Call):
+            return self.is_modal_image_expr(expr.func)
+
+        if isinstance(expr, cst.Attribute):
+            if m.matches(
+                expr, m.Attribute(value=m.Name("modal"), attr=m.Name("Image"))
+            ):
+                return True
+            return self.is_modal_image_expr(expr.value)
+
+        if isinstance(expr, cst.Name):
+            return expr.value in self.image_vars
+
+        return False
+
+    def leave_Assign(
+        self, original_node: cst.Assign, updated_node: cst.Assign
+    ) -> cst.Assign:
+        """Track assignments of names to modal.Image objects."""
+        if m.matches(
+            original_node.value,
+            m.Call(
+                func=m.Attribute(
+                    value=m.Attribute(
+                        value=m.Name("modal"), attr=m.Name("Image")
+                    ),
+                    attr=m.Name(),
+                )
+            ),
+        ):
+            call_func = original_node.value.func
+            if isinstance(call_func, cst.Attribute):
+                method_name = call_func.attr.value
+                if method_name in TARGET_METHODS:
+                    for target in original_node.targets:
+                        if m.matches(target.target, m.Name()):
+                            var_name = target.target.value
+                            self.image_vars.add(var_name)
+        return updated_node
+
+    def leave_Call(
+        self, original_node: cst.Call, updated_node: cst.Call
+    ) -> cst.Call:
+        """
+        Modify calls to targeted methods.
+        """
+        if not isinstance(original_node.func, cst.Attribute):
+            return updated_node
+
+        method_name = original_node.func.attr.value
+        if method_name not in TARGET_METHODS:
+            return updated_node
+
+        if not self.is_modal_image_expr(original_node.func.value):
+            return updated_node
+
+        for arg in original_node.args:
+            if arg.keyword is not None and arg.keyword.value == "force_build":
+                return updated_node
+
+        new_arg = cst.Arg(
+            keyword=cst.Name("force_build"), value=cst.Name("True")
+        )
+        new_args = list(updated_node.args) + [new_arg]
+        return updated_node.with_changes(args=new_args)
+
+
+def main():
+    if len(sys.argv) > 1:
+        filename = sys.argv[1]
+        source = Path(filename).read_text()
+    else:
+        source = TEST_CASE
+
+    module = cst.parse_module(source)
+    transformer = ForceBuildTransformer()
+    modified_tree = module.visit(transformer)
+    transformed_code = modified_tree.code
+
+    if len(sys.argv) > 1:
+        Path(filename).write_text(transformed_code)
+    else:
+        assert (
+            transformed_code.count("force_build = True") == TEST_CASE["count"]
+        )
+
+
+TEST_CASE = {
+    "source": """import modal
+
+img1 = modal.Image.debian_slim().pip_install("package==1.0")  # targeted, 1
+img2 = modal.Image.debian_slim()  # not targeted
+
+img3 = modal.Image.from_dockerfile("Dockerfile")  # targeted, 2
+img3.run_commands("echo hello")  # targeted, 3
+
+def inside_function(image):
+    # This call will be missed because 'image' isn't tracked
+    image.pip_install("other_package==2.0")
+""",
+    "count": 3,
+}
+
+if __name__ == "__main__":
+    main()

--- a/internal/add_force_build.py
+++ b/internal/add_force_build.py
@@ -1,56 +1,27 @@
+"""This script heuristically adds force_build=True to the calls of modal.Image methods
+in Python source files by searching and modifying the AST.
+
+The heuristic fails with a false negative if the method call is on a variable
+whose name either is not `image` or doesn't end with `_image`.
+
+The heuristic fails with a false positive if a method with the same name as
+one of the targeted methods of modal.Image is called on a variable whose name
+either is `image` or ends with `_image`.
+
+It can be tested with `pytest --doctest-modules internal/add_force_build.py`."""
+
 import ast
+import logging
+import os
 import sys
 from pathlib import Path
+from typing import Optional
 
-
-def get_args():
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Add force_build=True to modal.Image method calls."
-    )
-    parser.add_argument("input_file", help="Path to the input Python file")
-    parser.add_argument("--output_file", help="Path for the output Python file")
-    parser.add_argument(
-        "--in-place",
-        action="store_true",
-        help="Modify the file in place instead of writing to a separate output file",
-    )
-    return parser.parse_args()
-
-
-def main(input_file, in_place=False, output_file=None):
-    try:
-        source = Path(input_file).read_text()
-    except Exception as e:
-        print(f"Error reading {input_file}: {e}")
-        sys.exit(1)
-
-    try:
-        tree = ast.parse(source)
-    except SyntaxError as e:
-        print(f"Syntax error in {input_file}: {e}")
-        sys.exit(1)
-
-    transformer = AddForceBuild()
-    new_tree = transformer.visit(tree)
-
-    try:
-        new_source = ast.unparse(new_tree)
-    except Exception as e:
-        print(f"Error unparsing AST: {e}")
-        sys.exit(1)
-
-    out_path = input_file if in_place else output_file
-
-    try:
-        Path(out_path).write_text(new_source)
-    except Exception as e:
-        print(f"Error writing to {out_path}: {e}")
-        sys.exit(1)
-
-    print(f"Successfully processed {input_file} -> {out_path}")
-    sys.exit(0)
+log_level = os.environ.get("LOGLEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, log_level), format="%(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 
 TARGET_METHODS = {
@@ -74,19 +45,26 @@ force_build = ast.keyword(arg="force_build", value=ast.Constant(value=True))
 
 
 class AddForceBuild(ast.NodeTransformer):
-    """Adds force_build=True to invocations of TARGET_METHODS on modal.Images."""
+    """Adds force_build=True to invocations of TARGET_METHODS on modal.Images.
+
+    >>> source = '''
+    ... import modal
+    ... image = modal.Image().pip_install("pandas")
+    ... '''
+    >>> tree = ast.parse(source)
+    >>> transformer = AddForceBuild()
+    >>> new_source = ast.unparse(transformer.visit(tree))
+    >>> "force_build=True" in new_source
+    True
+    """
 
     def visit_Call(self, node):
-        # if it's a method call
         if isinstance(node.func, ast.Attribute):
             method_name = node.func.attr
-            # that we want to add force_build=True to
             if method_name in TARGET_METHODS:
                 obj = node.func.value
-                # heuristically check if we're on a modal.Image
                 if is_modal_image_chain(obj) or is_image_variable(obj):
-                    print("Found target call:", ast.unparse(node))
-                    # and add force_build if it's not there already
+                    logger.debug(f"Found target call: {ast.unparse(node)}")
                     if not has_force_build_already(node.keywords):
                         node.keywords.append(force_build)
         return self.generic_visit(node)
@@ -95,8 +73,15 @@ class AddForceBuild(ast.NodeTransformer):
 def is_image_variable(node):
     """Heuristic for checking whether a name refers to a Modal Image.
 
-    False-positives are OK here, since we will only attempt to modify
-    the source if the method called on the variable is one of the TARGET_METHODS.
+    >>> node = ast.Name(id='image', ctx=ast.Load())
+    >>> is_image_variable(node)
+    True
+    >>> node = ast.Name(id='my_image', ctx=ast.Load())
+    >>> is_image_variable(node)
+    True
+    >>> node = ast.Name(id='not_imag', ctx=ast.Load())
+    >>> is_image_variable(node)
+    False
     """
     if isinstance(node, ast.Name):
         return node.id == "image" or node.id.endswith("_image")
@@ -104,29 +89,155 @@ def is_image_variable(node):
 
 
 def has_force_build_already(kwargs):
+    """Check if force_build is already in the keyword arguments."""
     return any(kw.arg == "force_build" for kw in kwargs)
 
 
 def is_modal_image_chain(node):
-    """Boolean indicating whether a chain of attributes starts with modal.Image"""
-    chain = reduce_attr_chain(node)
+    """Boolean indicating whether a chain of attributes starts with modal.Image
+
+    >>> node = ast.parse('modal.Image').body[0].value
+    >>> is_modal_image_chain(node)
+    True
+    >>> node = ast.parse('modal.Volume').body[0].value
+    >>> is_modal_image_chain(node)
+    False
+    >>> node = ast.parse('PIL.Image.open').body[0].value
+    >>> is_modal_image_chain(node)
+    False
+    """
+    chain = extract_attr_chain(node)
     return chain[:2] == ["modal", "Image"]
 
 
-def reduce_attr_chain(node):
-    """Recursively reduce an attr chain down to a name or a name and attr.
+def extract_attr_chain(node):
+    """Parse a chain of attr accesses into a list of strings.
 
-    For example, for modal.Image(...).pip_install(...).env(...), this returns ['modal', 'Image'].
+    >>> node = ast.parse('modal.Image().pip_install()').body[0].value
+    >>> extract_attr_chain(node)[:2]
+    ['modal', 'Image']
+    >>> node = ast.parse('a.b.c').body[0].value
+    >>> extract_attr_chain(node)
+    ['a', 'b', 'c']
     """
     if isinstance(node, ast.Call):
-        return reduce_attr_chain(node.func)
+        return extract_attr_chain(node.func)
     elif isinstance(node, ast.Attribute):
-        return reduce_attr_chain(node.value) + [node.attr]
+        return extract_attr_chain(node.value) + [node.attr]
     elif isinstance(node, ast.Name):
         return [node.id]
     else:
         return []
 
 
+def main(
+    input_file: str, in_place: bool = False, output_file: Optional[str] = None
+) -> int:
+    """Main function to process Python files and add force_build=True.
+
+    Args:
+        input_file: Path to input Python file
+        in_place: Whether to modify the file in place
+        output_file: Path to output file (if not in_place)
+
+    Returns:
+        int: Exit code (0 for success, 1 for failure)
+    """
+    try:
+        source = read_source(input_file)
+        new_source = transform_source(source)
+        out_path = input_file if in_place else output_file
+        write_source(new_source, out_path)
+        return 0
+    except Exception as e:
+        logger.error(f"Failed to process {input_file}: {e}")
+        return 1
+
+
+def get_args():
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command line arguments
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Add force_build=True to modal.Image method calls."
+    )
+    parser.add_argument("input_file", help="Path to the input Python file")
+    parser.add_argument("--output_file", help="Path for the output Python file")
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Modify the file in place instead of writing to a separate output file",
+    )
+    return parser.parse_args()
+
+
+def read_source(input_file: str) -> str:
+    """Read source code from a file.
+
+    Args:
+        input_file: Path to the input file
+
+    Returns:
+        str: Source code content
+
+    Raises:
+        FileNotFoundError: If the input file doesn't exist
+    """
+    try:
+        return Path(input_file).read_text()
+    except Exception as e:
+        logger.error(f"Error reading {input_file}: {e}")
+        raise
+
+
+def transform_source(source: str) -> str:
+    """Transform source code by adding force_build=True to modal.Image methods.
+
+    Args:
+        source: Python source code
+
+    Returns:
+        str: Transformed source code
+
+    >>> code = '''
+    ... import modal
+    ... image = modal.Image().pip_install("pandas")
+    ... '''
+    >>> "force_build=True" in transform_source(code)
+    True
+
+    >>> code = '''
+    ... import modal
+    ... image = modal.Image().pip_install("pandas", force_build=False)
+    ... '''
+    >>> "force_build=True" not in transform_source(code)
+    True
+    """
+    tree = ast.parse(source)
+    transformer = AddForceBuild()
+    new_tree = transformer.visit(tree)
+    return ast.unparse(new_tree)
+
+
+def write_source(source: str, output_path: str) -> None:
+    """Write transformed source to output file.
+
+    Args:
+        source: Transformed source code
+        output_path: Path to write the output
+    """
+    try:
+        Path(output_path).write_text(source)
+        logger.info(f"Successfully wrote output to {output_path}")
+    except Exception as e:
+        logger.error(f"Error writing to {output_path}: {e}")
+        raise
+
+
 if __name__ == "__main__":
-    main(**vars(get_args()))
+    args = get_args()
+    sys.exit(main(**vars(args)))

--- a/internal/requirements.txt
+++ b/internal/requirements.txt
@@ -2,7 +2,6 @@ pytest
 jupyter
 ipython
 nbconvert
-libcst==1.6.0
 jupytext~=1.16.1
 pydantic~=1.10.14
 mypy==1.2.0

--- a/internal/requirements.txt
+++ b/internal/requirements.txt
@@ -2,6 +2,7 @@ pytest
 jupyter
 ipython
 nbconvert
+libcst==1.6.0
 jupytext~=1.16.1
 pydantic~=1.10.14
 mypy==1.2.0


### PR DESCRIPTION
This PR reworks the way we trigger forced builds of examples in CI so that we don't cause base images like `debian_slim` to be rebuilt in the `modal-labs` workspace.

It can be tested by re-enabling [the force-build-example workflow](https://github.com/modal-labs/modal-examples/actions/workflows/force-build-example.yml) and triggering a manual workflow dispatch from this branch.

The new `internal/add_force_build.py` script pulls out YAML frontmatter, parses the rest of the file into an AST, and then looks for method names that match certain `modal.Image` methods and appear to be `modal.Image` attribute accesses and adds `force_build=True`.

This is admittedly a hack. It seemed like being certain a method was on a `modal.Image` was going to require full Python type-checking (and `mypy` doesn't seem designed for code modification), but there might be a creative alternative I missed (like something cursed with `inspect`).

I'm willing to scrap this PR and go back to the drawing board if it ends up more trouble than it is worth.

### Type of Change

- [x] Other (changes to the codebase, but not to examples)
