### PR TITLE
use the new -m flag where we're running 'module-style'

### DIFF
--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -274,7 +274,7 @@ class ModelHyperparameters:
 # You can kick off training with the following command:
 
 # ```bash
-# modal run 06_gpu_and_ml.hyperparameter-sweep.hp_sweep_gpt
+# modal run 06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
 # ```
 
 # The output will look something like this:
@@ -373,7 +373,7 @@ def main(
 # You can deploy this TensorBoard service by running
 
 # ```
-# modal deploy 06_gpu_and_ml.hyperparameter-sweep.hp_sweep_gpt
+# modal deploy 06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
 # ```
 
 # and visit it at the URL that ends with `-monitor-training.modal.run`.

--- a/06_gpu_and_ml/openai_whisper/finetuning/readme.md
+++ b/06_gpu_and_ml/openai_whisper/finetuning/readme.md
@@ -7,10 +7,10 @@ epochs should improve performance, decreasing WER.
 You can benchmark this example's performance using Huggingface's [**autoevaluate leaderboard**]https://huggingface.co/spaces/autoevaluate/leaderboards?dataset=mozilla-foundation%2Fcommon_voice_11_0&only_verified=0&task=automatic-speech-recognition&config=hi&split=test&metric=wer).
 
 ```bash
-modal run train.train --num_train_epochs=10
+modal run -m train.train --num_train_epochs=10
 ```
 
 ### Testing
 
-Use `modal run train.end_to_end_check` to do a full train → serialize → save → load → predict
+Use `modal run -m train.end_to_end_check` to do a full train → serialize → save → load → predict
 run in less than 5 minutes, checking that the finetuning program is functional.

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/README.md
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/README.md
@@ -44,11 +44,11 @@ The last command will start a watcher process that will rebuild your static fron
 Once you have `vite build` running, in a separate shell run this to start an ephemeral app on Modal:
 
 ```shell
-modal serve app.main
+modal serve -m app.main
 ```
 
 Pressing `Ctrl+C` will stop your app.
 
 ### Deploy to Modal
 
-Once your happy with your changes, run `modal deploy app.main` to deploy your app to Modal.
+Once your happy with your changes, run `modal deploy -m app.main` to deploy your app to Modal.

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -448,6 +448,6 @@ def fetch_episodes(show_name: str, podcast_id: str, max_episodes=100):
 @app.local_entrypoint()
 def search_entrypoint(name: str):
     # To search for a podcast, run:
-    # modal run app.main --name "search string"
+    # modal run -m app.main --name "search string"
     for pod in search_podcast.remote(name):
         print(pod)

--- a/06_gpu_and_ml/text-to-pokemon/README.md
+++ b/06_gpu_and_ml/text-to-pokemon/README.md
@@ -23,7 +23,7 @@ Run this to create an ephemeral app live reloading the web API. That way you can
 
 ```bash
 cd "$(git rev-parse --show-toplevel)/06_gpu_and_ml/text-to-pokemon"
-modal serve text_to_pokemon.main
+modal serve -m text_to_pokemon.main
 ```
 
 Sending <kbd>Ctrl</kbd>+<kbd>C</kbd> will stop your app.
@@ -41,5 +41,5 @@ cd "$(git rev-parse --show-toplevel)/06_gpu_and_ml/text-to-pokemon/text_to_pokem
 npm install
 npx vite build
 cd "$(git rev-parse --show-toplevel)/06_gpu_and_ml/text-to-pokemon/"
-modal deploy text_to_pokemon.main
+modal -m deploy text_to_pokemon.main
 ```

--- a/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
+++ b/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
@@ -8,8 +8,8 @@ if modal.is_local():
     workspace = modal.config._profile
     environment = modal.config.config["environment"]
 else:
-    workspace = os.environ["MODAL_WORKSPACE"]
-    environment = os.environ["MODAL_ENVIRONMENT"]
+    workspace = os.environ["MODAL_WORKSPACE"] or ""
+    environment = os.environ["MODAL_ENVIRONMENT"] or ""
 
 
 image = (

--- a/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
+++ b/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import modal
 
 if modal.is_local():
-    workspace = modal.config._profile
-    environment = modal.config.config["environment"]
+    workspace = modal.config._profile or ""
+    environment = modal.config.config["environment"] or ""
 else:
     workspace = os.environ["MODAL_WORKSPACE"] or ""
     environment = os.environ["MODAL_ENVIRONMENT"] or ""

--- a/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
+++ b/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "serve", "07_web_endpoints.fasthtml-checkboxes.fasthtml_checkboxes"]
+# cmd: ["modal", "serve", "-m", "07_web_endpoints.fasthtml-checkboxes.fasthtml_checkboxes"]
 # deploy: true
 # mypy: ignore-errors
 # ---

--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "run", "13_sandboxes.codelangchain.agent", "--question", "Use gpt2 and transformers to generate text"]
+# cmd: ["modal", "run", "-m", "13_sandboxes.codelangchain.agent", "--question", "Use gpt2 and transformers to generate text"]
 # pytest: false
 # ---
 
@@ -168,7 +168,7 @@ def go(
 # [from our examples repo](https://github.com/modal-labs/modal-examples/tree/main/13_sandboxes/codelangchain):
 
 # ```bash
-# modal run codelangchain.agent --question "How do I run a pre-trained model from the transformers library?"
+# modal run -m codelangchain.agent --question "How do I run a pre-trained model from the transformers library?"
 # ```
 
 
@@ -190,7 +190,7 @@ def main(
 # If things are working properly, you should see output like the following:
 
 # ```bash
-# $ modal run agent.py --question "generate some cool output with transformers"
+# $ modal run -m codelangchain.agent --question "generate some cool output with transformers"
 # ---DECISION: FINISH---
 # ---FINISHING---
 # To generate some cool output using transformers, we can use a pre-trained language model from the Hugging Face Transformers library. In this example, we'll use the GPT-2 model to generate text based on a given prompt. The GPT-2 model is a popular choice for text generation tasks due to its ability to produce coherent and contextually relevant text. We'll use the pipeline API from the Transformers library, which simplifies the process of using pre-trained models for various tasks, including text generation.

--- a/13_sandboxes/codelangchain/langserve.py
+++ b/13_sandboxes/codelangchain/langserve.py
@@ -1,6 +1,6 @@
 # ---
 # pytest: false
-# cmd: ["modal", "serve", "13_sandboxes.codelangchain.langserve"]
+# cmd: ["modal", "serve", "-m", "13_sandboxes.codelangchain.langserve"]
 # ---
 
 # # Deploy LangChain and LangGraph applications with LangServe

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ generally run the files in any folder much like you run ordinary Python programs
 command like:
 
 ```bash
-modal run 01_getting_started.hello_world
+modal run 01_getting_started/hello_world.py
 ```
 
 Although these scripts are run on your local machine, they'll communicate with


### PR DESCRIPTION
We're deprecating the automatic "module mode" execution of Python files from the modal CLI. This PR changes all the cases (that I could find via monitoring failures and a cutty regex) where we used that.