### PR TITLE
Fixed the parameter names: Updated comfyapp.py to avoid PendingDeprec…

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -114,7 +114,8 @@ app = modal.App(name="example-comfyui", image=image)
 
 @app.function(
     allow_concurrent_inputs=10,  # required for UI startup process which runs several API calls concurrently
-    concurrency_limit=1,  # limit interactive session to 1 container
+    #PendingDeprecationError: container_idle_timeout -> scaledown_window
+    max_containers=1,  # limit interactive session to 1 container 
     gpu="L40S",  # good starter GPU for inference
     volumes={"/cache": vol},  # mounts our cached models
 )
@@ -138,7 +139,8 @@ def ui():
 # Group all these steps into a single Modal `cls` object, which we'll call `ComfyUI`.
 @app.cls(
     allow_concurrent_inputs=10,  # allow 10 concurrent API calls
-    container_idle_timeout=300,  # 5 minute container keep alive after it processes an input; increasing this value is a great way to reduce ComfyUI cold start times
+#PendingDeprecationError: container_idle_timeout -> scaledown_window
+    scaledown_window=300,  # 5 minute container keep alive after it processes an input; increasing this value is a great way to reduce ComfyUI cold start times
     gpu="L40S",
     volumes={"/cache": vol},
 )


### PR DESCRIPTION
PendingDeprecationError(

I received the following errors with the previous version: 

1.) /root/comfyapp.py:139: PendingDeprecationError: 2025-02-24: We have renamed several parameters related to autoscaling. Please update your code to use the following new names:
- container_idle_timeout -> scaledown_window

2.)/root/comfyapp.py:115: PendingDeprecationError: 2025-02-24: We have renamed several parameters related to autoscaling. Please update your code to use the following new names:
- concurrency_limit -> max_containers

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [ ] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
