### PR TITLE
updates image build CI

### DIFF
--- a/.github/workflows/build-and-run-example.yml
+++ b/.github/workflows/build-and-run-example.yml
@@ -1,4 +1,4 @@
-name: Force build
+name: Build and run example
 
 on:
   workflow_dispatch:
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 1
       - uses: ./.github/actions/setup
 
-      - name: Run a random example with MODAL_FORCE_BUILD set
+      - name: Run a random example with MODAL_IGNORE_CACHE set
         run: |
-          MODAL_FORCE_BUILD=1 python3 -m internal.run_example
+          MODAL_IGNORE_CACHE=1 python3 -m internal.run_example


### PR DESCRIPTION
This PR uses the new [`MODAL_IGNORE_CACHE`](https://github.com/modal-labs/modal-client/pull/2891) flag to trigger image builds in CI without invalidating the cache for other applications in the same workspace, which blocked the actual use of the original implementation in #1074. Supercedes #1079.

### Type of Change

- [x] Other (changes to the codebase, but not to examples)