### PR TITLE
Migrate modal.web_endpoint to modal.fastapi_endpoint

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -101,9 +101,7 @@ image = (
 )
 
 # Lastly, we copy the ComfyUI workflow JSON to the container.
-image = image.add_local_file(
-    Path(__file__).parent / "workflow_api.json", "/root/workflow_api.json"
-)
+image = image.add_local_file(Path(__file__).parent / "workflow_api.json", "/root/workflow_api.json")
 
 # ## Running ComfyUI interactively
 #
@@ -133,7 +131,7 @@ def ui():
 # To run a workflow as an API:
 # 1. Stand up a "headless" ComfyUI server in the background when the app starts.
 # 2. Define an `infer` method that takes in a workflow path and runs the workflow on the ComfyUI server.
-# 3. Create a web handler `api` with `web_endpoint`, so that we can run our workflow as a service and accept inputs from clients.
+# 3. Create a web handler `api` as a web endpoint, so that we can run our workflow as a service and accept inputs from clients.
 #
 # Group all these steps into a single Modal `cls` object, which we'll call `ComfyUI`.
 @app.cls(
@@ -160,24 +158,20 @@ class ComfyUI:
 
         # looks up the name of the output image file based on the workflow
         workflow = json.loads(Path(workflow_path).read_text())
-        file_prefix = [
-            node.get("inputs")
-            for node in workflow.values()
-            if node.get("class_type") == "SaveImage"
-        ][0]["filename_prefix"]
+        file_prefix = [node.get("inputs") for node in workflow.values() if node.get("class_type") == "SaveImage"][0][
+            "filename_prefix"
+        ]
 
         # returns the image as bytes
         for f in Path(output_dir).iterdir():
             if f.name.startswith(file_prefix):
                 return f.read_bytes()
 
-    @modal.web_endpoint(method="POST")
+    @modal.fastapi_endpoint(method="POST")
     def api(self, item: Dict):
         from fastapi import Response
 
-        workflow_data = json.loads(
-            (Path(__file__).parent / "workflow_api.json").read_text()
-        )
+        workflow_data = json.loads((Path(__file__).parent / "workflow_api.json").read_text())
 
         # insert the prompt
         workflow_data["6"]["inputs"]["text"] = item["prompt"]

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -101,7 +101,9 @@ image = (
 )
 
 # Lastly, we copy the ComfyUI workflow JSON to the container.
-image = image.add_local_file(Path(__file__).parent / "workflow_api.json", "/root/workflow_api.json")
+image = image.add_local_file(
+    Path(__file__).parent / "workflow_api.json", "/root/workflow_api.json"
+)
 
 # ## Running ComfyUI interactively
 #
@@ -158,9 +160,11 @@ class ComfyUI:
 
         # looks up the name of the output image file based on the workflow
         workflow = json.loads(Path(workflow_path).read_text())
-        file_prefix = [node.get("inputs") for node in workflow.values() if node.get("class_type") == "SaveImage"][0][
-            "filename_prefix"
-        ]
+        file_prefix = [
+            node.get("inputs")
+            for node in workflow.values()
+            if node.get("class_type") == "SaveImage"
+        ][0]["filename_prefix"]
 
         # returns the image as bytes
         for f in Path(output_dir).iterdir():
@@ -171,7 +175,9 @@ class ComfyUI:
     def api(self, item: Dict):
         from fastapi import Response
 
-        workflow_data = json.loads((Path(__file__).parent / "workflow_api.json").read_text())
+        workflow_data = json.loads(
+            (Path(__file__).parent / "workflow_api.json").read_text()
+        )
 
         # insert the prompt
         workflow_data["6"]["inputs"]["text"] = item["prompt"]

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -72,7 +72,9 @@ gpu = "A10G"
 # distributed [Volume](https://modal.com/docs/guide/volumes)
 # to store the data, checkpointed models, and TensorBoard logs.
 
-volume = modal.Volume.from_name("example-hp-sweep-gpt-volume", create_if_missing=True)
+volume = modal.Volume.from_name(
+    "example-hp-sweep-gpt-volume", create_if_missing=True
+)
 volume_path = PosixPath("/vol/data")
 model_filename = "nano_gpt_model.pt"
 best_model_filename = "best_nano_gpt_model.pt"
@@ -83,7 +85,9 @@ model_save_path = volume_path / "models"
 
 # The container image for training  is based on Modal's default slim Debian Linux image with `torch`
 # for defining and running our neural network and `tensorboard` for monitoring training.
-base_image = modal.Image.debian_slim(python_version="3.11").pip_install("pydantic==2.9.1")
+base_image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "pydantic==2.9.1"
+)
 
 torch_image = base_image.pip_install(
     "torch==2.1.2",
@@ -94,14 +98,20 @@ torch_image = base_image.pip_install(
 # We also have some local dependencies that we'll need to import into the remote environment.
 # We add them into the remote container.
 
-torch_image = torch_image.add_local_dir(Path(__file__).parent / "src", remote_path="/root/src")
+torch_image = torch_image.add_local_dir(
+    Path(__file__).parent / "src", remote_path="/root/src"
+)
 
 # We'll serve a simple web endpoint:
-web_image = base_image.pip_install("fastapi[standard]==0.115.4", "starlette==0.41.2")
+web_image = base_image.pip_install(
+    "fastapi[standard]==0.115.4", "starlette==0.41.2"
+)
 
 # And we'll deploy a web UI for interacting with our trained models using Gradio.
 assets_path = Path(__file__).parent / "assets"
-ui_image = web_image.pip_install("gradio~=4.44.0").add_local_dir(assets_path, remote_path="/assets")
+ui_image = web_image.pip_install("gradio~=4.44.0").add_local_dir(
+    assets_path, remote_path="/assets"
+)
 
 
 # We can also "pre-import" libraries that will be used by the functions we run on Modal in a given image
@@ -189,7 +199,9 @@ def train_model(
     optimizer = setup_optimizer(model, learning_rate)
 
     # TensorBoard logging & checkpointing prep
-    logs_manager = LogsManager(experiment_name, hparams, num_parameters, tb_log_path)
+    logs_manager = LogsManager(
+        experiment_name, hparams, num_parameters, tb_log_path
+    )
     L.info(f"Model name: {logs_manager.model_name}")
 
     model_save_dir = model_save_path / experiment_name / logs_manager.model_name
@@ -198,13 +210,17 @@ def train_model(
         checkpoint = torch.load(str(model_save_dir / model_filename))
         is_best_model = not run_to_first_save
         if is_best_model:
-            make_best_symbolic_link(model_save_dir, model_filename, experiment_name)
+            make_best_symbolic_link(
+                model_save_dir, model_filename, experiment_name
+            )
         model.load_state_dict(checkpoint["model"])
         start_step = checkpoint["steps"] + 1
     else:
         model_save_dir.mkdir(parents=True, exist_ok=True)
         start_step = 0
-        checkpoint = init_checkpoint(model, tokenizer, optimizer, start_step, hparams)
+        checkpoint = init_checkpoint(
+            model, tokenizer, optimizer, start_step, hparams
+        )
 
     checkpoint_path = model_save_dir / model_filename
 
@@ -296,7 +312,9 @@ def main(
 
     hparams_list = [
         ModelHyperparameters(n_heads=h, context_size=c, dropout=d)
-        for h, c, d in product(nheads_options, context_size_options, dropout_options)
+        for h, c, d in product(
+            nheads_options, context_size_options, dropout_options
+        )
     ]
 
     # run training for each hyperparameter setting
@@ -318,7 +336,9 @@ def main(
         # result = (node_rank, val_loss, hparams)
         node_rank = result[0]
         results.append(result)
-        print(f"[Node {node_rank + 1}/{n_nodes}] Finished. Early stop val loss result: {result[1:]}")
+        print(
+            f"[Node {node_rank + 1}/{n_nodes}] Finished. Early stop val loss result: {result[1:]}"
+        )
 
     # find the model and hparams with the lowest validation loss
     best_result = min(results, key=lambda x: x[1])
@@ -423,7 +443,9 @@ class ModelInference:
     def get_latest_available_model_dirs(self, n_last):
         """Find the latest models that have a best model checkpoint saved."""
         save_model_dirs = glob.glob(f"{model_save_path}/*")
-        sorted_model_dirs = sorted(save_model_dirs, key=os.path.getctime, reverse=True)
+        sorted_model_dirs = sorted(
+            save_model_dirs, key=os.path.getctime, reverse=True
+        )
 
         valid_model_dirs = []
         for latest_model_dir in sorted_model_dirs:
@@ -474,7 +496,9 @@ class ModelInference:
         self.tokenizer = Tokenizer(unique_chars)
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        self.model = AttentionModel(self.tokenizer.vocab_size, hparams, self.device)
+        self.model = AttentionModel(
+            self.tokenizer.vocab_size, hparams, self.device
+        )
         self.model.load_state_dict(checkpoint["model"])
         self.model.to(self.device)
 
@@ -489,7 +513,9 @@ class ModelInference:
         self.load_model_impl()  # load updated model if available
 
         n_new_tokens = 1000
-        return self.model.generate_from_text(self.tokenizer, prompt, n_new_tokens)
+        return self.model.generate_from_text(
+            self.tokenizer, prompt, n_new_tokens
+        )
 
 
 # ### Adding a simple web endpoint
@@ -569,7 +595,9 @@ def ui():
     def generate(text="", experiment_name=""):
         if not text:
             text = "\n"
-        generated = ModelInference(experiment_name=experiment_name).generate.remote(text)
+        generated = ModelInference(
+            experiment_name=experiment_name
+        ).generate.remote(text)
         return text + generated
 
     example_prompts = [
@@ -594,8 +622,12 @@ def ui():
         css = f.read()
 
     n_last = 20
-    experiment_names = ModelInference().get_latest_available_experiment_names.remote(n_last)
-    theme = gr.themes.Default(primary_hue="green", secondary_hue="emerald", neutral_hue="neutral")
+    experiment_names = (
+        ModelInference().get_latest_available_experiment_names.remote(n_last)
+    )
+    theme = gr.themes.Default(
+        primary_hue="green", secondary_hue="emerald", neutral_hue="neutral"
+    )
 
     # add a Gradio UI around inference
     with gr.Blocks(theme=theme, css=css, title="SLM") as interface:
@@ -606,7 +638,9 @@ def ui():
         with gr.Row():
             gr.Markdown("## Model Version")
         with gr.Row():
-            experiment_dropdown = gr.Dropdown(experiment_names, label="Select Model Version")
+            experiment_dropdown = gr.Dropdown(
+                experiment_names, label="Select Model Version"
+            )
 
         # input and output
         with gr.Row():
@@ -644,7 +678,9 @@ def ui():
             # add in a few examples to inspire users
             for ii, prompt in enumerate(example_prompts):
                 btn = gr.Button(prompt, variant="secondary")
-                btn.click(fn=lambda idx=ii: example_prompts[idx], outputs=input_box)
+                btn.click(
+                    fn=lambda idx=ii: example_prompts[idx], outputs=input_box
+                )
 
     # mount for execution on Modal
     return mount_gradio_app(
@@ -727,7 +763,9 @@ def training_loop(
             # mark as finished if we hit n steps.
             checkpoint["finished_training"] = step >= n_steps
 
-            L.info(f"Saving checkpoint to {checkpoint_path}\t {checkpoint['finished_training']})")
+            L.info(
+                f"Saving checkpoint to {checkpoint_path}\t {checkpoint['finished_training']})"
+            )
             save_checkpoint(checkpoint, checkpoint_path)
 
             if run_to_first_save:
@@ -791,7 +829,9 @@ def init_checkpoint(model, tokenizer, optimizer, start_step, hparams):
 
 def log_evals(result, step, t_last, logs_manager):
     runtime_s = timer() - t_last
-    L.info(f"{step:5d}) // {runtime_s:>5.2f}s // Train Loss: {result['train']:.2f} // Val Loss: {result['val']:.2f}")
+    L.info(
+        f"{step:5d}) // {runtime_s:>5.2f}s // Train Loss: {result['train']:.2f} // Val Loss: {result['val']:.2f}"
+    )
     logs_manager.add_val_scalar("Cross Entropy Loss", result["val"], step)
     logs_manager.add_val_text("Sample Output", result["sample"], step)
     logs_manager.flush()

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -51,8 +51,9 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path, PosixPath
 
-import modal
 from pydantic import BaseModel
+
+import modal
 
 MINUTES = 60  # seconds
 HOURS = 60 * MINUTES
@@ -71,9 +72,7 @@ gpu = "A10G"
 # distributed [Volume](https://modal.com/docs/guide/volumes)
 # to store the data, checkpointed models, and TensorBoard logs.
 
-volume = modal.Volume.from_name(
-    "example-hp-sweep-gpt-volume", create_if_missing=True
-)
+volume = modal.Volume.from_name("example-hp-sweep-gpt-volume", create_if_missing=True)
 volume_path = PosixPath("/vol/data")
 model_filename = "nano_gpt_model.pt"
 best_model_filename = "best_nano_gpt_model.pt"
@@ -84,9 +83,7 @@ model_save_path = volume_path / "models"
 
 # The container image for training  is based on Modal's default slim Debian Linux image with `torch`
 # for defining and running our neural network and `tensorboard` for monitoring training.
-base_image = modal.Image.debian_slim(python_version="3.11").pip_install(
-    "pydantic==2.9.1"
-)
+base_image = modal.Image.debian_slim(python_version="3.11").pip_install("pydantic==2.9.1")
 
 torch_image = base_image.pip_install(
     "torch==2.1.2",
@@ -97,20 +94,14 @@ torch_image = base_image.pip_install(
 # We also have some local dependencies that we'll need to import into the remote environment.
 # We add them into the remote container.
 
-torch_image = torch_image.add_local_dir(
-    Path(__file__).parent / "src", remote_path="/root/src"
-)
+torch_image = torch_image.add_local_dir(Path(__file__).parent / "src", remote_path="/root/src")
 
 # We'll serve a simple web endpoint:
-web_image = base_image.pip_install(
-    "fastapi[standard]==0.115.4", "starlette==0.41.2"
-)
+web_image = base_image.pip_install("fastapi[standard]==0.115.4", "starlette==0.41.2")
 
 # And we'll deploy a web UI for interacting with our trained models using Gradio.
 assets_path = Path(__file__).parent / "assets"
-ui_image = web_image.pip_install("gradio~=4.44.0").add_local_dir(
-    assets_path, remote_path="/assets"
-)
+ui_image = web_image.pip_install("gradio~=4.44.0").add_local_dir(assets_path, remote_path="/assets")
 
 
 # We can also "pre-import" libraries that will be used by the functions we run on Modal in a given image
@@ -198,9 +189,7 @@ def train_model(
     optimizer = setup_optimizer(model, learning_rate)
 
     # TensorBoard logging & checkpointing prep
-    logs_manager = LogsManager(
-        experiment_name, hparams, num_parameters, tb_log_path
-    )
+    logs_manager = LogsManager(experiment_name, hparams, num_parameters, tb_log_path)
     L.info(f"Model name: {logs_manager.model_name}")
 
     model_save_dir = model_save_path / experiment_name / logs_manager.model_name
@@ -209,17 +198,13 @@ def train_model(
         checkpoint = torch.load(str(model_save_dir / model_filename))
         is_best_model = not run_to_first_save
         if is_best_model:
-            make_best_symbolic_link(
-                model_save_dir, model_filename, experiment_name
-            )
+            make_best_symbolic_link(model_save_dir, model_filename, experiment_name)
         model.load_state_dict(checkpoint["model"])
         start_step = checkpoint["steps"] + 1
     else:
         model_save_dir.mkdir(parents=True, exist_ok=True)
         start_step = 0
-        checkpoint = init_checkpoint(
-            model, tokenizer, optimizer, start_step, hparams
-        )
+        checkpoint = init_checkpoint(model, tokenizer, optimizer, start_step, hparams)
 
     checkpoint_path = model_save_dir / model_filename
 
@@ -311,9 +296,7 @@ def main(
 
     hparams_list = [
         ModelHyperparameters(n_heads=h, context_size=c, dropout=d)
-        for h, c, d in product(
-            nheads_options, context_size_options, dropout_options
-        )
+        for h, c, d in product(nheads_options, context_size_options, dropout_options)
     ]
 
     # run training for each hyperparameter setting
@@ -335,9 +318,7 @@ def main(
         # result = (node_rank, val_loss, hparams)
         node_rank = result[0]
         results.append(result)
-        print(
-            f"[Node {node_rank + 1}/{n_nodes}] Finished. Early stop val loss result: {result[1:]}"
-        )
+        print(f"[Node {node_rank + 1}/{n_nodes}] Finished. Early stop val loss result: {result[1:]}")
 
     # find the model and hparams with the lowest validation loss
     best_result = min(results, key=lambda x: x[1])
@@ -442,9 +423,7 @@ class ModelInference:
     def get_latest_available_model_dirs(self, n_last):
         """Find the latest models that have a best model checkpoint saved."""
         save_model_dirs = glob.glob(f"{model_save_path}/*")
-        sorted_model_dirs = sorted(
-            save_model_dirs, key=os.path.getctime, reverse=True
-        )
+        sorted_model_dirs = sorted(save_model_dirs, key=os.path.getctime, reverse=True)
 
         valid_model_dirs = []
         for latest_model_dir in sorted_model_dirs:
@@ -495,9 +474,7 @@ class ModelInference:
         self.tokenizer = Tokenizer(unique_chars)
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        self.model = AttentionModel(
-            self.tokenizer.vocab_size, hparams, self.device
-        )
+        self.model = AttentionModel(self.tokenizer.vocab_size, hparams, self.device)
         self.model.load_state_dict(checkpoint["model"])
         self.model.to(self.device)
 
@@ -512,12 +489,10 @@ class ModelInference:
         self.load_model_impl()  # load updated model if available
 
         n_new_tokens = 1000
-        return self.model.generate_from_text(
-            self.tokenizer, prompt, n_new_tokens
-        )
+        return self.model.generate_from_text(self.tokenizer, prompt, n_new_tokens)
 
 
-# ### Adding a simple `web_endpoint`
+# ### Adding a simple web endpoint
 
 # The `ModelInference` class above is available for use
 # from any other Python environment with the right Modal credentials
@@ -532,7 +507,7 @@ class GenerationRequest(BaseModel):
 
 
 @app.function(image=web_image)
-@modal.web_endpoint(method="POST", docs=True)
+@modal.fastapi_endpoint(method="POST", docs=True)
 def web_generate(request: GenerationRequest):
     output = ModelInference().generate.remote(request.prompt)
     return {"output": output}
@@ -594,9 +569,7 @@ def ui():
     def generate(text="", experiment_name=""):
         if not text:
             text = "\n"
-        generated = ModelInference(
-            experiment_name=experiment_name
-        ).generate.remote(text)
+        generated = ModelInference(experiment_name=experiment_name).generate.remote(text)
         return text + generated
 
     example_prompts = [
@@ -621,12 +594,8 @@ def ui():
         css = f.read()
 
     n_last = 20
-    experiment_names = (
-        ModelInference().get_latest_available_experiment_names.remote(n_last)
-    )
-    theme = gr.themes.Default(
-        primary_hue="green", secondary_hue="emerald", neutral_hue="neutral"
-    )
+    experiment_names = ModelInference().get_latest_available_experiment_names.remote(n_last)
+    theme = gr.themes.Default(primary_hue="green", secondary_hue="emerald", neutral_hue="neutral")
 
     # add a Gradio UI around inference
     with gr.Blocks(theme=theme, css=css, title="SLM") as interface:
@@ -637,9 +606,7 @@ def ui():
         with gr.Row():
             gr.Markdown("## Model Version")
         with gr.Row():
-            experiment_dropdown = gr.Dropdown(
-                experiment_names, label="Select Model Version"
-            )
+            experiment_dropdown = gr.Dropdown(experiment_names, label="Select Model Version")
 
         # input and output
         with gr.Row():
@@ -677,9 +644,7 @@ def ui():
             # add in a few examples to inspire users
             for ii, prompt in enumerate(example_prompts):
                 btn = gr.Button(prompt, variant="secondary")
-                btn.click(
-                    fn=lambda idx=ii: example_prompts[idx], outputs=input_box
-                )
+                btn.click(fn=lambda idx=ii: example_prompts[idx], outputs=input_box)
 
     # mount for execution on Modal
     return mount_gradio_app(
@@ -762,9 +727,7 @@ def training_loop(
             # mark as finished if we hit n steps.
             checkpoint["finished_training"] = step >= n_steps
 
-            L.info(
-                f"Saving checkpoint to {checkpoint_path}\t {checkpoint['finished_training']})"
-            )
+            L.info(f"Saving checkpoint to {checkpoint_path}\t {checkpoint['finished_training']})")
             save_checkpoint(checkpoint, checkpoint_path)
 
             if run_to_first_save:
@@ -828,9 +791,7 @@ def init_checkpoint(model, tokenizer, optimizer, start_step, hparams):
 
 def log_evals(result, step, t_last, logs_manager):
     runtime_s = timer() - t_last
-    L.info(
-        f"{step:5d}) // {runtime_s:>5.2f}s // Train Loss: {result['train']:.2f} // Val Loss: {result['val']:.2f}"
-    )
+    L.info(f"{step:5d}) // {runtime_s:>5.2f}s // Train Loss: {result['train']:.2f} // Val Loss: {result['val']:.2f}")
     logs_manager.add_val_scalar("Cross Entropy Loss", result["val"], step)
     logs_manager.add_val_text("Sample Output", result["sample"], step)
     logs_manager.flush()

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -51,9 +51,8 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path, PosixPath
 
-from pydantic import BaseModel
-
 import modal
+from pydantic import BaseModel
 
 MINUTES = 60  # seconds
 HOURS = 60 * MINUTES

--- a/06_gpu_and_ml/langchains/potus_speech_qanda.py
+++ b/06_gpu_and_ml/langchains/potus_speech_qanda.py
@@ -46,7 +46,11 @@ image = modal.Image.debian_slim(python_version="3.11").pip_install(
 app = modal.App(
     name="example-langchain-qanda",
     image=image,
-    secrets=[modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"])],
+    secrets=[
+        modal.Secret.from_name(
+            "openai-secret", required_keys=["OPENAI_API_KEY"]
+        )
+    ],
 )
 
 retriever = None  # embedding index that's relatively expensive to compute, so caching with global var.

--- a/06_gpu_and_ml/langchains/potus_speech_qanda.py
+++ b/06_gpu_and_ml/langchains/potus_speech_qanda.py
@@ -46,11 +46,7 @@ image = modal.Image.debian_slim(python_version="3.11").pip_install(
 app = modal.App(
     name="example-langchain-qanda",
     image=image,
-    secrets=[
-        modal.Secret.from_name(
-            "openai-secret", required_keys=["OPENAI_API_KEY"]
-        )
-    ],
+    secrets=[modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"])],
 )
 
 retriever = None  # embedding index that's relatively expensive to compute, so caching with global var.
@@ -180,7 +176,7 @@ def qanda_langchain(query: str) -> tuple[str, list[str]]:
 
 
 @app.function()
-@modal.web_endpoint(method="GET", docs=True)
+@modal.fastapi_endpoint(method="GET", docs=True)
 def web(query: str, show_sources: bool = False):
     answer, sources = qanda_langchain(query)
     if show_sources:

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -126,7 +126,9 @@ class Model:
             tp_size=GPU_COUNT,  # t_ensor p_arallel size, number of GPUs to split the model over
             log_level=SGL_LOG_LEVEL,
         )
-        self.runtime.endpoint.chat_template = sgl.lang.chat_template.get_chat_template(MODEL_CHAT_TEMPLATE)
+        self.runtime.endpoint.chat_template = (
+            sgl.lang.chat_template.get_chat_template(MODEL_CHAT_TEMPLATE)
+        )
         sgl.set_default_backend(self.runtime)
 
     @modal.fastapi_endpoint(method="POST", docs=True)
@@ -160,9 +162,13 @@ class Model:
         if question is None:
             question = "What is this?"
 
-        state = image_qa.run(image_path=image_path, question=question, max_new_tokens=128)
+        state = image_qa.run(
+            image_path=image_path, question=question, max_new_tokens=128
+        )
         # show the question, image, and response in the terminal for demonstration purposes
-        print(Colors.BOLD, Colors.GRAY, "Question: ", question, Colors.END, sep="")
+        print(
+            Colors.BOLD, Colors.GRAY, "Question: ", question, Colors.END, sep=""
+        )
         terminal_image = from_file(image_path)
         terminal_image.draw()
         answer = state["answer"]
@@ -173,7 +179,9 @@ class Model:
             Colors.END,
             sep="",
         )
-        print(f"request {request_id} completed in {round((time.monotonic_ns() - start) / 1e9, 2)} seconds")
+        print(
+            f"request {request_id} completed in {round((time.monotonic_ns() - start) / 1e9, 2)} seconds"
+        )
 
     @modal.exit()  # what should a container do before it shuts down?
     def shutdown_runtime(self):

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -21,9 +21,8 @@ import time
 import warnings
 from uuid import uuid4
 
-import requests
-
 import modal
+import requests
 
 # VLMs are generally larger than LLMs with the same cognitive capability.
 # LLMs are already hard to run effectively on CPUs, so we'll use a GPU here.

--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -53,9 +53,8 @@
 
 from typing import Optional
 
-import pydantic  # for typing, used later
-
 import modal
+import pydantic  # for typing, used later
 
 tensorrt_image = modal.Image.from_registry(
     "nvidia/cuda:12.4.1-devel-ubuntu22.04",

--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -66,7 +66,9 @@ tensorrt_image = modal.Image.from_registry(
 # including OpenMPI for distributed communication, some core software like `git`,
 # and the `tensorrt_llm` package itself.
 
-tensorrt_image = tensorrt_image.apt_install("openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget").pip_install(
+tensorrt_image = tensorrt_image.apt_install(
+    "openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget"
+).pip_install(
     "tensorrt_llm==0.14.0",
     "pynvml<12",  # avoid breaking change to pynvml version API
     pre=True,
@@ -145,9 +147,7 @@ tensorrt_image = (  # update the image by downloading the model we're using
 # This script takes a few minutes to run.
 
 GIT_HASH = "b0880169d0fb8cd0363049d91aa548e58a41be07"
-CONVERSION_SCRIPT_URL = (
-    f"https://raw.githubusercontent.com/NVIDIA/TensorRT-LLM/{GIT_HASH}/examples/quantization/quantize.py"
-)
+CONVERSION_SCRIPT_URL = f"https://raw.githubusercontent.com/NVIDIA/TensorRT-LLM/{GIT_HASH}/examples/quantization/quantize.py"
 
 # NVIDIA's Ada Lovelace/Hopper chips, like the 4090, L40S, and H100,
 # are capable of native calculations in 8bit floating point numbers, so we choose that as our quantization format (`qformat`).
@@ -208,7 +208,9 @@ tensorrt_image = (  # update the image by quantizing the model
 
 MAX_INPUT_LEN, MAX_OUTPUT_LEN = 256, 256
 MAX_NUM_TOKENS = 2**17
-MAX_BATCH_SIZE = 1024  # better throughput at larger batch sizes, limited by GPU RAM
+MAX_BATCH_SIZE = (
+    1024  # better throughput at larger batch sizes, limited by GPU RAM
+)
 ENGINE_DIR = "/root/model/model_output"
 
 SIZE_ARGS = f"--max_input_len={MAX_INPUT_LEN} --max_num_tokens={MAX_NUM_TOKENS} --max_batch_size={MAX_BATCH_SIZE}"
@@ -248,7 +250,9 @@ tensorrt_image = (  # update the image by building the TensorRT engine
 
 # Now that we have the engine compiled, we can serve it with Modal by creating an `App`.
 
-app = modal.App(f"example-trtllm-{MODEL_ID.split('/')[-1]}", image=tensorrt_image)
+app = modal.App(
+    f"example-trtllm-{MODEL_ID.split('/')[-1]}", image=tensorrt_image
+)
 
 # Thanks to our custom container runtime system even this large, many gigabyte container boots in seconds.
 
@@ -274,7 +278,9 @@ class Model:
         The @enter decorator ensures that it runs only once per container, when it starts."""
         import time
 
-        print(f"{COLOR['HEADER']}🥶 Cold boot: spinning up TRT-LLM engine{COLOR['ENDC']}")
+        print(
+            f"{COLOR['HEADER']}🥶 Cold boot: spinning up TRT-LLM engine{COLOR['ENDC']}"
+        )
         self.init_start = time.monotonic_ns()
 
         import tensorrt_llm
@@ -283,7 +289,9 @@ class Model:
 
         self.tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
         # LLaMA models do not have a padding token, so we use the EOS token
-        self.tokenizer.add_special_tokens({"pad_token": self.tokenizer.eos_token})
+        self.tokenizer.add_special_tokens(
+            {"pad_token": self.tokenizer.eos_token}
+        )
         # and then we add it from the left, to minimize impact on the output
         self.tokenizer.padding_side = "left"
         self.pad_id = self.tokenizer.pad_token_id
@@ -299,7 +307,9 @@ class Model:
         self.model = ModelRunner.from_dir(**runner_kwargs)
 
         self.init_duration_s = (time.monotonic_ns() - self.init_start) / 1e9
-        print(f"{COLOR['HEADER']}🚀 Cold boot finished in {self.init_duration_s}s{COLOR['ENDC']}")
+        print(
+            f"{COLOR['HEADER']}🚀 Cold boot finished in {self.init_duration_s}s{COLOR['ENDC']}"
+        )
 
     @modal.method()
     def generate(self, prompts: list[str], settings=None):
@@ -314,16 +324,22 @@ class Model:
                 repetition_penalty=1.1,
             )
 
-        settings["max_new_tokens"] = MAX_OUTPUT_LEN  # exceeding this will raise an error
+        settings["max_new_tokens"] = (
+            MAX_OUTPUT_LEN  # exceeding this will raise an error
+        )
         settings["end_id"] = self.end_id
         settings["pad_id"] = self.pad_id
 
         num_prompts = len(prompts)
 
         if num_prompts > MAX_BATCH_SIZE:
-            raise ValueError(f"Batch size {num_prompts} exceeds maximum of {MAX_BATCH_SIZE}")
+            raise ValueError(
+                f"Batch size {num_prompts} exceeds maximum of {MAX_BATCH_SIZE}"
+            )
 
-        print(f"{COLOR['HEADER']}🚀 Generating completions for batch of size {num_prompts}...{COLOR['ENDC']}")
+        print(
+            f"{COLOR['HEADER']}🚀 Generating completions for batch of size {num_prompts}...{COLOR['ENDC']}"
+        )
         start = time.monotonic_ns()
 
         parsed_prompts = [
@@ -341,18 +357,29 @@ class Model:
             sep="\n\t",
         )
 
-        inputs_t = self.tokenizer(parsed_prompts, return_tensors="pt", padding=True, truncation=False)["input_ids"]
+        inputs_t = self.tokenizer(
+            parsed_prompts, return_tensors="pt", padding=True, truncation=False
+        )["input_ids"]
 
-        print(f"{COLOR['HEADER']}Input tensors:{COLOR['ENDC']}", inputs_t[:, :8])
+        print(
+            f"{COLOR['HEADER']}Input tensors:{COLOR['ENDC']}", inputs_t[:, :8]
+        )
 
         outputs_t = self.model.generate(inputs_t, **settings)
 
-        outputs_text = self.tokenizer.batch_decode(outputs_t[:, 0])  # only one output per input, so we index with 0
+        outputs_text = self.tokenizer.batch_decode(
+            outputs_t[:, 0]
+        )  # only one output per input, so we index with 0
 
-        responses = [extract_assistant_response(output_text) for output_text in outputs_text]
+        responses = [
+            extract_assistant_response(output_text)
+            for output_text in outputs_text
+        ]
         duration_s = (time.monotonic_ns() - start) / 1e9
 
-        num_tokens = sum(map(lambda r: len(self.tokenizer.encode(r)), responses))
+        num_tokens = sum(
+            map(lambda r: len(self.tokenizer.encode(r)), responses)
+        )
 
         for prompt, response in zip(prompts, responses):
             print(
@@ -579,7 +606,9 @@ class GenerateRequest(pydantic.BaseModel):
 
 
 @app.function(image=web_image)
-@modal.fastapi_endpoint(method="POST", label=f"{MODEL_ID.lower().split('/')[-1]}-web", docs=True)
+@modal.fastapi_endpoint(
+    method="POST", label=f"{MODEL_ID.lower().split('/')[-1]}-web", docs=True
+)
 def generate_web(data: GenerateRequest) -> list[str]:
     """Generate responses to a batch of prompts, optionally with custom inference settings."""
     return Model.generate.remote(data.prompts, settings=None)

--- a/06_gpu_and_ml/llm-serving/trtllm_llama.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_llama.py
@@ -53,8 +53,9 @@
 
 from typing import Optional
 
-import modal
 import pydantic  # for typing, used later
+
+import modal
 
 tensorrt_image = modal.Image.from_registry(
     "nvidia/cuda:12.4.1-devel-ubuntu22.04",
@@ -65,9 +66,7 @@ tensorrt_image = modal.Image.from_registry(
 # including OpenMPI for distributed communication, some core software like `git`,
 # and the `tensorrt_llm` package itself.
 
-tensorrt_image = tensorrt_image.apt_install(
-    "openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget"
-).pip_install(
+tensorrt_image = tensorrt_image.apt_install("openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget").pip_install(
     "tensorrt_llm==0.14.0",
     "pynvml<12",  # avoid breaking change to pynvml version API
     pre=True,
@@ -146,7 +145,9 @@ tensorrt_image = (  # update the image by downloading the model we're using
 # This script takes a few minutes to run.
 
 GIT_HASH = "b0880169d0fb8cd0363049d91aa548e58a41be07"
-CONVERSION_SCRIPT_URL = f"https://raw.githubusercontent.com/NVIDIA/TensorRT-LLM/{GIT_HASH}/examples/quantization/quantize.py"
+CONVERSION_SCRIPT_URL = (
+    f"https://raw.githubusercontent.com/NVIDIA/TensorRT-LLM/{GIT_HASH}/examples/quantization/quantize.py"
+)
 
 # NVIDIA's Ada Lovelace/Hopper chips, like the 4090, L40S, and H100,
 # are capable of native calculations in 8bit floating point numbers, so we choose that as our quantization format (`qformat`).
@@ -207,9 +208,7 @@ tensorrt_image = (  # update the image by quantizing the model
 
 MAX_INPUT_LEN, MAX_OUTPUT_LEN = 256, 256
 MAX_NUM_TOKENS = 2**17
-MAX_BATCH_SIZE = (
-    1024  # better throughput at larger batch sizes, limited by GPU RAM
-)
+MAX_BATCH_SIZE = 1024  # better throughput at larger batch sizes, limited by GPU RAM
 ENGINE_DIR = "/root/model/model_output"
 
 SIZE_ARGS = f"--max_input_len={MAX_INPUT_LEN} --max_num_tokens={MAX_NUM_TOKENS} --max_batch_size={MAX_BATCH_SIZE}"
@@ -249,9 +248,7 @@ tensorrt_image = (  # update the image by building the TensorRT engine
 
 # Now that we have the engine compiled, we can serve it with Modal by creating an `App`.
 
-app = modal.App(
-    f"example-trtllm-{MODEL_ID.split('/')[-1]}", image=tensorrt_image
-)
+app = modal.App(f"example-trtllm-{MODEL_ID.split('/')[-1]}", image=tensorrt_image)
 
 # Thanks to our custom container runtime system even this large, many gigabyte container boots in seconds.
 
@@ -277,9 +274,7 @@ class Model:
         The @enter decorator ensures that it runs only once per container, when it starts."""
         import time
 
-        print(
-            f"{COLOR['HEADER']}🥶 Cold boot: spinning up TRT-LLM engine{COLOR['ENDC']}"
-        )
+        print(f"{COLOR['HEADER']}🥶 Cold boot: spinning up TRT-LLM engine{COLOR['ENDC']}")
         self.init_start = time.monotonic_ns()
 
         import tensorrt_llm
@@ -288,9 +283,7 @@ class Model:
 
         self.tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
         # LLaMA models do not have a padding token, so we use the EOS token
-        self.tokenizer.add_special_tokens(
-            {"pad_token": self.tokenizer.eos_token}
-        )
+        self.tokenizer.add_special_tokens({"pad_token": self.tokenizer.eos_token})
         # and then we add it from the left, to minimize impact on the output
         self.tokenizer.padding_side = "left"
         self.pad_id = self.tokenizer.pad_token_id
@@ -306,9 +299,7 @@ class Model:
         self.model = ModelRunner.from_dir(**runner_kwargs)
 
         self.init_duration_s = (time.monotonic_ns() - self.init_start) / 1e9
-        print(
-            f"{COLOR['HEADER']}🚀 Cold boot finished in {self.init_duration_s}s{COLOR['ENDC']}"
-        )
+        print(f"{COLOR['HEADER']}🚀 Cold boot finished in {self.init_duration_s}s{COLOR['ENDC']}")
 
     @modal.method()
     def generate(self, prompts: list[str], settings=None):
@@ -323,22 +314,16 @@ class Model:
                 repetition_penalty=1.1,
             )
 
-        settings["max_new_tokens"] = (
-            MAX_OUTPUT_LEN  # exceeding this will raise an error
-        )
+        settings["max_new_tokens"] = MAX_OUTPUT_LEN  # exceeding this will raise an error
         settings["end_id"] = self.end_id
         settings["pad_id"] = self.pad_id
 
         num_prompts = len(prompts)
 
         if num_prompts > MAX_BATCH_SIZE:
-            raise ValueError(
-                f"Batch size {num_prompts} exceeds maximum of {MAX_BATCH_SIZE}"
-            )
+            raise ValueError(f"Batch size {num_prompts} exceeds maximum of {MAX_BATCH_SIZE}")
 
-        print(
-            f"{COLOR['HEADER']}🚀 Generating completions for batch of size {num_prompts}...{COLOR['ENDC']}"
-        )
+        print(f"{COLOR['HEADER']}🚀 Generating completions for batch of size {num_prompts}...{COLOR['ENDC']}")
         start = time.monotonic_ns()
 
         parsed_prompts = [
@@ -356,29 +341,18 @@ class Model:
             sep="\n\t",
         )
 
-        inputs_t = self.tokenizer(
-            parsed_prompts, return_tensors="pt", padding=True, truncation=False
-        )["input_ids"]
+        inputs_t = self.tokenizer(parsed_prompts, return_tensors="pt", padding=True, truncation=False)["input_ids"]
 
-        print(
-            f"{COLOR['HEADER']}Input tensors:{COLOR['ENDC']}", inputs_t[:, :8]
-        )
+        print(f"{COLOR['HEADER']}Input tensors:{COLOR['ENDC']}", inputs_t[:, :8])
 
         outputs_t = self.model.generate(inputs_t, **settings)
 
-        outputs_text = self.tokenizer.batch_decode(
-            outputs_t[:, 0]
-        )  # only one output per input, so we index with 0
+        outputs_text = self.tokenizer.batch_decode(outputs_t[:, 0])  # only one output per input, so we index with 0
 
-        responses = [
-            extract_assistant_response(output_text)
-            for output_text in outputs_text
-        ]
+        responses = [extract_assistant_response(output_text) for output_text in outputs_text]
         duration_s = (time.monotonic_ns() - start) / 1e9
 
-        num_tokens = sum(
-            map(lambda r: len(self.tokenizer.encode(r)), responses)
-        )
+        num_tokens = sum(map(lambda r: len(self.tokenizer.encode(r)), responses))
 
         for prompt, response in zip(prompts, responses):
             print(
@@ -583,7 +557,7 @@ def main():
 
 # ### Calling inference via an API
 
-# We can use `modal.web_endpoint` and `app.function` to turn any Python function into a web API.
+# We can use `modal.fastapi_endpoint` with `app.function` to turn any Python function into a web API.
 
 # This API wrapper doesn't need all the dependencies of the core inference service,
 # so we switch images here to a basic Linux image, `debian_slim`, and add the FastAPI stack.
@@ -605,9 +579,7 @@ class GenerateRequest(pydantic.BaseModel):
 
 
 @app.function(image=web_image)
-@modal.web_endpoint(
-    method="POST", label=f"{MODEL_ID.lower().split('/')[-1]}-web", docs=True
-)
+@modal.fastapi_endpoint(method="POST", label=f"{MODEL_ID.lower().split('/')[-1]}-web", docs=True)
 def generate_web(data: GenerateRequest) -> list[str]:
     """Generate responses to a batch of prompts, optionally with custom inference settings."""
     return Model.generate.remote(data.prompts, settings=None)

--- a/06_gpu_and_ml/stable_diffusion/stable_video_diffusion.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_video_diffusion.py
@@ -11,9 +11,7 @@ import sys
 import modal
 
 app = modal.App(name="example-stable-video-diffusion-streamlit")
-q = modal.Queue.from_name(
-    "stable-video-diffusion-streamlit", create_if_missing=True
-)
+q = modal.Queue.from_name("stable-video-diffusion-streamlit", create_if_missing=True)
 
 session_timeout = 15 * 60
 
@@ -44,9 +42,7 @@ svd_image = (
     # pre-built python 3.11 wheel.
     modal.Image.debian_slim(python_version="3.10")
     .apt_install("git")
-    .run_commands(
-        "git clone https://github.com/Stability-AI/generative-models.git /sgm"
-    )
+    .run_commands("git clone https://github.com/Stability-AI/generative-models.git /sgm")
     .workdir("/sgm")
     .pip_install(".")
     .pip_install(
@@ -75,9 +71,7 @@ def run_streamlit(publish_url: bool = False):
         # Reload Streamlit config with information about Modal tunnel address.
         if publish_url:
             q.put(tunnel.url)
-        load_config_options(
-            {"browser.serverAddress": tunnel.host, "browser.serverPort": 443}
-        )
+        load_config_options({"browser.serverAddress": tunnel.host, "browser.serverPort": 443})
         run(
             main_script_path="/sgm/scripts/demo/video_sampling.py",
             is_hello=False,
@@ -94,7 +88,7 @@ endpoint_image = modal.Image.debian_slim(python_version="3.10").pip_install(
 
 
 @app.function(image=endpoint_image)
-@modal.web_endpoint(method="GET", label="svd")
+@modal.fastapi_endpoint(method="GET", label="svd")
 def share():
     from fastapi.responses import RedirectResponse
 

--- a/06_gpu_and_ml/stable_diffusion/stable_video_diffusion.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_video_diffusion.py
@@ -11,7 +11,9 @@ import sys
 import modal
 
 app = modal.App(name="example-stable-video-diffusion-streamlit")
-q = modal.Queue.from_name("stable-video-diffusion-streamlit", create_if_missing=True)
+q = modal.Queue.from_name(
+    "stable-video-diffusion-streamlit", create_if_missing=True
+)
 
 session_timeout = 15 * 60
 
@@ -42,7 +44,9 @@ svd_image = (
     # pre-built python 3.11 wheel.
     modal.Image.debian_slim(python_version="3.10")
     .apt_install("git")
-    .run_commands("git clone https://github.com/Stability-AI/generative-models.git /sgm")
+    .run_commands(
+        "git clone https://github.com/Stability-AI/generative-models.git /sgm"
+    )
     .workdir("/sgm")
     .pip_install(".")
     .pip_install(
@@ -71,7 +75,9 @@ def run_streamlit(publish_url: bool = False):
         # Reload Streamlit config with information about Modal tunnel address.
         if publish_url:
             q.put(tunnel.url)
-        load_config_options({"browser.serverAddress": tunnel.host, "browser.serverPort": 443})
+        load_config_options(
+            {"browser.serverAddress": tunnel.host, "browser.serverPort": 443}
+        )
         run(
             main_script_path="/sgm/scripts/demo/video_sampling.py",
             is_hello=False,

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -104,9 +104,7 @@ class Inference:
         ).to("cuda")
 
     @modal.method()
-    def run(
-        self, prompt: str, batch_size: int = 4, seed: int = None
-    ) -> list[bytes]:
+    def run(self, prompt: str, batch_size: int = 4, seed: int = None) -> list[bytes]:
         seed = seed if seed is not None else random.randint(0, 2**32 - 1)
         print("seeding RNG with", seed)
         torch.manual_seed(seed)
@@ -126,7 +124,7 @@ class Inference:
         torch.cuda.empty_cache()  # reduce fragmentation
         return image_output
 
-    @modal.web_endpoint(docs=True)
+    @modal.fastapi_endpoint(docs=True)
     def web(self, prompt: str, seed: int = None):
         return Response(
             content=self.run.local(  # run in the same container
@@ -179,13 +177,10 @@ def entrypoint(
         duration = time.time() - start
         print(f"Run {sample_idx + 1} took {duration:.3f}s")
         if sample_idx:
-            print(
-                f"\tGenerated {len(images)} image(s) at {(duration) / len(images):.3f}s / image."
-            )
+            print(f"\tGenerated {len(images)} image(s) at {(duration) / len(images):.3f}s / image.")
         for batch_idx, image_bytes in enumerate(images):
             output_path = (
-                output_dir
-                / f"output_{slugify(prompt)[:64]}_{str(sample_idx).zfill(2)}_{str(batch_idx).zfill(2)}.png"
+                output_dir / f"output_{slugify(prompt)[:64]}_{str(sample_idx).zfill(2)}_{str(batch_idx).zfill(2)}.png"
             )
             if not batch_idx:
                 print("Saving outputs", end="\n\t")
@@ -198,7 +193,7 @@ def entrypoint(
 
 # ## Generating Stable Diffusion images via an API
 
-# The Modal `Cls` above also included a [`web_endpoint`](https://modal.com/docs/examples/basic_web),
+# The Modal `Cls` above also included a [`fastapi_endpoint`](https://modal.com/docs/examples/basic_web),
 # which adds a simple web API to the inference method.
 
 # To try it out, run

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -104,7 +104,9 @@ class Inference:
         ).to("cuda")
 
     @modal.method()
-    def run(self, prompt: str, batch_size: int = 4, seed: int = None) -> list[bytes]:
+    def run(
+        self, prompt: str, batch_size: int = 4, seed: int = None
+    ) -> list[bytes]:
         seed = seed if seed is not None else random.randint(0, 2**32 - 1)
         print("seeding RNG with", seed)
         torch.manual_seed(seed)
@@ -177,10 +179,13 @@ def entrypoint(
         duration = time.time() - start
         print(f"Run {sample_idx + 1} took {duration:.3f}s")
         if sample_idx:
-            print(f"\tGenerated {len(images)} image(s) at {(duration) / len(images):.3f}s / image.")
+            print(
+                f"\tGenerated {len(images)} image(s) at {(duration) / len(images):.3f}s / image."
+            )
         for batch_idx, image_bytes in enumerate(images):
             output_path = (
-                output_dir / f"output_{slugify(prompt)[:64]}_{str(sample_idx).zfill(2)}_{str(batch_idx).zfill(2)}.png"
+                output_dir
+                / f"output_{slugify(prompt)[:64]}_{str(sample_idx).zfill(2)}_{str(batch_idx).zfill(2)}.png"
             )
             if not batch_idx:
                 print("Saving outputs", end="\n\t")

--- a/07_web_endpoints/badges.py
+++ b/07_web_endpoints/badges.py
@@ -10,7 +10,9 @@
 
 import modal
 
-image = modal.Image.debian_slim().pip_install("fastapi[standard]", "pybadges", "pypistats")
+image = modal.Image.debian_slim().pip_install(
+    "fastapi[standard]", "pybadges", "pypistats"
+)
 
 app = modal.App("example-web-badges", image=image)
 

--- a/07_web_endpoints/badges.py
+++ b/07_web_endpoints/badges.py
@@ -10,22 +10,20 @@
 
 import modal
 
-image = modal.Image.debian_slim().pip_install(
-    "fastapi[standard]", "pybadges", "pypistats"
-)
+image = modal.Image.debian_slim().pip_install("fastapi[standard]", "pybadges", "pypistats")
 
 app = modal.App("example-web-badges", image=image)
 
 # ## Defining the web endpoint
 #
 # In addition to using `@app.function()` to decorate our function, we use the
-# `@modal.web_endpoint` decorator ([learn more](/docs/guide/webhooks#web_endpoint)), which instructs Modal
+# `@modal.fastapi_endpoint` decorator ([learn more](/docs/guide/webhooks)) which instructs Modal
 # to create a REST endpoint that serves this function. Note that the default method is `GET`, but this
 # can be overridden using the `method` argument.
 
 
 @app.function()
-@modal.web_endpoint()
+@modal.fastapi_endpoint()
 async def package_downloads(package_name: str):
     import json
 

--- a/07_web_endpoints/basic_web.py
+++ b/07_web_endpoints/basic_web.py
@@ -9,7 +9,7 @@
 # without having to worry about setting up servers or managing infrastructure.
 
 # This tutorial shows the path with the shortest ["time to 200"](https://shkspr.mobi/blog/2021/05/whats-your-apis-time-to-200/):
-# [`modal.web_endpoint`](https://modal.com/docs/reference/modal.web_endpoint).
+# [`modal.fastapi_endpoint`](https://modal.com/docs/reference/modal.fastapi_endpoint).
 
 # On Modal, web endpoints have all the superpowers of Modal Functions:
 # they can be [accelerated with GPUs](https://modal.com/docs/guide/gpu),
@@ -30,7 +30,7 @@
 
 # And that's where most of the power of the Internet comes from: sharing information and functionality across different computer systems.
 
-# So we provide the `web_endpoint` decorator to wrap your Modal Functions in the lingua franca of the web: HTTP.
+# So we provide the `fastapi_endpoint` decorator to wrap your Modal Functions in the lingua franca of the web: HTTP.
 # Here's what that looks like:
 
 import modal
@@ -40,7 +40,7 @@ app = modal.App(name="example-lifecycle-web", image=image)
 
 
 @app.function()
-@modal.web_endpoint(
+@modal.fastapi_endpoint(
     docs=True  # adds interactive documentation in the browser
 )
 def hello():
@@ -82,7 +82,7 @@ def hello():
 
 
 @app.function()
-@modal.web_endpoint(docs=True)
+@modal.fastapi_endpoint(docs=True)
 def greet(user: str) -> str:
     return f"Hello {user}!"
 
@@ -108,7 +108,7 @@ def greet(user: str) -> str:
 
 
 @app.function()
-@modal.web_endpoint(method="POST", docs=True)
+@modal.fastapi_endpoint(method="POST", docs=True)
 def goodbye(data: dict) -> str:
     name = data.get("name") or "world"
     return f"Goodbye {name}!"
@@ -154,7 +154,7 @@ class WebApp:
         print("🏁 Starting up!")
         self.start_time = datetime.now(timezone.utc)
 
-    @modal.web_endpoint(docs=True)
+    @modal.fastapi_endpoint(docs=True)
     def web(self):
         from datetime import datetime, timezone
 
@@ -173,11 +173,11 @@ class WebApp:
 
 # To protect your Modal web endpoints so that they can't be triggered except
 # by members of your [Modal workspace](https://modal.com/docs/guide/workspaces),
-# add the `requires_proxy_auth=True` flag to the `web_endpoint` decorator.
+# add the `requires_proxy_auth=True` flag to the `fastapi_endpoint` decorator.
 
 
 @app.function(gpu="h100")
-@modal.web_endpoint(requires_proxy_auth=True, docs=False)
+@modal.fastapi_endpoint(requires_proxy_auth=True, docs=False)
 def expensive_secret():
     return "I didn't care for 'The Godfather'. It insists upon itself."
 
@@ -206,7 +206,7 @@ def expensive_secret():
 
 # ## What next?
 
-# Modal's `web_endpoint` decorator is opinionated and designed for relatively simple web applications --
+# Modal's `fastapi_endpoint` decorator is opinionated and designed for relatively simple web applications --
 # one or a few independent Python functions that you want to expose to the web.
 
 # Three additional decorators allow you to serve more complex web applications with greater control:

--- a/07_web_endpoints/count_faces.py
+++ b/07_web_endpoints/count_faces.py
@@ -37,11 +37,7 @@ def count_faces(image_bytes: bytes) -> int:
 
     # Example borrowed from https://towardsdatascience.com/face-detection-in-2-minutes-using-opencv-python-90f89d7c0f81
     # Load the cascade
-    face_cascade = cv2.CascadeClassifier(
-        os.path.join(
-            cv2.data.haarcascades, "haarcascade_frontalface_default.xml"
-        )
-    )
+    face_cascade = cv2.CascadeClassifier(os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml"))
     # Read the input image
     np_bytes = np.frombuffer(image_bytes, dtype=np.uint8)
     img = cv2.imdecode(np_bytes, cv2.IMREAD_COLOR)
@@ -52,9 +48,7 @@ def count_faces(image_bytes: bytes) -> int:
     return len(faces)
 
 
-@app.function(
-    image=modal.Image.debian_slim(python_version="3.11").pip_install("inflect")
-)
+@app.function(image=modal.Image.debian_slim(python_version="3.11").pip_install("inflect"))
 @modal.asgi_app()
 def web():
     import inflect
@@ -104,8 +98,6 @@ def web():
             </html>
             """
         except Exception as e:
-            raise HTTPException(
-                status_code=400, detail=f"Error processing image: {str(e)}"
-            )
+            raise HTTPException(status_code=400, detail=f"Error processing image: {str(e)}")
 
     return app

--- a/07_web_endpoints/count_faces.py
+++ b/07_web_endpoints/count_faces.py
@@ -37,7 +37,11 @@ def count_faces(image_bytes: bytes) -> int:
 
     # Example borrowed from https://towardsdatascience.com/face-detection-in-2-minutes-using-opencv-python-90f89d7c0f81
     # Load the cascade
-    face_cascade = cv2.CascadeClassifier(os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml"))
+    face_cascade = cv2.CascadeClassifier(
+        os.path.join(
+            cv2.data.haarcascades, "haarcascade_frontalface_default.xml"
+        )
+    )
     # Read the input image
     np_bytes = np.frombuffer(image_bytes, dtype=np.uint8)
     img = cv2.imdecode(np_bytes, cv2.IMREAD_COLOR)
@@ -48,7 +52,9 @@ def count_faces(image_bytes: bytes) -> int:
     return len(faces)
 
 
-@app.function(image=modal.Image.debian_slim(python_version="3.11").pip_install("inflect"))
+@app.function(
+    image=modal.Image.debian_slim(python_version="3.11").pip_install("inflect")
+)
 @modal.asgi_app()
 def web():
     import inflect
@@ -98,6 +104,8 @@ def web():
             </html>
             """
         except Exception as e:
-            raise HTTPException(status_code=400, detail=f"Error processing image: {str(e)}")
+            raise HTTPException(
+                status_code=400, detail=f"Error processing image: {str(e)}"
+            )
 
     return app

--- a/07_web_endpoints/fastapi_app.py
+++ b/07_web_endpoints/fastapi_app.py
@@ -9,10 +9,9 @@
 
 from typing import Optional
 
+import modal
 from fastapi import FastAPI, Header
 from pydantic import BaseModel
-
-import modal
 
 image = modal.Image.debian_slim().pip_install("fastapi[standard]", "pydantic")
 app = modal.App("example-fastapi-app", image=image)

--- a/07_web_endpoints/fastapi_app.py
+++ b/07_web_endpoints/fastapi_app.py
@@ -31,7 +31,9 @@ async def handle_root(user_agent: Optional[str] = Header(None)):
 
 @web_app.post("/foo")
 async def handle_foo(item: Item, user_agent: Optional[str] = Header(None)):
-    print(f"POST /foo - received user_agent={user_agent}, item.name={item.name}")
+    print(
+        f"POST /foo - received user_agent={user_agent}, item.name={item.name}"
+    )
     return item
 
 

--- a/07_web_endpoints/fastapi_app.py
+++ b/07_web_endpoints/fastapi_app.py
@@ -9,9 +9,10 @@
 
 from typing import Optional
 
-import modal
 from fastapi import FastAPI, Header
 from pydantic import BaseModel
+
+import modal
 
 image = modal.Image.debian_slim().pip_install("fastapi[standard]", "pydantic")
 app = modal.App("example-fastapi-app", image=image)
@@ -30,9 +31,7 @@ async def handle_root(user_agent: Optional[str] = Header(None)):
 
 @web_app.post("/foo")
 async def handle_foo(item: Item, user_agent: Optional[str] = Header(None)):
-    print(
-        f"POST /foo - received user_agent={user_agent}, item.name={item.name}"
-    )
+    print(f"POST /foo - received user_agent={user_agent}, item.name={item.name}")
     return item
 
 
@@ -43,7 +42,7 @@ def fastapi_app():
 
 
 @app.function()
-@modal.web_endpoint(method="POST")
+@modal.fastapi_endpoint(method="POST")
 def f(item: Item):
     return "Hello " + item.name
 

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -9,9 +9,10 @@
 import asyncio
 import time
 
-import modal
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
+
+import modal
 
 image = modal.Image.debian_slim().pip_install("fastapi[standard]")
 app = modal.App("example-fastapi-streaming", image=image)
@@ -38,9 +39,7 @@ async def fake_video_streamer():
 
 @web_app.get("/")
 async def main():
-    return StreamingResponse(
-        fake_video_streamer(), media_type="text/event-stream"
-    )
+    return StreamingResponse(fake_video_streamer(), media_type="text/event-stream")
 
 
 @app.function()
@@ -61,11 +60,9 @@ def sync_fake_video_streamer():
 
 
 @app.function()
-@modal.web_endpoint()
+@modal.fastapi_endpoint()
 def hook():
-    return StreamingResponse(
-        sync_fake_video_streamer.remote_gen(), media_type="text/event-stream"
-    )
+    return StreamingResponse(sync_fake_video_streamer.remote_gen(), media_type="text/event-stream")
 
 
 # This `mapped` web endpoint Modal function does a parallel `.map` on a simple
@@ -79,11 +76,9 @@ def map_me(i):
 
 
 @app.function()
-@modal.web_endpoint()
+@modal.fastapi_endpoint()
 def mapped():
-    return StreamingResponse(
-        map_me.map(range(10)), media_type="text/event-stream"
-    )
+    return StreamingResponse(map_me.map(range(10)), media_type="text/event-stream")
 
 
 # To try for yourself, run

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -9,10 +9,9 @@
 import asyncio
 import time
 
+import modal
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
-
-import modal
 
 image = modal.Image.debian_slim().pip_install("fastapi[standard]")
 app = modal.App("example-fastapi-streaming", image=image)

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -39,7 +39,9 @@ async def fake_video_streamer():
 
 @web_app.get("/")
 async def main():
-    return StreamingResponse(fake_video_streamer(), media_type="text/event-stream")
+    return StreamingResponse(
+        fake_video_streamer(), media_type="text/event-stream"
+    )
 
 
 @app.function()
@@ -62,7 +64,9 @@ def sync_fake_video_streamer():
 @app.function()
 @modal.fastapi_endpoint()
 def hook():
-    return StreamingResponse(sync_fake_video_streamer.remote_gen(), media_type="text/event-stream")
+    return StreamingResponse(
+        sync_fake_video_streamer.remote_gen(), media_type="text/event-stream"
+    )
 
 
 # This `mapped` web endpoint Modal function does a parallel `.map` on a simple
@@ -78,7 +82,9 @@ def map_me(i):
 @app.function()
 @modal.fastapi_endpoint()
 def mapped():
-    return StreamingResponse(map_me.map(range(10)), media_type="text/event-stream")
+    return StreamingResponse(
+        map_me.map(range(10)), media_type="text/event-stream"
+    )
 
 
 # To try for yourself, run

--- a/10_integrations/algolia_indexer.py
+++ b/10_integrations/algolia_indexer.py
@@ -112,7 +112,7 @@ CONFIG = {
 # ## The actual function
 #
 # We want to trigger our crawler from our CI/CD pipeline, so we're serving it as a
-# [web endpoint](/docs/guide/webhooks#web_endpoint) that can be triggered by a `GET` request during deploy.
+# [web endpoint](/docs/guide/webhooks) that can be triggered by a `GET` request during deploy.
 # You could also consider running the crawler on a [schedule](/docs/guide/cron).
 #
 # The Algolia crawler is written for Python 3.6 and needs to run in the `pipenv` created for it,
@@ -135,7 +135,7 @@ def crawl():
 
 
 @app.function(image=modal.Image.debian_slim().pip_install("fastapi[standard]"))
-@modal.web_endpoint()
+@modal.fastapi_endpoint()
 def crawl_webhook():
     crawl.remote()
     return "Finished indexing docs"

--- a/10_integrations/pushgateway.py
+++ b/10_integrations/pushgateway.py
@@ -78,7 +78,9 @@ def serve():
 # metric. This is useful when you have multiple instances of the same app pushing metrics to the Pushgateway.
 # Without this, the Pushgateway will overwrite the metric with the latest value.
 
-client_image = modal.Image.debian_slim().pip_install("prometheus-client==0.20.0", "fastapi[standard]==0.115.4")
+client_image = modal.Image.debian_slim().pip_install(
+    "prometheus-client==0.20.0", "fastapi[standard]==0.115.4"
+)
 app = modal.App(
     "example-pushgateway",
     image=client_image,

--- a/10_integrations/pushgateway.py
+++ b/10_integrations/pushgateway.py
@@ -78,9 +78,7 @@ def serve():
 # metric. This is useful when you have multiple instances of the same app pushing metrics to the Pushgateway.
 # Without this, the Pushgateway will overwrite the metric with the latest value.
 
-client_image = modal.Image.debian_slim().pip_install(
-    "prometheus-client==0.20.0", "fastapi[standard]==0.115.4"
-)
+client_image = modal.Image.debian_slim().pip_install("prometheus-client==0.20.0", "fastapi[standard]==0.115.4")
 app = modal.App(
     "example-pushgateway",
     image=client_image,
@@ -118,7 +116,7 @@ class ExampleClientApplication:
             grouping_key={"instance": self.instance_id},
         )
 
-    @modal.web_endpoint(label="hello-pushgateway")
+    @modal.fastapi_endpoint(label="hello-pushgateway")
     def hello(self):
         self.counter.inc()
         push_to_gateway(

--- a/misc/falcon_bitsandbytes.py
+++ b/misc/falcon_bitsandbytes.py
@@ -132,9 +132,7 @@ class Falcon40B_4bit:
             max_new_tokens=512,
         )
 
-        streamer = TextIteratorStreamer(
-            self.tokenizer, skip_special_tokens=True
-        )
+        streamer = TextIteratorStreamer(self.tokenizer, skip_special_tokens=True)
         generate_kwargs = dict(
             input_ids=input_ids,
             generation_config=generation_config,
@@ -168,10 +166,7 @@ prompt_template = (
 
 @app.local_entrypoint()
 def cli(prompt: str = None):
-    question = (
-        prompt
-        or "What are the main differences between Python and JavaScript programming languages?"
-    )
+    question = prompt or "What are the main differences between Python and JavaScript programming languages?"
     model = Falcon40B_4bit()
     for text in model.generate.remote_gen(prompt_template.format(question)):
         print(text, end="", flush=True)
@@ -183,7 +178,7 @@ def cli(prompt: str = None):
 # stream back a response.
 # You can try our deployment [here](https://modal-labs--example-falcon-bnb-get.modal.run/?question=How%20do%20planes%20work?).
 @app.function(timeout=60 * 10)
-@modal.web_endpoint()
+@modal.fastapi_endpoint()
 def get(question: str):
     from itertools import chain
 

--- a/misc/falcon_bitsandbytes.py
+++ b/misc/falcon_bitsandbytes.py
@@ -132,7 +132,9 @@ class Falcon40B_4bit:
             max_new_tokens=512,
         )
 
-        streamer = TextIteratorStreamer(self.tokenizer, skip_special_tokens=True)
+        streamer = TextIteratorStreamer(
+            self.tokenizer, skip_special_tokens=True
+        )
         generate_kwargs = dict(
             input_ids=input_ids,
             generation_config=generation_config,
@@ -166,7 +168,10 @@ prompt_template = (
 
 @app.local_entrypoint()
 def cli(prompt: str = None):
-    question = prompt or "What are the main differences between Python and JavaScript programming languages?"
+    question = (
+        prompt
+        or "What are the main differences between Python and JavaScript programming languages?"
+    )
     model = Falcon40B_4bit()
     for text in model.generate.remote_gen(prompt_template.format(question)):
         print(text, end="", flush=True)

--- a/misc/falcon_gptq.py
+++ b/misc/falcon_gptq.py
@@ -78,7 +78,9 @@ class Falcon40BGPTQ:
         from auto_gptq import AutoGPTQForCausalLM
         from transformers import AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(IMAGE_MODEL_DIR, use_fast=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            IMAGE_MODEL_DIR, use_fast=True
+        )
         print("Loaded tokenizer.")
 
         self.model = AutoGPTQForCausalLM.from_quantized(
@@ -98,7 +100,9 @@ class Falcon40BGPTQ:
         from transformers import TextIteratorStreamer
 
         inputs = self.tokenizer(prompt, return_tensors="pt")
-        streamer = TextIteratorStreamer(self.tokenizer, skip_special_tokens=True)
+        streamer = TextIteratorStreamer(
+            self.tokenizer, skip_special_tokens=True
+        )
         generation_kwargs = dict(
             inputs=inputs.input_ids.cuda(),
             attention_mask=inputs.attention_mask,

--- a/misc/falcon_gptq.py
+++ b/misc/falcon_gptq.py
@@ -78,9 +78,7 @@ class Falcon40BGPTQ:
         from auto_gptq import AutoGPTQForCausalLM
         from transformers import AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            IMAGE_MODEL_DIR, use_fast=True
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(IMAGE_MODEL_DIR, use_fast=True)
         print("Loaded tokenizer.")
 
         self.model = AutoGPTQForCausalLM.from_quantized(
@@ -100,9 +98,7 @@ class Falcon40BGPTQ:
         from transformers import TextIteratorStreamer
 
         inputs = self.tokenizer(prompt, return_tensors="pt")
-        streamer = TextIteratorStreamer(
-            self.tokenizer, skip_special_tokens=True
-        )
+        streamer = TextIteratorStreamer(self.tokenizer, skip_special_tokens=True)
         generation_kwargs = dict(
             inputs=inputs.input_ids.cuda(),
             attention_mask=inputs.attention_mask,
@@ -144,7 +140,7 @@ def cli():
 # stream back a response.
 # You can try our deployment [here](https://modal-labs--example-falcon-gptq-get.modal.run/?question=Why%20are%20manhole%20covers%20round?).
 @app.function(timeout=60 * 10)
-@modal.web_endpoint()
+@modal.fastapi_endpoint()
 def get(question: str):
     from itertools import chain
 

--- a/misc/stable_lm.py
+++ b/misc/stable_lm.py
@@ -7,10 +7,9 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Union
 
+import modal
 from pydantic import BaseModel
 from typing_extensions import Annotated, Literal
-
-import modal
 
 
 def build_models():

--- a/misc/stable_lm.py
+++ b/misc/stable_lm.py
@@ -28,7 +28,9 @@ def build_models():
         device_map="auto",
         local_files_only=True,
     )
-    m.save_pretrained(model_path, safe_serialization=True, max_shard_size="24GB")
+    m.save_pretrained(
+        model_path, safe_serialization=True, max_shard_size="24GB"
+    )
     tok = AutoTokenizer.from_pretrained(model_path)
     tok.save_pretrained(model_path)
     [p.unlink() for p in Path(model_path).rglob("*.bin")]  # type: ignore
@@ -73,7 +75,11 @@ image = (
 app = modal.App(
     name="example-stability-lm",
     image=image,
-    secrets=[modal.Secret.from_dict({"REPO_ID": "stabilityai/stablelm-tuned-alpha-7b"})],
+    secrets=[
+        modal.Secret.from_dict(
+            {"REPO_ID": "stabilityai/stablelm-tuned-alpha-7b"}
+        )
+    ],
 )
 
 
@@ -87,18 +93,24 @@ class CompletionRequest(BaseModel):
         float,
         "Adjusts randomness of outputs, greater than 1 is random and 0 is deterministic.",
     ] = 0.8
-    max_tokens: Annotated[int, "Maximum number of new tokens to generate for text completion."] = 16
+    max_tokens: Annotated[
+        int, "Maximum number of new tokens to generate for text completion."
+    ] = 16
     top_p: Annotated[
         float,
         "Probability threshold for the decoder to use in sampling next most likely token.",
     ] = 0.9
-    stream: Annotated[bool, "Whether to stream the generated text or return it all at once."] = False
+    stream: Annotated[
+        bool, "Whether to stream the generated text or return it all at once."
+    ] = False
     stop: Annotated[Union[str, List[str]], "Any additional stop words."] = []
     top_k: Annotated[
         int,
         "Limits the set of tokens to consider for next token generation to the top k.",
     ] = 40
-    do_sample: Annotated[bool, "Whether to use sampling or greedy decoding for text completion."] = True
+    do_sample: Annotated[
+        bool, "Whether to use sampling or greedy decoding for text completion."
+    ] = True
 
 
 @app.cls(gpu="A10G")
@@ -110,7 +122,9 @@ class StabilityLM:
         "<|padding|>",
         "<|endoftext|>",
     ]
-    model_url: str = modal.parameter(default="stabilityai/stablelm-tuned-alpha-7b")
+    model_url: str = modal.parameter(
+        default="stabilityai/stablelm-tuned-alpha-7b"
+    )
 
     @modal.enter()
     def setup_model(self):
@@ -123,7 +137,9 @@ class StabilityLM:
         import torch
         from transformers import AutoTokenizer, TextIteratorStreamer, pipeline
 
-        tokenizer = AutoTokenizer.from_pretrained(self.model_url, local_files_only=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.model_url, local_files_only=True
+        )
         self.stop_ids = tokenizer.convert_tokens_to_ids(self.stop_tokens)
         self.streamer = TextIteratorStreamer(
             tokenizer,
@@ -140,22 +156,30 @@ class StabilityLM:
         )
         self.generator.model = torch.compile(self.generator.model)
 
-    def get_config(self, completion_request: CompletionRequest) -> Dict[str, Any]:
+    def get_config(
+        self, completion_request: CompletionRequest
+    ) -> Dict[str, Any]:
         return dict(
             pad_token_id=self.generator.tokenizer.eos_token_id,
             eos_token_id=list(
                 set(
                     self.generator.tokenizer.convert_tokens_to_ids(
-                        self.generator.tokenizer.tokenize("".join(completion_request.stop))
+                        self.generator.tokenizer.tokenize(
+                            "".join(completion_request.stop)
+                        )
                     )
                     + self.stop_ids
                 )
             ),
             max_new_tokens=completion_request.max_tokens,
-            **completion_request.dict(exclude={"prompt", "model", "stop", "max_tokens", "stream"}),
+            **completion_request.dict(
+                exclude={"prompt", "model", "stop", "max_tokens", "stream"}
+            ),
         )
 
-    def generate_completion(self, completion_request: CompletionRequest) -> Generator[str, None, None]:
+    def generate_completion(
+        self, completion_request: CompletionRequest
+    ) -> Generator[str, None, None]:
         import re
         from threading import Thread
 
@@ -163,7 +187,9 @@ class StabilityLM:
 
         text = format_prompt(completion_request.prompt)
         gen_config = GenerationConfig(**self.get_config(completion_request))
-        stop_words = self.generator.tokenizer.convert_ids_to_tokens(gen_config.eos_token_id)
+        stop_words = self.generator.tokenizer.convert_ids_to_tokens(
+            gen_config.eos_token_id
+        )
         stop_words_pattern = re.compile("|".join(map(re.escape, stop_words)))
         thread = Thread(
             target=self.generator.__call__,
@@ -181,7 +207,9 @@ class StabilityLM:
         return "".join(self.generate_completion(completion_request))
 
     @modal.method()
-    def generate_stream(self, completion_request: CompletionRequest) -> Generator:
+    def generate_stream(
+        self, completion_request: CompletionRequest
+    ) -> Generator:
         for text in self.generate_completion(completion_request):
             yield text
 
@@ -234,7 +262,9 @@ async def completions(completion_request: CompletionRequest):
                     choices=[
                         Choice(
                             index=0,
-                            text=StabilityLM().generate.remote(completion_request=completion_request),
+                            text=StabilityLM().generate.remote(
+                                completion_request=completion_request
+                            ),
                         )
                     ],
                 )
@@ -244,7 +274,9 @@ async def completions(completion_request: CompletionRequest):
         )
 
     def wrapped_stream():
-        for new_text in StabilityLM().generate_stream.remote(completion_request=completion_request):
+        for new_text in StabilityLM().generate_stream.remote(
+            completion_request=completion_request
+        ):
             yield (
                 msgspec.json.encode(
                     CompletionResponse(
@@ -271,9 +303,13 @@ def main():
         "Generate a list of the 10 most beautiful cities in the world.",
         "How can I tell apart female and male red cardinals?",
     ]
-    instruction_requests = [CompletionRequest(prompt=q, max_tokens=128) for q in instructions]
+    instruction_requests = [
+        CompletionRequest(prompt=q, max_tokens=128) for q in instructions
+    ]
     print("Running example non-streaming completions:\n")
-    for q, a in zip(instructions, list(StabilityLM().generate.map(instruction_requests))):
+    for q, a in zip(
+        instructions, list(StabilityLM().generate.map(instruction_requests))
+    ):
         print(f"{q_style}{q}{q_end}\n{a}\n\n")
 
     print("Running example streaming completion:\n")

--- a/misc/trellis3d.py
+++ b/misc/trellis3d.py
@@ -189,7 +189,9 @@ class Model:
                     texture_size=texture_size,
                 )
 
-                temp_glb = tempfile.NamedTemporaryFile(suffix=".glb", delete=False)
+                temp_glb = tempfile.NamedTemporaryFile(
+                    suffix=".glb", delete=False
+                )
                 temp_path = temp_glb.name
                 logger.info(f"Exporting mesh to: {temp_path}")
                 glb.export(temp_path)

--- a/misc/trellis3d.py
+++ b/misc/trellis3d.py
@@ -4,9 +4,10 @@ import logging
 import tempfile
 import traceback
 
-import modal
 import requests
 from fastapi import HTTPException, Request, Response, status
+
+import modal
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -188,9 +189,7 @@ class Model:
                     texture_size=texture_size,
                 )
 
-                temp_glb = tempfile.NamedTemporaryFile(
-                    suffix=".glb", delete=False
-                )
+                temp_glb = tempfile.NamedTemporaryFile(suffix=".glb", delete=False)
                 temp_path = temp_glb.name
                 logger.info(f"Exporting mesh to: {temp_path}")
                 glb.export(temp_path)
@@ -229,7 +228,7 @@ class Model:
                 detail=error_msg,
             )
 
-    @modal.web_endpoint(method="GET", docs=True)
+    @modal.fastapi_endpoint(method="GET", docs=True)
     async def generate(
         self,
         request: Request,

--- a/misc/trellis3d.py
+++ b/misc/trellis3d.py
@@ -4,10 +4,9 @@ import logging
 import tempfile
 import traceback
 
+import modal
 import requests
 from fastapi import HTTPException, Request, Response, status
-
-import modal
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Updates the examples to be 1.0 compatible by substituting `modal.fastapi_endpoint` for `modal.web_endpoint`.

Needs to be merged before https://github.com/modal-labs/modal/pull/20457 as it fixes a cross-reference that needs to change.

Part of CLI-339

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
