### PR TITLE
feat: Add a shebang example which explains enable_output and app_run.

### DIFF
--- a/misc/hello_shebang.py
+++ b/misc/hello_shebang.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# ---
+# lambda-test: false
+# ---
+
+# # Syntax for making modal scripts executable
+
+# This example shows how you can add a shebang to a script that is meant to be invoked with `modal run`.
+
+import sys
+
+import modal
+
+app = modal.App("example-hello-world")
+
+@app.function()
+def f(i):
+    if i % 2 == 0:
+        print("hello", i)
+    else:
+        print("world", i, file=sys.stderr)
+
+    return i * i
+
+
+@app.local_entrypoint()
+def main():
+    # run the function locally
+    print(f.local(1000))
+
+    # run the function remotely on Modal
+    print(f.remote(1002))
+
+    # run the function in parallel and remotely on Modal
+    total = 0
+    for ret in f.map(range(200)):
+        total += ret
+
+    print(total)
+
+
+if __name__ == "__main__":
+    # Use `modal.enable_output()` to print the Sandbox's image build logs to the console, just like `modal run` does.
+    # Use `app.run()` to substitute the `modal run` CLI invocation.
+    with modal.enable_output(), app.run():
+        main()
+

--- a/misc/hello_shebang.py
+++ b/misc/hello_shebang.py
@@ -13,6 +13,7 @@ import modal
 
 app = modal.App("example-hello-world")
 
+
 @app.function()
 def f(i):
     if i % 2 == 0:
@@ -44,4 +45,3 @@ if __name__ == "__main__":
     # Use `app.run()` to substitute the `modal run` CLI invocation.
     with modal.enable_output(), app.run():
         main()
-


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [x] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
