### PR TITLE
make relative modal.com links global, standardize formatting

### DIFF
--- a/01_getting_started/hello_world.py
+++ b/01_getting_started/hello_world.py
@@ -1,15 +1,15 @@
 # # Hello, world!
-#
+
 # This tutorial demonstrates some core features of Modal:
-#
+
 # * You can run functions on Modal just as easily as you run them locally.
 # * Running functions in parallel on Modal is simple and fast.
 # * Logs and errors show up immediately, even for functions running on Modal.
-#
+
 # ## Importing Modal and setting up
-#
+
 # We start by importing `modal` and creating a `App`.
-# We build up this `App` to [define our application](/docs/guide/apps).
+# We build up this `App` to [define our application](https://modal.com/docs/guide/apps).
 
 import sys
 
@@ -18,17 +18,17 @@ import modal
 app = modal.App("example-hello-world")
 
 # ## Defining a function
-#
+
 # Modal takes code and runs it in the cloud.
-#
+
 # So first we've got to write some code.
-#
+
 # Let's write a simple function that takes in an input,
 # prints a log or an error to the console,
 # and then returns an output.
-#
+
 # To make this function work with Modal, we just wrap it in a decorator,
-# [`@app.function`](/docs/reference/modal.App#function).
+# [`@app.function`](https://modal.com/docs/reference/modal.App#function).
 
 
 @app.function()
@@ -42,15 +42,15 @@ def f(i):
 
 
 # ## Running our function locally, remotely, and in parallel
-#
+
 # Now let's see three different ways we can call that function:
-#
+
 # 1. As a regular call on your `local` machine, with `f.local`
-#
+
 # 2. As a `remote` call that runs in the cloud, with `f.remote`
-#
+
 # 3. By `map`ping many copies of `f` in the cloud over many inputs, with `f.map`
-#
+
 # We call `f` in each of these ways inside the `main` function below.
 
 
@@ -70,53 +70,55 @@ def main():
     print(total)
 
 
-# Enter `modal run hello_world.py` in a shell, and you'll see
-# a Modal app initialize.
+# Enter `modal run hello_world.py` in a shell, and you'll see a Modal app initialize.
 # You'll then see the `print`ed logs of
 # the `main` function and, mixed in with them, all the logs of `f` as it is run
 # locally, then remotely, and then remotely and in parallel.
-#
-# That's all triggered by adding the [`@app.local_entrypoint`](/docs/reference/modal.App#local_entrypoint) decorator on `main`,
-# which defines it as the function to start from locally when we invoke `modal run`.
-#
+
+# That's all triggered by adding the
+# [`@app.local_entrypoint`](https://modal.com/docs/reference/modal.App#local_entrypoint)
+# decorator on `main`, which defines it as the function to start from locally when we invoke `modal run`.
+
 # ## What just happened?
-#
+
 # When we called `.remote` on `f`, the function was executed
 # _in the cloud_, on Modal's infrastructure, not on the local machine.
-#
+
 # In short, we took the function `f`, put it inside a container,
 # sent it the inputs, and streamed back the logs and outputs.
-#
+
 # ## But why does this matter?
-#
+
 # Try one of these things next to start seeing the full power of Modal!
-#
+
 # ### You can change the code and run it again
-#
+
 # For instance, change the `print` statement in the function `f`
 # to print `"spam"` and `"eggs"` instead and run the app again.
 # You'll see that that your new code is run with no extra work from you --
 # and it should even run faster!
-#
+
 # Modal's goal is to make running code in the cloud feel like you're
 # running code locally. That means no waiting for long image builds when you've just moved a comma,
 # no fiddling with container image pushes, and no context-switching to a web UI to inspect logs.
-#
+
 # ### You can map over more data
-#
+
 # Change the `map` range from `200` to some large number, like `1170`. You'll see
 # Modal create and run even more containers in parallel this time.
-#
+
 # And it'll happen lightning fast!
-#
+
 # ### You can run a more interesting function
-#
+
 # The function `f` is a bit silly and doesn't do much, but in its place
 # imagine something that matters to you, like:
-#
-# * Running [language model inference](/docs/examples/vllm_inference) or [fine-tuning](/docs/examples/slack-finetune)
-# * Manipulating [audio](/docs/examples/discord-musicgen) or [images](/docs/examples/dreambooth_app)
-# * [Collecting financial data](/docs/examples/fetch_stock_prices) to backtest a trading algorithm
-#
+
+# * Running [language model inference](https://modal.com/docs/examples/vllm_inference)
+# or [fine-tuning](https://modal.com/docs/examples/slack-finetune)
+# * Manipulating [audio](https://modal.com/docs/examples/musicgen)
+# or [images](https://modal.com//docs/examples/diffusers_lora_finetune)
+# * [Collecting financial data](https://modal.com//docs/examples/fetch_stock_prices) to backtest a trading algorithm
+
 # Modal lets you parallelize that operation effortlessly by running hundreds or
 # thousands of containers in the cloud.

--- a/01_getting_started/hello_world.py
+++ b/01_getting_started/hello_world.py
@@ -117,8 +117,8 @@ def main():
 # * Running [language model inference](https://modal.com/docs/examples/vllm_inference)
 # or [fine-tuning](https://modal.com/docs/examples/slack-finetune)
 # * Manipulating [audio](https://modal.com/docs/examples/musicgen)
-# or [images](https://modal.com//docs/examples/diffusers_lora_finetune)
-# * [Collecting financial data](https://modal.com//docs/examples/fetch_stock_prices) to backtest a trading algorithm
+# or [images](https://modal.com/docs/examples/diffusers_lora_finetune)
+# * [Collecting financial data](https://modal.com/docs/examples/fetch_stock_prices) to backtest a trading algorithm
 
 # Modal lets you parallelize that operation effortlessly by running hundreds or
 # thousands of containers in the cloud.

--- a/02_building_containers/screenshot.py
+++ b/02_building_containers/screenshot.py
@@ -1,20 +1,20 @@
 # # Screenshot with Chromium
-#
+
 # In this example, we use Modal functions and the `playwright` package to take screenshots
 # of websites from a list of URLs in parallel.
-#
+
 # You can run this example on the command line with
-#
+
 # ```
 # modal run 02_building_containers/screenshot.py --url 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
 # ```
-#
+
 # This should take a few seconds then create a `/tmp/screenshots/screenshot.png` file, shown below.
-#
+
 # ![screenshot](./screenshot.png)
-#
+
 # ## Setup
-#
+
 # First we import the Modal client library.
 
 import pathlib
@@ -24,7 +24,7 @@ import modal
 app = modal.App("example-screenshot")
 
 # ## Define a custom image
-#
+
 # We need an image with the `playwright` Python package as well as its `chromium` plugin pre-installed.
 # This requires intalling a few Debian packages, as well as setting up a new Debian repository.
 # Modal lets you run arbitrary commands, just like in Docker:
@@ -41,7 +41,7 @@ image = modal.Image.debian_slim().run_commands(
 )
 
 # ## The screenshot function
-#
+
 # Next, the scraping function which runs headless Chromium, goes to a website, and takes a screenshot.
 # This is a Modal function which runs inside the remote container.
 
@@ -62,7 +62,7 @@ async def screenshot(url):
 
 
 # ## Entrypoint code
-#
+
 # Let's kick it off by reading a bunch of URLs from a txt file and scrape some of those.
 
 
@@ -76,5 +76,6 @@ def main(url: str = "https://modal.com"):
     print(f"wrote {len(data)} bytes to {filename}")
 
 
-# And we're done! Please also see our [introductory guide](/docs/examples/web-scraper) for another
-# example of a web scraper, with more in-depth logic.
+# And we're done! Please also see our
+# [introductory guide](https://modal.com/docs/examples/web-scraper)
+# for another example of a web scraper, with more in-depth logic.

--- a/03_scaling_out/dynamic_batching.py
+++ b/03_scaling_out/dynamic_batching.py
@@ -1,14 +1,14 @@
 # # Dynamic batching for ASCII and character conversion
-#
+
 # This example demonstrates how to dynamically batch a simple
 # application that converts ASCII codes to characters and vice versa.
-#
+
 # For more details about using dynamic batching and optimizing
 # the batching configurations for your application, see
 # the [dynamic batching guide](https://modal.com/docs/guide/dynamic-batching).
-#
+
 # ## Setup
-#
+
 # Let's start by defining the image for the application.
 
 import modal
@@ -20,7 +20,7 @@ app = modal.App(
 
 
 # ## Defining a Batched Function
-#
+
 # Now, let's define a function that converts ASCII codes to characters. This
 # async Batched Function allows us to convert up to four ASCII codes at once.
 
@@ -34,20 +34,20 @@ async def asciis_to_chars(asciis: list[int]) -> list[str]:
 # If there are fewer than four ASCII codes in the batch, the Function will wait
 # for one second, as specified by `wait_ms`, to allow more inputs to arrive before
 # returning the result.
-#
+
 # The input `asciis` to the Function is a list of integers, and the
 # output is a list of strings. To allow batching, the input list `asciis`
 # and the output list must have the same length.
-#
+
 # You must invoke the Function with an individual ASCII input, and a single
 # character will be returned in response.
 
 # ## Defining a class with a Batched Method
-#
+
 # Next, let's define a class that converts characters to ASCII codes. This
 # class has an async Batched Method `chars_to_asciis` that converts characters
 # to ASCII codes.
-#
+
 # Note that if a class has a Batched Method, it cannot have other Batched Methods
 # or Methods.
 
@@ -61,12 +61,12 @@ class AsciiConverter:
 
 
 # ## ASCII and character conversion
-#
+
 # Finally, let's define the `local_entrypoint` that uses the Batched Function
 # and Class Method to convert ASCII codes to characters and
 # vice versa.
-#
-# We use [`map.aio`](/docs/reference/modal.Function#map) to asynchronously map
+
+# We use [`map.aio`](https://modal.com/docs/reference/modal.Function#map) to asynchronously map
 # over the ASCII codes and characters. This allows us to invoke the Batched
 # Function and the Batched Method over a range of ASCII codes and characters
 # in parallel.

--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -25,10 +25,12 @@ slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 
 # ## Defining the function and importing the secret
 
-# Our Slack bot will need access to a bot token. We can use Modal's [Secrets](/secrets) interface to accomplish this.
-# To quickly create a Slack bot secret, navigate to the [create secret](/secrets/create) page, select the Slack secret template
+# Our Slack bot will need access to a bot token.
+# We can use Modal's [Secrets](https://modal.com/secrets) interface to accomplish this.
+# To quickly create a Slack bot secret, navigate to the
+# [create secret](https://modal.com/secrets/create) page, select the Slack secret template
 # from the list options, and follow the instructions in the "Where to find the credentials?" panel.
-# Name your secret `hn-bot-slack`, so that the code in this example still works.
+# Name your secret `hn-bot-slack.`
 
 # Now, we define the function `post_to_slack`, which simply instantiates the Slack client using our token,
 # and then uses it to post a message to a given channel name.
@@ -62,8 +64,8 @@ WINDOW_SIZE_DAYS = 1
 requests_image = modal.Image.debian_slim().pip_install("requests")
 
 # We can now define our main entrypoint, that queries Algolia for the term, and calls `post_to_slack`
-# on all the results. We specify a [schedule](/docs/guide/cron) in the function decorator, which
-# means that our function will run automatically at the given interval.
+# on all the results. We specify a [schedule](https://modal.com/docs/guide/cron)
+# in the function decorator, which means that our function will run automatically at the given interval.
 
 
 @app.function(image=requests_image)
@@ -103,5 +105,5 @@ def run_daily():
 
 # In order to deploy this as a persistent cron job, you can run `modal deploy hackernews_alerts.py`,
 
-# Once the job is deployed, visit the [apps page](/apps) page to see
+# Once the job is deployed, visit the [apps page](https://modal.com/apps) page to see
 # its execution history, logs and other stats.

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -37,11 +37,12 @@ output_vol = modal.Volume.from_name("finetune-volume", create_if_missing=True)
 # ### Handling preemption
 
 # As this finetuning job is long-running it's possible that it experiences a preemption.
-# The training code is robust to pre-emption events by periodically saving checkpoints and restoring
+# The training code is robust to preemption events by periodically saving checkpoints and restoring
 # from checkpoint on restart. But it's also helpful to observe in logs when a preemption restart has occurred,
 # so we track restarts with a `modal.Dict`.
 
-# See the [guide on preemptions](/docs/guide/preemption#preemption) for more details on preemption handling.
+# See the [guide on preemptions](https://modal.com/docs/guide/preemption#preemption)
+# for more details on preemption handling.
 
 restart_tracker_dict = modal.Dict.from_name(
     "finetune-restart-tracker", create_if_missing=True
@@ -212,7 +213,6 @@ def monitor():
 
 
 # ## Model Inference
-#
 
 
 @app.cls(volumes={VOL_MOUNT_PATH: output_vol})

--- a/06_gpu_and_ml/openai_whisper/batched_whisper.py
+++ b/06_gpu_and_ml/openai_whisper/batched_whisper.py
@@ -144,7 +144,7 @@ class Model:
 # In this example, we use the [librispeech_asr_dummy dataset](https://huggingface.co/datasets/hf-internal-testing/librispeech_asr_dummy)
 # from Hugging Face's Datasets library to test the model.
 
-# We use [`map.aio`](/docs/reference/modal.Function#map) to asynchronously map over the audio files.
+# We use [`map.aio`](https://modal.com/docs/reference/modal.Function#map) to asynchronously map over the audio files.
 # This allows us to invoke the batched transcription method on each audio sample in parallel.
 
 

--- a/07_web_endpoints/badges.py
+++ b/07_web_endpoints/badges.py
@@ -1,11 +1,12 @@
 # ---
 # cmd: ["modal", "serve", "07_web_endpoints/badges.py"]
 # ---
+
 # # Serve a dynamic SVG badge
 
-# In this example, we use Modal's [webhook](/docs/guide/webhooks) capability to host a dynamic SVG badge that shows
-# you the current # of downloads for a Python package.
-#
+# In this example, we use Modal's [webhook](https://modal.com/docs/guide/webhooks) capability to host a dynamic SVG badge that shows
+# you the current number of downloads for a Python package.
+
 # First let's start off by creating a Modal app, and defining an image with the Python packages we're going to be using:
 
 import modal
@@ -17,11 +18,11 @@ image = modal.Image.debian_slim().pip_install(
 app = modal.App("example-web-badges", image=image)
 
 # ## Defining the web endpoint
-#
+
 # In addition to using `@app.function()` to decorate our function, we use the
-# `@modal.fastapi_endpoint` decorator ([learn more](/docs/guide/webhooks)) which instructs Modal
-# to create a REST endpoint that serves this function. Note that the default method is `GET`, but this
-# can be overridden using the `method` argument.
+# [`@modal.fastapi_endpoint` decorator](https://modal.com/docs/guide/webhooks)
+# which instructs Modal to create a REST endpoint that serves this function.
+# Note that the default method is `GET`, but this can be overridden using the `method` argument.
 
 
 @app.function()
@@ -49,24 +50,24 @@ async def package_downloads(package_name: str):
 # Also note that FastAPI automatically interprets `package_name` as a [query param](https://fastapi.tiangolo.com/tutorial/query-params/).
 
 # ## Running and deploying
-#
+
 # We can now run an ephemeral app on the command line using:
-#
+
 # ```shell
 # modal serve badges.py
 # ```
-#
+
 # This will create a short-lived web url that exists until you terminate the script.
 # It will also hot-reload the code if you make changes to it.
-#
+
 # If you want to create a persistent URL, you have to deploy the script.
 # To deploy using the Modal CLI by running `modal deploy badges.py`,
-#
+
 # Either way, as soon as we run this command, Modal gives us the link to our brand new
 # web endpoint in the output:
-#
+
 # ![web badge deployment](./badges_deploy.png)
-#
+
 # We can now visit the link using a web browser, using a `package_name` of our choice in the URL query params.
 # For example:
 # - `https://YOUR_SUBDOMAIN.modal.run/?package_name=synchronicity`

--- a/10_integrations/algolia_indexer.py
+++ b/10_integrations/algolia_indexer.py
@@ -2,15 +2,16 @@
 # deploy: true
 # env: {"MODAL_ENVIRONMENT": "main"}
 # ---
+
 # # Algolia docsearch crawler
-#
+
 # This tutorial shows you how to use Modal to run the [Algolia docsearch
 # crawler](https://docsearch.algolia.com/docs/legacy/run-your-own/) to index your
 # website and make it searchable. This is not just example code - we run the same
 # code in production to power search on this page (`Ctrl+K` to try it out!).
 
 # ## Basic setup
-#
+
 # Let's get the imports out of the way.
 
 import json
@@ -19,7 +20,7 @@ import subprocess
 
 import modal
 
-# Modal lets you [use and extend existing Docker images](/docs/guide/custom-container#use-an-existing-container-image-with-from_registry),
+# Modal lets you [use and extend existing Docker images](https://modal.com/docs/guide/custom-container#use-an-existing-container-image-with-from_registry),
 # as long as they have `python` and `pip` available. We'll use the official crawler image built by Algolia, with a small
 # adjustment: since this image has `python` symlinked to `python3.6` and Modal is not compatible with Python 3.6, we
 # install Python 3.11 and symlink that as the `python` executable instead.
@@ -33,7 +34,7 @@ algolia_image = modal.Image.from_registry(
 app = modal.App("example-algolia-indexer")
 
 # ## Configure the crawler
-#
+
 # Now, let's configure the crawler with the website we want to index, and which
 # CSS selectors we want to scrape. Complete documentation for crawler configuration is available
 # [here](https://docsearch.algolia.com/docs/legacy/config-file).
@@ -102,7 +103,7 @@ CONFIG = {
 }
 
 # ## Create an API key
-#
+
 # If you don't already have one, sign up for an account on [Algolia](https://www.algolia.com/). Set up
 # a project and create an API key with `write` access to your index, and with the ACL permissions
 # `addObject`, `editSettings` and `deleteIndex`. Now, create a Secret on the Modal [Secrets](https://modal.com/secrets)
@@ -110,11 +111,11 @@ CONFIG = {
 # but we named it `algolia-secret` and so that's what the code below expects.
 
 # ## The actual function
-#
+
 # We want to trigger our crawler from our CI/CD pipeline, so we're serving it as a
-# [web endpoint](/docs/guide/webhooks) that can be triggered by a `GET` request during deploy.
-# You could also consider running the crawler on a [schedule](/docs/guide/cron).
-#
+# [web endpoint](https://modal.com/docs/guide/webhooks) that can be triggered by a `GET` request during deploy.
+# You could also consider running the crawler on a [schedule](https://modal.com/docs/guide/cron).
+
 # The Algolia crawler is written for Python 3.6 and needs to run in the `pipenv` created for it,
 # so we're invoking it using a subprocess.
 
@@ -150,7 +151,7 @@ def crawl_webhook():
 # ```
 
 # If successful, this will print a URL for your new webhook, that you can hit using
-# `curl` or a browser. Logs from webhook invocations can be found from the [apps](/apps)
+# `curl` or a browser. Logs from webhook invocations can be found from the [apps](https://modal.com/apps)
 # page.
 
 # The indexed contents can be found at https://www.algolia.com/apps/APP_ID/explorer/browse/, for your

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -45,7 +45,8 @@ datasette_image = (
 # ## Persistent dataset storage
 
 # To separate database creation and maintenance from serving, we'll need the underlying
-# database file to be stored persistently. To achieve this we use a [`Volume`](/docs/guide/volumes).
+# database file to be stored persistently. To achieve this we use a
+# [`Volume`](https://modal.com/docs/guide/volumes).
 
 volume = modal.Volume.from_name(
     "example-covid-datasette-cache-vol", create_if_missing=True
@@ -221,7 +222,7 @@ def prep_db():
 # ## Keep it fresh
 
 # Johns Hopkins commits new data to the dataset repository every day, so we set up
-# a [scheduled](/docs/guide/cron) function to automatically refresh the database
+# a [scheduled](https://modal.com/docs/guide/cron) function to automatically refresh the database
 # every 24 hours.
 
 
@@ -272,4 +273,4 @@ def run():
     prep_db.remote()
 
 
-# You can explore the data at the [deployed web endpoint](https://modal-labs--example-covid-datasette-app.modal.run/covid-19).
+# You can explore the data at the [deployed web endpoint](https://modal-labs-examples--example-covid-datasette-app.modal.run/covid-19).

--- a/10_integrations/multion_news_agent.py
+++ b/10_integrations/multion_news_agent.py
@@ -22,17 +22,23 @@ app = modal.App("multion-news-tweet-agent")
 
 multion_image = modal.Image.debian_slim().pip_install("multion")
 
-# We can now define our main entrypoint, that uses [MultiOn](https://www.multion.ai/) to scrape AI news everyday and post it on our twitter account. We specify a [schedule](/docs/guide/cron) in the function decorator, which
+# We can now define our main entrypoint, which uses [MultiOn](https://www.multion.ai/)
+# to scrape AI news everyday and post it on our Twitter account.
+# We specify a [schedule](https://modal.com/docs/guide/cron) in the function decorator, which
 # means that our function will run automatically at the given interval.
 
 # ## Set up MultiOn
-#
-# [MultiOn](https://multion.ai/) is a next-gen Web Action Agent that can take actions on behalf of the user. You can watch it in action here: [Youtube demo](https://www.youtube.com/watch?v=Rm67ry6bogw).
+
+# [MultiOn](https://multion.ai/) is a Web Action Agent that can take actions on behalf of the user.
+# You can watch it in action [here](https://www.youtube.com/watch?v=Rm67ry6bogw).
 
 # The MultiOn API enables building the next level of web automation & custom AI agents capable of performing complex actions on the internet with just a few lines of code.
 
-# To get started, first create an account with [MultiOn](https://app.multion.ai/), install the [MultiOn chrome extension](https://chrome.google.com/webstore/detail/ddmjhdbknfidiopmbaceghhhbgbpenmm) and login to your Twitter account in your browser.
-# To use the API create a [MultiOn API Key](https://app.multion.ai/api-keys) and store it as a modal secret on [the dashboard](https://modal.com/secrets)
+# To get started, first create an account with [MultiOn](https://app.multion.ai/),
+# install the [MultiOn chrome extension](https://chrome.google.com/webstore/detail/ddmjhdbknfidiopmbaceghhhbgbpenmm)
+# and login to your Twitter account in your browser.
+# To use the API, create a [MultiOn API Key](https://app.multion.ai/api-keys)
+# and store it as a Modal sEcret on [the dashboard](https://modal.com/secrets)
 
 
 @app.function(
@@ -75,5 +81,5 @@ def run_daily():
 
 # In order to deploy this as a persistent cron job, you can run `modal deploy multion_news_agent.py`.
 
-# Once the job is deployed, visit the [apps page](/apps) page to see
+# Once the job is deployed, visit the [apps page](https://modal.com/apps) page to see
 # its execution history, logs and other stats.


### PR DESCRIPTION
This PR makes all relative URLs, which are implicitly to https://modal.com, explicitly global URLs. That makes the URLs easier to copy from an editor at the expense of making it harder to catch 404s.

It also standardizes some formatting choices, e.g. using blank lines in places where the rendered page will have vertical spacing, like between blocks and around headers.

- [x] Example updates (Bug fixes, new features, etc.)