### PR TITLE
pin python version in more examples

### DIFF
--- a/02_building_containers/screenshot.py
+++ b/02_building_containers/screenshot.py
@@ -30,7 +30,7 @@ app = modal.App("example-screenshot")
 # Modal lets you run arbitrary commands, just like in Docker:
 
 
-image = modal.Image.debian_slim().run_commands(
+image = modal.Image.debian_slim(python_version="3.12").run_commands(
     "apt-get update",
     "apt-get install -y software-properties-common",
     "apt-add-repository non-free",

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -23,7 +23,7 @@ VOL_MOUNT_PATH = Path("/vol")
 # Other Flan-T5 models can be found [here](https://huggingface.co/docs/transformers/model_doc/flan-t5)
 BASE_MODEL = "google/flan-t5-base"
 
-image = modal.Image.debian_slim().pip_install(
+image = modal.Image.debian_slim(python_version="3.12").pip_install(
     "accelerate",
     "transformers",
     "torch",

--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -23,7 +23,7 @@ def download_model():
 
 
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.12")
     .pip_install("sentence-transformers==3.2.0")
     .run_function(download_model)
 )

--- a/06_gpu_and_ml/import_torch.py
+++ b/06_gpu_and_ml/import_torch.py
@@ -9,9 +9,7 @@ import modal
 
 app = modal.App(
     "example-import-torch",
-    image=modal.Image.debian_slim().pip_install(
-        "torch", find_links="https://download.pytorch.org/whl/cu116"
-    ),
+    image=modal.Image.debian_slim().pip_install("torch"),
 )
 
 

--- a/07_web_endpoints/flask_streaming.py
+++ b/07_web_endpoints/flask_streaming.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# cmd: ["modal", "serve", "07_web_endpoints/flask_streaming.py"]
 # ---
 
 # # Deploy Flask app with streaming results with Modal

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -37,7 +37,7 @@ import modal
 
 app = modal.App("example-covid-datasette")
 datasette_image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.12")
     .pip_install("datasette~=0.63.2", "sqlite-utils")
     .apt_install("unzip")
 )

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference.py
@@ -36,7 +36,7 @@ TARGET_PATH = f"{VOL_PATH}/target"
 # See [this guide](https://modal.com/docs/guide/custom-container) for details.
 
 dbt_image = (  # start from a slim Linux image
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.12")
     .pip_install(  # install python packages
         "dbt-duckdb==1.8.1",  # dbt with duckdb connector
         "pandas==2.2.2",  # dataframes

--- a/10_integrations/s3_bucket_mount.py
+++ b/10_integrations/s3_bucket_mount.py
@@ -28,7 +28,7 @@ from pathlib import Path, PosixPath
 
 import modal
 
-image = modal.Image.debian_slim().pip_install(
+image = modal.Image.debian_slim(python_version="3.12").pip_install(
     "requests==2.31.0", "duckdb==0.10.0", "matplotlib==3.8.3"
 )
 app = modal.App(image=image)

--- a/11_notebooks/jupyter_inside_modal.py
+++ b/11_notebooks/jupyter_inside_modal.py
@@ -18,7 +18,7 @@ import time
 import modal
 
 app = modal.App(
-    image=modal.Image.debian_slim().pip_install(
+    image=modal.Image.debian_slim(python_version="3.12").pip_install(
         "jupyter", "bing-image-downloader~=1.1.2"
     )
 )


### PR DESCRIPTION
I've left the Python version unpinned in a few examples that we actually test, since they are cases where we'd want the feature to work across Python versions, e.g. the flask/FastAPI serving examples. These examples also generally have the library versions unpinned for the same reason. They're more like canaries for library compatibility issues than are the other examples, which are closer to applications and so have tighter version pinning.