### PR TITLE
surface failures from run_random_example

### DIFF
--- a/internal/run_example.py
+++ b/internal/run_example.py
@@ -52,8 +52,7 @@ def run_random_example():
         lambda ex: ex.metadata and ex.metadata.get("lambda-test", True),
         utils.get_examples(),
     )
-    run_script(random.choice(list(examples)))
-    return 0
+    return run_script(random.choice(list(examples)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The [build-and-run-example workflow](https://github.com/modal-labs/modal-examples/actions/workflows/build-and-run-example.yml) was failing silently because we always returned 0 instead of the example's actual returncode. This PR returns the returncode.