### PR TITLE
add example for installing flash attention

### DIFF
--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -1,0 +1,40 @@
+import modal
+
+app = modal.App("example-install-flash-attn")
+
+image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.0-devel-ubuntu22.04", add_python="3.11"
+    )
+    .entrypoint(
+        []  # removes chatty prints on entry
+    )
+    .pip_install("ninja", "packaging", "wheel", "torch")
+    .pip_install("flash-attn", extra_options="--no-build-isolation")
+)
+
+
+@app.function(gpu="L40S", image=image)
+def run_flash_attn():
+    import torch
+    from flash_attn import flash_attn_func
+
+    batch_size, seqlen, nheads, headdim, nheads_k = 2, 4, 3, 16, 3
+
+    q = torch.randn(
+        batch_size, seqlen, nheads, headdim, dtype=torch.float16
+    ).to("cuda")
+    k = torch.randn(
+        batch_size, seqlen, nheads_k, headdim, dtype=torch.float16
+    ).to("cuda")
+    v = torch.randn(
+        batch_size, seqlen, nheads_k, headdim, dtype=torch.float16
+    ).to("cuda")
+
+    out = flash_attn_func(q, k, v)
+    assert out.shape == (batch_size, seqlen, nheads, headdim)
+
+
+@app.local_entrypoint()
+def main():
+    run_flash_attn.remote()


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [x] New example

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally

Intentionally not pinning dependencies so that this example can be used to monitor for regressions in this pattern for building `flash-attn`.

- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
