### PR TITLE
Uses prebuild wheel for flash-atten

### DIFF
--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -2,15 +2,14 @@ import modal
 
 app = modal.App("example-install-flash-attn")
 
-image = (
-    modal.Image.from_registry(
-        "nvidia/cuda:12.8.0-devel-ubuntu22.04", add_python="3.11"
-    )
-    .entrypoint(
-        []  # removes chatty prints on entry
-    )
-    .pip_install("ninja", "packaging", "wheel", "torch")
-    .pip_install("flash-attn", extra_options="--no-build-isolation")
+# Find releases at https://github.com/Dao-AILab/flash-attention/releases
+flash_attn_release = (
+    "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/"
+    "flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp313-cp313-linux_x86_64.whl"
+)
+
+image = modal.Image.debian_slim(python_version="3.13").pip_install(
+    "torch==2.6.0", "numpy==2.2.4", flash_attn_release
 )
 
 

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -2,8 +2,7 @@ import modal
 
 app = modal.App("example-install-flash-attn")
 
-# Find releases at https://github.com/Dao-AILab/flash-attention/releases
-flash_attn_release = (
+flash_attn_release = (  # find releases at https://github.com/Dao-AILab/flash-attention/releases
     "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/"
     "flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp313-cp313-linux_x86_64.whl"
 )


### PR DESCRIPTION
### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

Follow up to https://github.com/modal-labs/modal-examples/pull/1095. One can install `flash-attn` from their repo instead of building it in the image builder. 

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
