### PR TITLE
add back in absolute links

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -235,10 +235,10 @@ class ComfyUI:
 # ![comfyui menu](./comfyui_menu.jpeg)
 
 # ## More resources
-# - Use memory snapshotting to [speed up ComfyUI cold starts](/blog/comfyui-mem-snapshots)
-# - Run a ComfyUI workflow as a [Python script](/blog/comfyui-prototype-to-production)
+# - Use memory snapshotting to [speed up ComfyUI cold starts](https://modal.com/blog/comfyui-mem-snapshots)
+# - Run a ComfyUI workflow as a [Python script](https://modal.com/blog/comfyui-prototype-to-production)
 
-# - When to use [A1111 vs ComfyUI](/blog/a1111-vs-comfyui)
+# - When to use [A1111 vs ComfyUI](https://modal.com/blog/a1111-vs-comfyui)
 
 # - Understand tradeoffs of parallel processing strategies when
-# [scaling ComfyUI](/blog/scaling-comfyui)
+# [scaling ComfyUI](https://modal.com/blog/scaling-comfyui)


### PR DESCRIPTION
So that those who clone / develop locally can actually click through

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
