### PR TITLE
use custom cuda image

### DIFF
--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -69,9 +69,13 @@ def download_model_to_image():
 # Modal runs Python functions on containers in the cloud.
 # The environment those functions run in is defined by the container's `Image`.
 # The block of code below defines our example's `Image`.
+cuda_version = "12.8.0"  # should be no greater than host CUDA version
+flavor = "devel"  #  includes full CUDA toolkit
+operating_sys = "ubuntu22.04"
+tag = f"{cuda_version}-{flavor}-{operating_sys}"
 
 vlm_image = (
-    modal.Image.debian_slim(python_version="3.11")
+    modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.11")
     .pip_install(  # add sglang and some Python dependencies
         "transformers==4.47.1",
         "numpy<2",


### PR DESCRIPTION
A user running this example reported an issue of crash looping containers with the message:

`ImportError: libnvrtc.so.12: cannot open shared object file: No such file or directory`

When I first ran it, it worked because it leveraged the cached build. However when I triggered a force build I also started getting this error (and now the synthetic monitoring has also just started failing). Something strange might be happening with image build caching?

Anyways I was able to resolve by using a custom cuda image.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
