### PR TITLE
Basic ComfyUI memory snapshot example for sub-2s cold start time

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -14,13 +14,13 @@
 # 1. Start up the ComfyUI server in development mode:
 
 # ```bash
-# modal serve 06_gpu_and_ml/comfyui/comfyapp.py
+# modal deploy 06_gpu_and_ml/comfyui/comfyapp.py
 # ```
 
 # 2. In another terminal, run inference:
 
 # ```bash
-# python 06_gpu_and_ml/comfyui/comfyclient.py --dev --modal-workspace $(modal profile current) --prompt "Surreal dreamscape with floating islands, upside-down waterfalls, and impossible geometric structures, all bathed in a soft, ethereal light"
+# python 06_gpu_and_ml/comfyui/comfyclient.py --modal-workspace $(modal profile current) --prompt "Surreal dreamscape with floating islands, upside-down waterfalls, and impossible geometric structures, all bathed in a soft, ethereal light"
 # ```
 
 # ![example comfyui image](./flux_gen_image.jpeg)
@@ -64,6 +64,12 @@ image = (
     # Add .run_commands(...) calls for any other custom nodes you want to download
 )
 
+# We'll also add our own custom node that patches core ComfyUI so that we can use Modal's [memory snapshot](https://modal.com/docs/guide/memory-snapshot) feature to speed up cold starts (more on that on [running as an API](https://modal.com/docs/examples/comfyapp#running-comfyui-as-an-api)).
+image = image.add_local_dir(
+    local_path=Path(__file__).parent / "memory_snapshot_helper",
+    remote_path="/root/comfy/ComfyUI/custom_nodes/memory_snapshot_helper",
+    copy=True,
+)
 # See [this post](https://modal.com/blog/comfyui-custom-nodes) for more examples
 # on how to install popular custom nodes like ComfyUI Impact Pack and ComfyUI IPAdapter Plus.
 
@@ -109,15 +115,11 @@ image = (
     )
 )
 
-# Lastly, we copy the ComfyUI workflow JSON to the container.
+# Lastly, copy the ComfyUI workflow JSON to the container.
 image = image.add_local_file(
     Path(__file__).parent / "workflow_api.json", "/root/workflow_api.json"
 )
 
-image = image.add_local_dir(
-        local_path=Path(__file__).parent / "memory_snapshot_helper",
-        remote_path="/root/comfy/ComfyUI/custom_nodes/memory_snapshot_helper"
-    )
 
 # ## Running ComfyUI interactively
 
@@ -127,33 +129,16 @@ image = image.add_local_dir(
 app = modal.App(name="example-comfyui", image=image)
 
 
-@app.cls(
+@app.function(
     allow_concurrent_inputs=10,  # required for UI startup process which runs several API calls concurrently
     max_containers=1,  # limit interactive session to 1 container
     gpu="L40S",  # good starter GPU for inference
     volumes={"/cache": vol},  # mounts our cached models
-    enable_memory_snapshot=True,
 )
-class ComfyUIWebServer:
-    @modal.enter(snap=True)
-    def launch_comfy_background(self):
-        cmd = "comfy launch --background -- --listen 0.0.0.0 --port 8000"
-        subprocess.run(cmd, shell=True, check=True)
-    @modal.enter(snap=False)
-    def restore_snapshot(self):        
-        # Initialize GPU for ComfyUI after snapshot restore
-        import requests
-        response = requests.post("http://0.0.0.0:8000/cuda/set_device")
-        if response.status_code != 200:
-            print("Failed to set CUDA device")
-        else:
-            print("Successfully set CUDA device")
-        print("Recovered from snapshot")
-        
-    @modal.web_server(8000, startup_timeout=60)
-    def ui(self):
-        pass
-        
+@modal.web_server(8000, startup_timeout=60)
+def ui():
+    subprocess.Popen("comfy launch -- --listen 0.0.0.0 --port 8000", shell=True)
+
 
 # At this point you can run `modal serve 06_gpu_and_ml/comfyui/comfyapp.py` and open the UI in your browser for the classic ComfyUI experience.
 
@@ -174,21 +159,37 @@ class ComfyUIWebServer:
 
 
 @app.cls(
-    allow_concurrent_inputs=10,  # allow 10 concurrent API calls
+    allow_concurrent_inputs=5,  # run 5 inputs per container
     scaledown_window=300,  # 5 minute container keep alive after it processes an input
     gpu="L40S",
     volumes={"/cache": vol},
+    enable_memory_snapshot=True,  # snapshot container state for faster cold starts
 )
 class ComfyUI:
-    @modal.enter()
+    port: int = 8000
+
+    @modal.enter(snap=True)
     def launch_comfy_background(self):
-        # starts the ComfyUI server in the background exactly once when the first input is received
-        cmd = "comfy launch --background"
+        cmd = f"comfy launch --background -- --port {self.port}"
         subprocess.run(cmd, shell=True, check=True)
+
+    @modal.enter(snap=False)
+    def restore_snapshot(self):
+        # initialize GPU for ComfyUI after snapshot restore
+        # note: requires patching core ComfyUI, see the memory_snapshot_helper directory for more details
+        import requests
+
+        response = requests.post(
+            f"http://127.0.0.1:{self.port}/cuda/set_device"
+        )
+        if response.status_code != 200:
+            print("Failed to set CUDA device")
+        else:
+            print("Successfully set CUDA device")
 
     @modal.method()
     def infer(self, workflow_path: str = "/root/workflow_api.json"):
-        # checks if ComfyUI server is healthy and accepting requests
+        # sometimes the ComfyUI server stops responding (we think because of memory leaks), so this makes sure it's still up
         self.poll_server_health()
 
         # runs the comfy run --workflow command as a subprocess
@@ -240,15 +241,18 @@ class ComfyUI:
         import urllib
 
         try:
-            # dummy request to check if the server is healthy
-            req = urllib.request.Request("http://127.0.0.1:8188/system_stats")
+            # check if the server is up (response should be immediate)
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{self.port}/system_stats"
+            )
             urllib.request.urlopen(req, timeout=5)
             print("ComfyUI server is healthy")
         except (socket.timeout, urllib.error.URLError) as e:
-            # if no response in 5 seconds, stop the container; Modal will schedule queued inputs on a new container
+            # if no response in 5 seconds, stop the container
             print(f"Server health check failed: {str(e)}")
             modal.experimental.stop_fetching_inputs()
 
+            # all queued inputs will be marked "Failed", so you need to catch these errors in your client and then retry
             raise Exception("ComfyUI server is not healthy, stopping container")
 
 
@@ -257,7 +261,7 @@ class ComfyUI:
 # ![comfyui menu](./comfyui_menu.jpeg)
 
 # ## More resources
-# - Use memory snapshotting to [speed up ComfyUI cold starts](https://modal.com/blog/comfyui-mem-snapshots)
+# - [Alternative approach](https://modal.com/blog/comfyui-mem-snapshots) for deploying ComfyUI with memory snapshots
 # - Run a ComfyUI workflow as a [Python script](https://modal.com/blog/comfyui-prototype-to-production)
 
 # - When to use [A1111 vs ComfyUI](https://modal.com/blog/a1111-vs-comfyui)

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -45,9 +45,9 @@ image = (  # build up a Modal Image to run ComfyUI, step by step
     )
     .apt_install("git")  # install git to clone ComfyUI
     .pip_install("fastapi[standard]==0.115.4")  # install web dependencies
-    .pip_install("comfy-cli==1.3.5")  # install comfy-cli
+    .pip_install("comfy-cli==1.3.8")  # install comfy-cli
     .run_commands(  # use comfy-cli to install ComfyUI and its dependencies
-        "comfy --skip-prompt install --nvidia --version 0.3.10"
+        "comfy --skip-prompt install --fast-deps --nvidia --version 0.3.10"
     )
 )
 
@@ -59,7 +59,7 @@ image = (  # build up a Modal Image to run ComfyUI, step by step
 
 image = (
     image.run_commands(  # download a custom node
-        "comfy node install was-node-suite-comfyui@1.0.2"
+        "comfy node install --fast-deps was-node-suite-comfyui@1.0.2"
     )
     # Add .run_commands(...) calls for any other custom nodes you want to download
 )

--- a/06_gpu_and_ml/comfyui/memory_snapshot_helper/__init__.py
+++ b/06_gpu_and_ml/comfyui/memory_snapshot_helper/__init__.py
@@ -1,13 +1,16 @@
-from server import PromptServer
-from aiohttp import web
 import os
+
+from aiohttp import web
+from server import PromptServer
 
 # ------- API Endpoints -------
 
+
 @PromptServer.instance.routes.post("/cuda/set_device")
 async def set_current_device(request):
-    os.environ['CUDA_VISIBLE_DEVICES'] = "0"
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
     return web.json_response({"status": "success"})
+
 
 # Empty for ComfyUI node registration
 NODE_CLASS_MAPPINGS = {}

--- a/06_gpu_and_ml/comfyui/memory_snapshot_helper/__init__.py
+++ b/06_gpu_and_ml/comfyui/memory_snapshot_helper/__init__.py
@@ -1,0 +1,13 @@
+from server import PromptServer
+from aiohttp import web
+import os
+
+# ------- API Endpoints -------
+
+@PromptServer.instance.routes.post("/cuda/set_device")
+async def set_current_device(request):
+    os.environ['CUDA_VISIBLE_DEVICES'] = "0"
+    return web.json_response({"status": "success"})
+
+# Empty for ComfyUI node registration
+NODE_CLASS_MAPPINGS = {}

--- a/06_gpu_and_ml/comfyui/memory_snapshot_helper/prestartup_script.py
+++ b/06_gpu_and_ml/comfyui/memory_snapshot_helper/prestartup_script.py
@@ -8,20 +8,22 @@ model_management_path = str(comfy_dir / "model_management.py")
 original_model_management_path = str(comfy_dir / "model_management_original.py")
 is_patched = os.path.exists(original_model_management_path)
 
+
 def _apply_cuda_safe_patch():
     """Apply a permanent patch that avoid torch cuda init during snapshots"""
 
-
     shutil.copy(model_management_path, original_model_management_path)
-    print("[memory_snapshot_helper] ==> Applying CUDA-safe patch for model_management.py")
+    print(
+        "[memory_snapshot_helper] ==> Applying CUDA-safe patch for model_management.py"
+    )
 
-    with open(model_management_path, 'r') as f:
+    with open(model_management_path, "r") as f:
         content = f.read()
 
     # Find the get_torch_device function and modify the CUDA device access
     # The original line uses: return torch.device(torch.cuda.current_device())
     # We'll replace it with a check if CUDA is available
-    
+
     # Define the patched content as a constant
     CUDA_SAFE_PATCH = """import os
         if torch.cuda.is_available():
@@ -32,17 +34,21 @@ def _apply_cuda_safe_patch():
 
     if "return torch.device(torch.cuda.current_device())" in content:
         patched_content = content.replace(
-            "return torch.device(torch.cuda.current_device())",
-            CUDA_SAFE_PATCH
+            "return torch.device(torch.cuda.current_device())", CUDA_SAFE_PATCH
         )
-        
+
         # Save the patched version
-        with open(model_management_path, 'w') as f:
+        with open(model_management_path, "w") as f:
             f.write(patched_content)
-        
-        print("[memory_snapshot_helper] ==> Successfully patched model_management.py")
+
+        print(
+            "[memory_snapshot_helper] ==> Successfully patched model_management.py"
+        )
     else:
-        raise Exception("[memory_snapshot_helper] ==> Failed to patch model_management.py")
+        raise Exception(
+            "[memory_snapshot_helper] ==> Failed to patch model_management.py"
+        )
+
 
 if not is_patched:
     _apply_cuda_safe_patch()

--- a/06_gpu_and_ml/comfyui/memory_snapshot_helper/prestartup_script.py
+++ b/06_gpu_and_ml/comfyui/memory_snapshot_helper/prestartup_script.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+from pathlib import Path
+
+comfy_dir = Path(__file__).parent.parent.parent / "comfy"
+
+model_management_path = str(comfy_dir / "model_management.py")
+original_model_management_path = str(comfy_dir / "model_management_original.py")
+is_patched = os.path.exists(original_model_management_path)
+
+def _apply_cuda_safe_patch():
+    """Apply a permanent patch that avoid torch cuda init during snapshots"""
+
+
+    shutil.copy(model_management_path, original_model_management_path)
+    print("[memory_snapshot_helper] ==> Applying CUDA-safe patch for model_management.py")
+
+    with open(model_management_path, 'r') as f:
+        content = f.read()
+
+    # Find the get_torch_device function and modify the CUDA device access
+    # The original line uses: return torch.device(torch.cuda.current_device())
+    # We'll replace it with a check if CUDA is available
+    
+    # Define the patched content as a constant
+    CUDA_SAFE_PATCH = """import os
+        if torch.cuda.is_available():
+            return torch.device(torch.cuda.current_device())
+        else:
+            logging.info("[memory_snapshot_helper] CUDA is not available, defaulting to cpu")
+            return torch.device('cpu')  # Safe fallback during snapshot"""
+
+    if "return torch.device(torch.cuda.current_device())" in content:
+        patched_content = content.replace(
+            "return torch.device(torch.cuda.current_device())",
+            CUDA_SAFE_PATCH
+        )
+        
+        # Save the patched version
+        with open(model_management_path, 'w') as f:
+            f.write(patched_content)
+        
+        print("[memory_snapshot_helper] ==> Successfully patched model_management.py")
+    else:
+        raise Exception("[memory_snapshot_helper] ==> Failed to patch model_management.py")
+
+if not is_patched:
+    _apply_cuda_safe_patch()


### PR DESCRIPTION
- Bump comfy-cli to 1.3.8, use `--fast-deps` to speed up image building with [uv](https://github.com/astral-sh/uv)
- Introduced a simple ComfyUI custom nodes for memory snapshots.
- Updated ComfyUI app to include methods for launching in the background and restoring from snapshots.


To test memory snapshot, `modal deploy 06_gpu_and_ml/comfyui/comfyapp.py` and start and stop the container for a few times.

![image](https://github.com/user-attachments/assets/34370ae1-cc02-4a51-95cb-6c1e90ad0da7)

I've successfully implemented memory snapshot preloading for models, but don't believe the current implementation is ideal for an example. Let's go with this PR as a first step.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
