### PR TITLE
Fix a mistake in ollama example related to cli

### DIFF
--- a/06_gpu_and_ml/llm-serving/ollama.py
+++ b/06_gpu_and_ml/llm-serving/ollama.py
@@ -339,11 +339,7 @@ async def local_main():
 # 3. Scales automatically based on usage
 # 4. Preserves your models in the persistent volume between invocations
 #
-# After deployment, you can find your endpoint URL with:
-#
-# ```bash
-# modal app show ollama-server
-# ```
+# After deployment, you can find your endpoint URL in your Modal dashboard.
 #
 # You can then use this endpoint with any OpenAI-compatible client by setting:
 #


### PR DESCRIPTION
This commit fixes a nonexistent CLI option that was put in the example.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
