### PR TITLE
allow longer lines

### DIFF
--- a/02_building_containers/import_sklearn.py
+++ b/02_building_containers/import_sklearn.py
@@ -13,9 +13,7 @@ import modal
 
 app = modal.App(
     "import-sklearn",
-    image=modal.Image.debian_slim()
-    .apt_install("libgomp1")
-    .pip_install("scikit-learn"),
+    image=modal.Image.debian_slim().apt_install("libgomp1").pip_install("scikit-learn"),
 )
 
 # The `app.image.imports()` lets us conditionally import in the global scope.

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -19,9 +19,9 @@ def run_flash_attn():
 
     batch_size, seqlen, nheads, headdim, nheads_k = 2, 4, 3, 16, 3
 
-    q = torch.randn(
-        batch_size, seqlen, nheads, headdim, dtype=torch.float16
-    ).to("cuda")
+    q = torch.randn(batch_size, seqlen, nheads, headdim, dtype=torch.float16).to(
+        "cuda"
+    )
     k = torch.randn(
         batch_size, seqlen, nheads_k, headdim, dtype=torch.float16
     ).to("cuda")

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -22,12 +22,12 @@ def run_flash_attn():
     q = torch.randn(batch_size, seqlen, nheads, headdim, dtype=torch.float16).to(
         "cuda"
     )
-    k = torch.randn(
-        batch_size, seqlen, nheads_k, headdim, dtype=torch.float16
-    ).to("cuda")
-    v = torch.randn(
-        batch_size, seqlen, nheads_k, headdim, dtype=torch.float16
-    ).to("cuda")
+    k = torch.randn(batch_size, seqlen, nheads_k, headdim, dtype=torch.float16).to(
+        "cuda"
+    )
+    v = torch.randn(batch_size, seqlen, nheads_k, headdim, dtype=torch.float16).to(
+        "cuda"
+    )
 
     out = flash_attn_func(q, k, v)
     assert out.shape == (batch_size, seqlen, nheads, headdim)

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -19,9 +19,7 @@ def run_flash_attn():
 
     batch_size, seqlen, nheads, headdim, nheads_k = 2, 4, 3, 16, 3
 
-    q = torch.randn(batch_size, seqlen, nheads, headdim, dtype=torch.float16).to(
-        "cuda"
-    )
+    q = torch.randn(batch_size, seqlen, nheads, headdim, dtype=torch.float16).to("cuda")
     k = torch.randn(batch_size, seqlen, nheads_k, headdim, dtype=torch.float16).to(
         "cuda"
     )

--- a/04_secrets/db_to_sheet.py
+++ b/04_secrets/db_to_sheet.py
@@ -140,9 +140,7 @@ requests_image = modal.Image.debian_slim(python_version="3.11").pip_install(
 @app.function(
     image=requests_image,
     secrets=[
-        modal.Secret.from_name(
-            "weather-secret", required_keys=["OPENWEATHER_API_KEY"]
-        )
+        modal.Secret.from_name("weather-secret", required_keys=["OPENWEATHER_API_KEY"])
     ],
 )
 def city_weather(city):

--- a/04_secrets/db_to_sheet.py
+++ b/04_secrets/db_to_sheet.py
@@ -221,9 +221,7 @@ pygsheets_image = modal.Image.debian_slim(python_version="3.11").pip_install(
 @app.function(
     image=pygsheets_image,
     secrets=[
-        modal.Secret.from_name(
-            "gsheets-secret", required_keys=["SERVICE_ACCOUNT_JSON"]
-        )
+        modal.Secret.from_name("gsheets-secret", required_keys=["SERVICE_ACCOUNT_JSON"])
     ],
 )
 def update_sheet_report(rows):

--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -39,9 +39,7 @@ slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 @app.function(
     image=slack_sdk_image,
     secrets=[
-        modal.Secret.from_name(
-            "hn-bot-slack", required_keys=["SLACK_BOT_TOKEN"]
-        )
+        modal.Secret.from_name("hn-bot-slack", required_keys=["SLACK_BOT_TOKEN"])
     ],
 )
 async def post_to_slack(message: str):

--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -38,9 +38,7 @@ slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 
 @app.function(
     image=slack_sdk_image,
-    secrets=[
-        modal.Secret.from_name("hn-bot-slack", required_keys=["SLACK_BOT_TOKEN"])
-    ],
+    secrets=[modal.Secret.from_name("hn-bot-slack", required_keys=["SLACK_BOT_TOKEN"])],
 )
 async def post_to_slack(message: str):
     import slack_sdk

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -121,9 +121,7 @@ def configure_rendering(ctx, with_gpu: bool):
 
     # report rendering devices -- a nice snippet for debugging and ensuring the accelerators are being used
     for dev in cycles.preferences.devices:
-        print(
-            f"ID:{dev['id']} Name:{dev['name']} Type:{dev['type']} Use:{dev['use']}"
-        )
+        print(f"ID:{dev['id']} Name:{dev['name']} Type:{dev['type']} Use:{dev['use']}")
 
 
 # ## Combining frames into a video

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -49,7 +49,9 @@ rendering_image = (
 # Functions in Modal are defined along with their hardware and their dependencies.
 # This function can be run with GPU acceleration or without it, and we'll use a global flag in the code to switch between the two.
 
-WITH_GPU = True  # try changing this to False to run rendering massively in parallel on CPUs!
+WITH_GPU = (
+    True  # try changing this to False to run rendering massively in parallel on CPUs!
+)
 
 # We decorate the function with `@app.function` to define it as a Modal function.
 # Note that in addition to defining the hardware requirements of the function,

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -182,9 +182,7 @@ def main(frame_count: int = 250, frame_skip: int = 1):
 
     input_path = Path(__file__).parent / "IceModal.blend"
     blend_bytes = input_path.read_bytes()
-    args = [
-        (blend_bytes, frame) for frame in range(1, frame_count + 1, frame_skip)
-    ]
+    args = [(blend_bytes, frame) for frame in range(1, frame_count + 1, frame_skip)]
     images = list(render.starmap(args))
     for i, image in enumerate(images):
         frame_path = output_directory / f"frame_{i + 1}.png"

--- a/06_gpu_and_ml/blender/blender_video.py
+++ b/06_gpu_and_ml/blender/blender_video.py
@@ -130,9 +130,7 @@ def configure_rendering(ctx, with_gpu: bool):
 # We add another function to our app, running on a different, simpler container image
 # and different hardware, to combine the frames into a video.
 
-combination_image = modal.Image.debian_slim(python_version="3.11").apt_install(
-    "ffmpeg"
-)
+combination_image = modal.Image.debian_slim(python_version="3.11").apt_install("ffmpeg")
 
 # The function to combine the frames into a video takes a sequence of byte sequences, one for each rendered frame,
 # and converts them into a single sequence of bytes, the MP4 file.

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -193,9 +193,7 @@ class ComfyUI:
         self.poll_server_health()
 
         # runs the comfy run --workflow command as a subprocess
-        cmd = (
-            f"comfy run --workflow {workflow_path} --wait --timeout 1200 --verbose"
-        )
+        cmd = f"comfy run --workflow {workflow_path} --wait --timeout 1200 --verbose"
         subprocess.run(cmd, shell=True, check=True)
 
         # completed workflows write output images to this directory

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -242,9 +242,7 @@ class ComfyUI:
 
         try:
             # check if the server is up (response should be immediate)
-            req = urllib.request.Request(
-                f"http://127.0.0.1:{self.port}/system_stats"
-            )
+            req = urllib.request.Request(f"http://127.0.0.1:{self.port}/system_stats")
             urllib.request.urlopen(req, timeout=5)
             print("ComfyUI server is healthy")
         except (socket.timeout, urllib.error.URLError) as e:

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -181,9 +181,7 @@ class ComfyUI:
         # note: requires patching core ComfyUI, see the memory_snapshot_helper directory for more details
         import requests
 
-        response = requests.post(
-            f"http://127.0.0.1:{self.port}/cuda/set_device"
-        )
+        response = requests.post(f"http://127.0.0.1:{self.port}/cuda/set_device")
         if response.status_code != 200:
             print("Failed to set CUDA device")
         else:

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -193,7 +193,9 @@ class ComfyUI:
         self.poll_server_health()
 
         # runs the comfy run --workflow command as a subprocess
-        cmd = f"comfy run --workflow {workflow_path} --wait --timeout 1200 --verbose"
+        cmd = (
+            f"comfy run --workflow {workflow_path} --wait --timeout 1200 --verbose"
+        )
         subprocess.run(cmd, shell=True, check=True)
 
         # completed workflows write output images to this directory

--- a/06_gpu_and_ml/comfyui/memory_snapshot_helper/prestartup_script.py
+++ b/06_gpu_and_ml/comfyui/memory_snapshot_helper/prestartup_script.py
@@ -41,9 +41,7 @@ def _apply_cuda_safe_patch():
         with open(model_management_path, "w") as f:
             f.write(patched_content)
 
-        print(
-            "[memory_snapshot_helper] ==> Successfully patched model_management.py"
-        )
+        print("[memory_snapshot_helper] ==> Successfully patched model_management.py")
     else:
         raise Exception(
             "[memory_snapshot_helper] ==> Failed to patch model_management.py"

--- a/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
+++ b/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
@@ -270,11 +270,7 @@ class TrainConfig(SharedConfig):
     timeout=1800,  # 30 minutes
     secrets=[huggingface_secret]
     + (
-        [
-            modal.Secret.from_name(
-                "wandb-secret", required_keys=["WANDB_API_KEY"]
-            )
-        ]
+        [modal.Secret.from_name("wandb-secret", required_keys=["WANDB_API_KEY"])]
         if USE_WANDB
         else []
     ),

--- a/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
+++ b/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
@@ -78,9 +78,7 @@ image = modal.Image.debian_slim(python_version="3.10").pip_install(
 # The container environments Modal Functions run in are highly flexible --
 # see [the docs](https://modal.com/docs/guide/custom-container) for more details.
 
-GIT_SHA = (
-    "e649678bf55aeaa4b60bd1f68b1ee726278c0304"  # specify the commit to fetch
-)
+GIT_SHA = "e649678bf55aeaa4b60bd1f68b1ee726278c0304"  # specify the commit to fetch
 
 image = (
     image.apt_install("git")

--- a/06_gpu_and_ml/embeddings/text_embeddings_inference.py
+++ b/06_gpu_and_ml/embeddings/text_embeddings_inference.py
@@ -47,9 +47,7 @@ def spawn_server() -> subprocess.Popen:
             # If so, a connection can never be made.
             retcode = process.poll()
             if retcode is not None:
-                raise RuntimeError(
-                    f"launcher exited unexpectedly with code {retcode}"
-                )
+                raise RuntimeError(f"launcher exited unexpectedly with code {retcode}")
 
 
 def download_model():

--- a/06_gpu_and_ml/embeddings/text_embeddings_inference.py
+++ b/06_gpu_and_ml/embeddings/text_embeddings_inference.py
@@ -165,8 +165,6 @@ def embed_dataset():
 
     # data is of type list[tuple[str, str]].
     # starmap spreads the tuples into positional arguments.
-    for output_batch in model.embed.map(
-        generate_batches(), order_outputs=False
-    ):
+    for output_batch in model.embed.map(generate_batches(), order_outputs=False):
         # Do something with the outputs.
         pass

--- a/06_gpu_and_ml/embeddings/wikipedia/main.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/main.py
@@ -71,9 +71,7 @@ def spawn_server() -> subprocess.Popen:
             # If so, a connection can never be made.
             retcode = process.poll()
             if retcode is not None:
-                raise RuntimeError(
-                    f"launcher exited unexpectedly with code {retcode}"
-                )
+                raise RuntimeError(f"launcher exited unexpectedly with code {retcode}")
 
 
 tei_image = (

--- a/06_gpu_and_ml/embeddings/wikipedia/main.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/main.py
@@ -327,9 +327,7 @@ def embed_dataset(down_scale: float = 1, batch_size: int = 512 * 50):
     }
 
     if SAVE_TO_DISK:
-        save_dataset_to_intermediate_checkpoint(
-            acc_chunks, embeddings, batch_size
-        )
+        save_dataset_to_intermediate_checkpoint(acc_chunks, embeddings, batch_size)
 
     if UPLOAD_TO_HF:
         upload_result_to_hf(batch_size)

--- a/06_gpu_and_ml/embeddings/wikipedia/main.py
+++ b/06_gpu_and_ml/embeddings/wikipedia/main.py
@@ -297,9 +297,7 @@ def embed_dataset(down_scale: float = 1, batch_size: int = 512 * 50):
     start = time.perf_counter()
     acc_chunks = []
     embeddings = []
-    for resp in model.embed.map(
-        batches, order_outputs=False, return_exceptions=True
-    ):
+    for resp in model.embed.map(batches, order_outputs=False, return_exceptions=True):
         if isinstance(resp, Exception):
             print(f"Exception: {resp}")
             continue

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -120,10 +120,7 @@ def finetune(num_train_epochs: int = 1, size_percentage: int = 10):
         )
 
         labels["input_ids"] = [
-            [
-                l if l != tokenizer.pad_token_id else padding_token_id
-                for l in label
-            ]
+            [l if l != tokenizer.pad_token_id else padding_token_id for l in label]
             for label in labels["input_ids"]
         ]
 

--- a/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
+++ b/06_gpu_and_ml/flan_t5/flan_t5_finetune.py
@@ -226,9 +226,7 @@ class Summarizer:
             BASE_MODEL, cache_dir=VOL_MOUNT_PATH / "model/"
         )
 
-        self.summarizer = pipeline(
-            "summarization", tokenizer=tokenizer, model=model
-        )
+        self.summarizer = pipeline("summarization", tokenizer=tokenizer, model=model)
 
     @modal.method()
     def generate(self, input: str) -> str:

--- a/06_gpu_and_ml/gpu_fallbacks.py
+++ b/06_gpu_and_ml/gpu_fallbacks.py
@@ -36,9 +36,7 @@ async def remote(_idx):
 def local(count: int = 32):
     from collections import Counter
 
-    gpu_counter = Counter(
-        remote.map([i for i in range(count)], order_outputs=False)
-    )
+    gpu_counter = Counter(remote.map([i for i in range(count)], order_outputs=False))
     print(f"ran {gpu_counter.total()} times")
     print(f"on the following {len(gpu_counter.keys())} GPUs:", end="\n")
     print(

--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -60,9 +60,7 @@ with image.imports():
     gpu="A10G",
     max_containers=1,  # Max one container for this app, for the sake of demoing concurrent_inputs
 )
-@modal.concurrent(
-    max_inputs=100
-)  # Allow concurrent inputs into our single container.
+@modal.concurrent(max_inputs=100)  # Allow concurrent inputs into our single container.
 class Server:
     n_models: int = modal.parameter(default=10)
 

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -209,9 +209,7 @@ def train_model(
         checkpoint = torch.load(str(model_save_dir / model_filename))
         is_best_model = not run_to_first_save
         if is_best_model:
-            make_best_symbolic_link(
-                model_save_dir, model_filename, experiment_name
-            )
+            make_best_symbolic_link(model_save_dir, model_filename, experiment_name)
         model.load_state_dict(checkpoint["model"])
         start_step = checkpoint["steps"] + 1
     else:
@@ -495,9 +493,7 @@ class ModelInference:
         self.tokenizer = Tokenizer(unique_chars)
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        self.model = AttentionModel(
-            self.tokenizer.vocab_size, hparams, self.device
-        )
+        self.model = AttentionModel(self.tokenizer.vocab_size, hparams, self.device)
         self.model.load_state_dict(checkpoint["model"])
         self.model.to(self.device)
 
@@ -592,9 +588,9 @@ def ui():
     def generate(text="", experiment_name=""):
         if not text:
             text = "\n"
-        generated = ModelInference(
-            experiment_name=experiment_name
-        ).generate.remote(text)
+        generated = ModelInference(experiment_name=experiment_name).generate.remote(
+            text
+        )
         return text + generated
 
     example_prompts = [
@@ -675,9 +671,7 @@ def ui():
             # add in a few examples to inspire users
             for ii, prompt in enumerate(example_prompts):
                 btn = gr.Button(prompt, variant="secondary")
-                btn.click(
-                    fn=lambda idx=ii: example_prompts[idx], outputs=input_box
-                )
+                btn.click(fn=lambda idx=ii: example_prompts[idx], outputs=input_box)
 
     # mount for execution on Modal
     return mount_gradio_app(

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -430,9 +430,7 @@ class ModelInference:
     def get_latest_available_model_dirs(self, n_last):
         """Find the latest models that have a best model checkpoint saved."""
         save_model_dirs = glob.glob(f"{model_save_path}/*")
-        sorted_model_dirs = sorted(
-            save_model_dirs, key=os.path.getctime, reverse=True
-        )
+        sorted_model_dirs = sorted(save_model_dirs, key=os.path.getctime, reverse=True)
 
         valid_model_dirs = []
         for latest_model_dir in sorted_model_dirs:

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -512,9 +512,7 @@ class ModelInference:
         self.load_model_impl()  # load updated model if available
 
         n_new_tokens = 1000
-        return self.model.generate_from_text(
-            self.tokenizer, prompt, n_new_tokens
-        )
+        return self.model.generate_from_text(self.tokenizer, prompt, n_new_tokens)
 
 
 # ### Adding a simple web endpoint

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -102,9 +102,7 @@ torch_image = torch_image.add_local_dir(
 )
 
 # We'll serve a simple web endpoint:
-web_image = base_image.pip_install(
-    "fastapi[standard]==0.115.4", "starlette==0.41.2"
-)
+web_image = base_image.pip_install("fastapi[standard]==0.115.4", "starlette==0.41.2")
 
 # And we'll deploy a web UI for interacting with our trained models using Gradio.
 assets_path = Path(__file__).parent / "assets"
@@ -198,9 +196,7 @@ def train_model(
     optimizer = setup_optimizer(model, learning_rate)
 
     # TensorBoard logging & checkpointing prep
-    logs_manager = LogsManager(
-        experiment_name, hparams, num_parameters, tb_log_path
-    )
+    logs_manager = LogsManager(experiment_name, hparams, num_parameters, tb_log_path)
     L.info(f"Model name: {logs_manager.model_name}")
 
     model_save_dir = model_save_path / experiment_name / logs_manager.model_name
@@ -309,9 +305,7 @@ def main(
 
     hparams_list = [
         ModelHyperparameters(n_heads=h, context_size=c, dropout=d)
-        for h, c, d in product(
-            nheads_options, context_size_options, dropout_options
-        )
+        for h, c, d in product(nheads_options, context_size_options, dropout_options)
     ]
 
     # run training for each hyperparameter setting
@@ -615,8 +609,8 @@ def ui():
         css = f.read()
 
     n_last = 20
-    experiment_names = (
-        ModelInference().get_latest_available_experiment_names.remote(n_last)
+    experiment_names = ModelInference().get_latest_available_experiment_names.remote(
+        n_last
     )
     theme = gr.themes.Default(
         primary_hue="green", secondary_hue="emerald", neutral_hue="neutral"

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -71,9 +71,7 @@ gpu = "A10G"
 # distributed [Volume](https://modal.com/docs/guide/volumes)
 # to store the data, checkpointed models, and TensorBoard logs.
 
-volume = modal.Volume.from_name(
-    "example-hp-sweep-gpt-volume", create_if_missing=True
-)
+volume = modal.Volume.from_name("example-hp-sweep-gpt-volume", create_if_missing=True)
 volume_path = PosixPath("/vol/data")
 model_filename = "nano_gpt_model.pt"
 best_model_filename = "best_nano_gpt_model.pt"
@@ -211,9 +209,7 @@ def train_model(
     else:
         model_save_dir.mkdir(parents=True, exist_ok=True)
         start_step = 0
-        checkpoint = init_checkpoint(
-            model, tokenizer, optimizer, start_step, hparams
-        )
+        checkpoint = init_checkpoint(model, tokenizer, optimizer, start_step, hparams)
 
     checkpoint_path = model_save_dir / model_filename
 

--- a/06_gpu_and_ml/hyperparameter-sweep/src/dataset.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/src/dataset.py
@@ -35,9 +35,7 @@ class Dataset:
 
         starts = torch.randint(len(data) - self.context_size, (self.batch_size,))
 
-        x = torch.stack(
-            [data[start : start + self.context_size] for start in starts]
-        )
+        x = torch.stack([data[start : start + self.context_size] for start in starts])
 
         # +1 because we want to predict the next token.
         y = torch.stack(

--- a/06_gpu_and_ml/hyperparameter-sweep/src/dataset.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/src/dataset.py
@@ -33,9 +33,7 @@ class Dataset:
         """Get a batch of train or validation data."""
         data = self.train_data if split == "train" else self.val_data
 
-        starts = torch.randint(
-            len(data) - self.context_size, (self.batch_size,)
-        )
+        starts = torch.randint(len(data) - self.context_size, (self.batch_size,))
 
         x = torch.stack(
             [data[start : start + self.context_size] for start in starts]
@@ -43,9 +41,6 @@ class Dataset:
 
         # +1 because we want to predict the next token.
         y = torch.stack(
-            [
-                data[start + 1 : start + self.context_size + 1]
-                for start in starts
-            ]
+            [data[start + 1 : start + self.context_size + 1] for start in starts]
         )
         return x.to(self.device), y.to(self.device)

--- a/06_gpu_and_ml/hyperparameter-sweep/src/logs_manager.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/src/logs_manager.py
@@ -19,9 +19,7 @@ class LogsManager:
         self.val_writer = SummaryWriter(log_dir=f"{model_log_dir}/val")
 
         # save hyperparameters to TensorBoard for easy reference
-        pretty_hparams_str = "\n".join(
-            f"{k}: {v}" for k, v in hparams.__dict__.items()
-        )
+        pretty_hparams_str = "\n".join(f"{k}: {v}" for k, v in hparams.__dict__.items())
         pretty_hparams_str += f"\nNum parameters: {num_parameters}"
         self.train_writer.add_text("Hyperparameters", pretty_hparams_str)
 

--- a/06_gpu_and_ml/hyperparameter-sweep/src/model.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/src/model.py
@@ -117,9 +117,7 @@ class AttentionModel(nn.Module):
             vocab_size, hparams.n_embed, device=device
         )
         self.pos_embedding_table = nn.Embedding(hparams.context_size, hparams.n_embed)
-        self.blocks = nn.Sequential(
-            *[Block(hparams) for _ in range(hparams.n_blocks)]
-        )
+        self.blocks = nn.Sequential(*[Block(hparams) for _ in range(hparams.n_blocks)])
 
         self.ln_f = nn.LayerNorm(hparams.n_embed)
         self.lm_head = nn.Linear(hparams.n_embed, vocab_size)

--- a/06_gpu_and_ml/hyperparameter-sweep/src/model.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/src/model.py
@@ -60,9 +60,7 @@ class MultiHeadFast(nn.Module):
         else:
             weight = torch.einsum("bnth,bnuh->bntu", q, k)
             weight /= torch.sqrt(self.head_size)
-            weight = weight.masked_fill(
-                self.tril[:, :, :T, :T] == 0, float("-inf")
-            )
+            weight = weight.masked_fill(self.tril[:, :, :T, :T] == 0, float("-inf"))
             dist = F.softmax(weight, dim=-1)
             dist = self.head_dropout(dist)
 

--- a/06_gpu_and_ml/hyperparameter-sweep/src/model.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/src/model.py
@@ -116,9 +116,7 @@ class AttentionModel(nn.Module):
         self.token_embedding_table = nn.Embedding(
             vocab_size, hparams.n_embed, device=device
         )
-        self.pos_embedding_table = nn.Embedding(
-            hparams.context_size, hparams.n_embed
-        )
+        self.pos_embedding_table = nn.Embedding(hparams.context_size, hparams.n_embed)
         self.blocks = nn.Sequential(
             *[Block(hparams) for _ in range(hparams.n_blocks)]
         )

--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -81,9 +81,7 @@ MODEL_REVISION_ID = "a6d59ee37c13c58261aa79027d3e41cd41960925"
 
 model_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 
-MODEL_PATH = (
-    "/models"  # where the Volume will appear on our Functions' filesystems
-)
+MODEL_PATH = "/models"  # where the Volume will appear on our Functions' filesystems
 
 image = image.env(
     {

--- a/06_gpu_and_ml/langchains/potus_speech_qanda.py
+++ b/06_gpu_and_ml/langchains/potus_speech_qanda.py
@@ -47,9 +47,7 @@ app = modal.App(
     name="example-langchain-qanda",
     image=image,
     secrets=[
-        modal.Secret.from_name(
-            "openai-secret", required_keys=["OPENAI_API_KEY"]
-        )
+        modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"])
     ],
 )
 

--- a/06_gpu_and_ml/langchains/potus_speech_qanda.py
+++ b/06_gpu_and_ml/langchains/potus_speech_qanda.py
@@ -46,9 +46,7 @@ image = modal.Image.debian_slim(python_version="3.11").pip_install(
 app = modal.App(
     name="example-langchain-qanda",
     image=image,
-    secrets=[
-        modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"])
-    ],
+    secrets=[modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"])],
 )
 
 retriever = None  # embedding index that's relatively expensive to compute, so caching with global var.

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -215,9 +215,7 @@ class Model:
             batch_images = self.colqwen2_processor.process_images(batch).to(
                 self.colqwen2_model.device
             )
-            pdf_embeddings += list(
-                self.colqwen2_model(**batch_images).to("cpu")
-            )
+            pdf_embeddings += list(self.colqwen2_model(**batch_images).to("cpu"))
 
         # Store the image embeddings in the session, for later retrieval
         session.pdf_embeddings = pdf_embeddings

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -208,9 +208,7 @@ class Model:
         # Generated embeddings from the image(s)
         BATCH_SZ = 4
         pdf_embeddings = []
-        batches = [
-            images[i : i + BATCH_SZ] for i in range(0, len(images), BATCH_SZ)
-        ]
+        batches = [images[i : i + BATCH_SZ] for i in range(0, len(images), BATCH_SZ)]
         for batch in batches:
             batch_images = self.colqwen2_processor.process_images(batch).to(
                 self.colqwen2_model.device

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -290,9 +290,7 @@ class Model:
         )
         inputs = inputs.to("cuda:0")
 
-        generated_ids = self.qwen2_vl_model.generate(
-            **inputs, max_new_tokens=512
-        )
+        generated_ids = self.qwen2_vl_model.generate(**inputs, max_new_tokens=512)
         generated_ids_trimmed = [
             out_ids[len(in_ids) :]
             for in_ids, out_ids in zip(inputs.input_ids, generated_ids)

--- a/06_gpu_and_ml/llm-serving/llama_cpp.py
+++ b/06_gpu_and_ml/llm-serving/llama_cpp.py
@@ -363,9 +363,7 @@ def llama_cpp_inference(
     stdout, stderr = collect_output(p)
 
     if p.returncode != 0:
-        raise subprocess.CalledProcessError(
-            p.returncode, command, stdout, stderr
-        )
+        raise subprocess.CalledProcessError(p.returncode, command, stdout, stderr)
 
     if store_output:  # save results to a Modal Volume if requested
         print(f"🦙 saving results for {result_id}")

--- a/06_gpu_and_ml/llm-serving/llama_cpp.py
+++ b/06_gpu_and_ml/llm-serving/llama_cpp.py
@@ -190,9 +190,7 @@ tag = f"{cuda_version}-{flavor}-{operating_sys}"
 
 image = (
     modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.12")
-    .apt_install(
-        "git", "build-essential", "cmake", "curl", "libcurl4-openssl-dev"
-    )
+    .apt_install("git", "build-essential", "cmake", "curl", "libcurl4-openssl-dev")
     .run_commands("git clone https://github.com/ggerganov/llama.cpp")
     .run_commands(
         "cmake llama.cpp -B llama.cpp/build "

--- a/06_gpu_and_ml/llm-serving/ollama.py
+++ b/06_gpu_and_ml/llm-serving/ollama.py
@@ -152,9 +152,7 @@ class OllamaServer:
                 retcode = await pull_process.wait()
 
                 if retcode != 0:
-                    print(
-                        f"Error pulling model '{model_name}': exit code {retcode}"
-                    )
+                    print(f"Error pulling model '{model_name}': exit code {retcode}")
                 else:
                     print(f"Model '{model_name}' pulled successfully.")
             else:

--- a/06_gpu_and_ml/llm-serving/ollama.py
+++ b/06_gpu_and_ml/llm-serving/ollama.py
@@ -175,9 +175,7 @@ class OllamaServer:
         """Terminates the Ollama server process on shutdown."""
         print("Shutting down Ollama server...")
         if self.ollama_process and self.ollama_process.poll() is None:
-            print(
-                f"Terminating Ollama server (PID: {self.ollama_process.pid})..."
-            )
+            print(f"Terminating Ollama server (PID: {self.ollama_process.pid})...")
             try:
                 self.ollama_process.terminate()
                 self.ollama_process.wait(timeout=10)

--- a/06_gpu_and_ml/llm-serving/ollama.py
+++ b/06_gpu_and_ml/llm-serving/ollama.py
@@ -74,9 +74,7 @@ app = modal.App("ollama-server", image=ollama_image)
 # We use a Modal Volume to cache downloaded models between runs.
 # This prevents needing to re-download large model files each time.
 
-model_volume = modal.Volume.from_name(
-    "ollama-models-store", create_if_missing=True
-)
+model_volume = modal.Volume.from_name("ollama-models-store", create_if_missing=True)
 
 # ## The Ollama Server Class
 
@@ -240,9 +238,7 @@ class OllamaServer:
             all_results[model_name] = model_results
 
             for prompt in test_prompts:
-                print(
-                    f"\n--- Testing Prompt ---\n{prompt}\n----------------------"
-                )
+                print(f"\n--- Testing Prompt ---\n{prompt}\n----------------------")
 
                 # Create message in OpenAI format
                 messages: List[ChatCompletionMessageParam] = [

--- a/06_gpu_and_ml/llm-serving/openai_compatible/client.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/client.py
@@ -32,9 +32,7 @@ def get_completion(client, model_id, messages, args):
         "top_p": args.top_p,
     }
 
-    completion_args = {
-        k: v for k, v in completion_args.items() if v is not None
-    }
+    completion_args = {k: v for k, v in completion_args.items() if v is not None}
 
     try:
         response = client.chat.completions.create(**completion_args)

--- a/06_gpu_and_ml/llm-serving/openai_compatible/client.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/client.py
@@ -169,10 +169,7 @@ def main():
     ]
 
     print(
-        Colors.BOLD
-        + "🧠: Using system prompt: "
-        + args.system_prompt
-        + Colors.END
+        Colors.BOLD + "🧠: Using system prompt: " + args.system_prompt + Colors.END
     )
 
     if args.chat:

--- a/06_gpu_and_ml/llm-serving/openai_compatible/client.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/client.py
@@ -210,9 +210,7 @@ def main():
                         sep="",
                     )
 
-                messages.append(
-                    {"role": "assistant", "content": assistant_message}
-                )
+                messages.append({"role": "assistant", "content": assistant_message})
     else:
         messages.append({"role": "user", "content": args.prompt})
         print(Colors.GREEN + f"\nYou: {args.prompt}" + Colors.END)

--- a/06_gpu_and_ml/llm-serving/openai_compatible/client.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/client.py
@@ -168,9 +168,7 @@ def main():
         }
     ]
 
-    print(
-        Colors.BOLD + "🧠: Using system prompt: " + args.system_prompt + Colors.END
-    )
+    print(Colors.BOLD + "🧠: Using system prompt: " + args.system_prompt + Colors.END)
 
     if args.chat:
         print(

--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -28,7 +28,9 @@ OUT_DIRECTORY = remote_path / datetime.utcnow().replace(microsecond=0).isoformat
 app = modal.App("loadtest-vllm-oai", image=image, volumes={remote_path: volume})
 
 workers = 8
-host = f"https://{workspace}-{environment}--example-vllm-openai-compatible-serve.modal.run"
+host = (
+    f"https://{workspace}-{environment}--example-vllm-openai-compatible-serve.modal.run"
+)
 csv_file = OUT_DIRECTORY / "stats.csv"
 default_args = [
     "-H",

--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -21,9 +21,7 @@ image = (
         remote_path="/root/locustfile.py",
     )
 )
-volume = modal.Volume.from_name(
-    "loadtest-vllm-oai-results", create_if_missing=True
-)
+volume = modal.Volume.from_name("loadtest-vllm-oai-results", create_if_missing=True)
 remote_path = Path("/root") / "loadtests"
 OUT_DIRECTORY = remote_path / datetime.utcnow().replace(microsecond=0).isoformat()
 

--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -25,9 +25,7 @@ volume = modal.Volume.from_name(
     "loadtest-vllm-oai-results", create_if_missing=True
 )
 remote_path = Path("/root") / "loadtests"
-OUT_DIRECTORY = (
-    remote_path / datetime.utcnow().replace(microsecond=0).isoformat()
-)
+OUT_DIRECTORY = remote_path / datetime.utcnow().replace(microsecond=0).isoformat()
 
 app = modal.App("loadtest-vllm-oai", image=image, volumes={remote_path: volume})
 

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -169,9 +169,7 @@ class Model:
             image_path=image_path, question=question, max_new_tokens=128
         )
         # show the question, image, and response in the terminal for demonstration purposes
-        print(
-            Colors.BOLD, Colors.GRAY, "Question: ", question, Colors.END, sep=""
-        )
+        print(Colors.BOLD, Colors.GRAY, "Question: ", question, Colors.END, sep="")
         terminal_image = from_file(image_path)
         terminal_image.draw()
         answer = state["answer"]

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -129,8 +129,8 @@ class Model:
             tp_size=GPU_COUNT,  # t_ensor p_arallel size, number of GPUs to split the model over
             log_level=SGL_LOG_LEVEL,
         )
-        self.runtime.endpoint.chat_template = (
-            sgl.lang.chat_template.get_chat_template(MODEL_CHAT_TEMPLATE)
+        self.runtime.endpoint.chat_template = sgl.lang.chat_template.get_chat_template(
+            MODEL_CHAT_TEMPLATE
         )
         sgl.set_default_backend(self.runtime)
 

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -147,7 +147,9 @@ class Model:
 
         image_url = request.get("image_url")
         if image_url is None:
-            image_url = "https://modal-public-assets.s3.amazonaws.com/golden-gate-bridge.jpg"
+            image_url = (
+                "https://modal-public-assets.s3.amazonaws.com/golden-gate-bridge.jpg"
+            )
 
         response = requests.get(image_url)
         response.raise_for_status()

--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -398,7 +398,9 @@ class Model:
             yield output.outputs[0].text_diff
 
     def text_from_prompt(self, prompt):
-        SYSTEM_PROMPT = "You are a helpful, harmless, and honest AI assistant created by Meta."
+        SYSTEM_PROMPT = (
+            "You are a helpful, harmless, and honest AI assistant created by Meta."
+        )
 
         if isinstance(prompt, str):
             prompt = [{"role": "user", "content": prompt}]

--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -495,9 +495,7 @@ def main(mode: str = "fast"):
 
     p50 = sorted(latencies_ms)[int(len(latencies_ms) * 0.5) - 1]
     p90 = sorted(latencies_ms)[int(len(latencies_ms) * 0.9) - 1]
-    print(
-        f"🏎️  mode={mode} inference latency (p50, p90): ({p50:.2f}ms, {p90:.2f}ms)"
-    )
+    print(f"🏎️  mode={mode} inference latency (p50, p90): ({p50:.2f}ms, {p90:.2f}ms)")
 
 
 # Once deployed with `modal deploy`, this `Model.generate` function

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -207,9 +207,7 @@ tensorrt_image = (  # update the image by quantizing the model
 
 MAX_INPUT_LEN, MAX_OUTPUT_LEN = 256, 256
 MAX_NUM_TOKENS = 2**17
-MAX_BATCH_SIZE = (
-    1024  # better throughput at larger batch sizes, limited by GPU RAM
-)
+MAX_BATCH_SIZE = 1024  # better throughput at larger batch sizes, limited by GPU RAM
 ENGINE_DIR = "/root/model/model_output"
 
 SIZE_ARGS = f"--max_input_len={MAX_INPUT_LEN} --max_num_tokens={MAX_NUM_TOKENS} --max_batch_size={MAX_BATCH_SIZE}"

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -360,9 +360,7 @@ class Model:
             parsed_prompts, return_tensors="pt", padding=True, truncation=False
         )["input_ids"]
 
-        print(
-            f"{COLOR['HEADER']}Input tensors:{COLOR['ENDC']}", inputs_t[:, :8]
-        )
+        print(f"{COLOR['HEADER']}Input tensors:{COLOR['ENDC']}", inputs_t[:, :8])
 
         outputs_t = self.model.generate(inputs_t, **settings)
 
@@ -376,9 +374,7 @@ class Model:
         ]
         duration_s = (time.monotonic_ns() - start) / 1e9
 
-        num_tokens = sum(
-            map(lambda r: len(self.tokenizer.encode(r)), responses)
-        )
+        num_tokens = sum(map(lambda r: len(self.tokenizer.encode(r)), responses))
 
         for prompt, response in zip(prompts, responses):
             print(

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -249,9 +249,7 @@ tensorrt_image = (  # update the image by building the TensorRT engine
 
 # Now that we have the engine compiled, we can serve it with Modal by creating an `App`.
 
-app = modal.App(
-    f"example-trtllm-{MODEL_ID.split('/')[-1]}", image=tensorrt_image
-)
+app = modal.App(f"example-trtllm-{MODEL_ID.split('/')[-1]}", image=tensorrt_image)
 
 # Thanks to our custom container runtime system even this large, many gigabyte container boots in seconds.
 
@@ -288,9 +286,7 @@ class Model:
 
         self.tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
         # LLaMA models do not have a padding token, so we use the EOS token
-        self.tokenizer.add_special_tokens(
-            {"pad_token": self.tokenizer.eos_token}
-        )
+        self.tokenizer.add_special_tokens({"pad_token": self.tokenizer.eos_token})
         # and then we add it from the left, to minimize impact on the output
         self.tokenizer.padding_side = "left"
         self.pad_id = self.tokenizer.pad_token_id

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -365,8 +365,7 @@ class Model:
         )  # only one output per input, so we index with 0
 
         responses = [
-            extract_assistant_response(output_text)
-            for output_text in outputs_text
+            extract_assistant_response(output_text) for output_text in outputs_text
         ]
         duration_s = (time.monotonic_ns() - start) / 1e9
 

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -64,9 +64,7 @@ MODEL_REVISION = "a7c09948d9a632c2c840722f519672cd94af885d"
 # Although vLLM will download weights on-demand, we want to cache them if possible. We'll use [Modal Volumes](https://modal.com/docs/guide/volumes),
 # which act as a "shared disk" that all Modal Functions can access, for our cache.
 
-hf_cache_vol = modal.Volume.from_name(
-    "huggingface-cache", create_if_missing=True
-)
+hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
 vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
 
 

--- a/06_gpu_and_ml/llm-structured/instructor_generate.py
+++ b/06_gpu_and_ml/llm-structured/instructor_generate.py
@@ -44,9 +44,7 @@ image = modal.Image.debian_slim(python_version="3.11").pip_install(
 app = modal.App(
     image=image,
     secrets=[
-        modal.Secret.from_name(
-            "anthropic-secret", required_keys=["ANTHROPIC_API_KEY"]
-        )
+        modal.Secret.from_name("anthropic-secret", required_keys=["ANTHROPIC_API_KEY"])
     ],
 )
 

--- a/06_gpu_and_ml/llm-structured/instructor_generate.py
+++ b/06_gpu_and_ml/llm-structured/instructor_generate.py
@@ -191,9 +191,7 @@ def extract_example_metadata(
     )
 
     # inject the filename
-    full_metadata = ExampleMetadata(
-        **extracted_metadata.dict(), filename=filename
-    )
+    full_metadata = ExampleMetadata(**extracted_metadata.dict(), filename=filename)
 
     # return it as JSON
     return full_metadata.model_dump_json()

--- a/06_gpu_and_ml/llm-structured/instructor_generate.py
+++ b/06_gpu_and_ml/llm-structured/instructor_generate.py
@@ -150,9 +150,7 @@ class ExampleMetadataExtraction(BaseModel):
 class ExampleMetadata(ExampleMetadataExtraction):
     """Metadata about an example from the Modal examples repo."""
 
-    filename: Optional[str] = Field(
-        ..., description="The filename of the example."
-    )
+    filename: Optional[str] = Field(..., description="The filename of the example.")
 
 
 # With these schemas in hand, it's straightforward to write the function that extracts the metadata.

--- a/06_gpu_and_ml/llm-structured/jsonformer_generate.py
+++ b/06_gpu_and_ml/llm-structured/jsonformer_generate.py
@@ -32,9 +32,7 @@ def download_model():
     )
     model.save_pretrained(CACHE_PATH, safe_serialization=True)
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        MODEL_ID, use_fast=True, use_cache=True
-    )
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, use_fast=True, use_cache=True)
     tokenizer.save_pretrained(CACHE_PATH, safe_serialization=True)
 
 

--- a/06_gpu_and_ml/llm-structured/outlines_generate.py
+++ b/06_gpu_and_ml/llm-structured/outlines_generate.py
@@ -115,9 +115,7 @@ def generate(
     model = outlines.models.transformers(MODEL_NAME, device="cuda")
 
     generator = outlines.generate.json(model, schema)
-    character = generator(
-        f"Give me a character description. Describe {prompt}."
-    )
+    character = generator(f"Give me a character description. Describe {prompt}.")
 
     return character
 

--- a/06_gpu_and_ml/long-training.py
+++ b/06_gpu_and_ml/long-training.py
@@ -41,9 +41,7 @@ def train(experiment):
     last_checkpoint = experiment_dir / "last.ckpt"
 
     if last_checkpoint.exists():
-        print(
-            f"⚡️ resuming training from the latest checkpoint: {last_checkpoint}"
-        )
+        print(f"⚡️ resuming training from the latest checkpoint: {last_checkpoint}")
         train_model(
             DATA_PATH,
             experiment_dir,

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -120,12 +120,10 @@ class ObjectDetection:
         inputs = self.feature_extractor(image, return_tensors="pt")
         outputs = self.model(**inputs)
         img_size = torch.tensor([tuple(reversed(image.size))])
-        processed_outputs = (
-            self.feature_extractor.post_process_object_detection(
-                outputs=outputs,
-                target_sizes=img_size,
-                threshold=0,
-            )
+        processed_outputs = self.feature_extractor.post_process_object_detection(
+            outputs=outputs,
+            target_sizes=img_size,
+            threshold=0,
         )
         output_dict = processed_outputs[0]
 
@@ -147,9 +145,7 @@ class ObjectDetection:
             text = self.model.config.id2label[label]
             box = tuple(map(int, box))
             output_image_draw.rectangle(box, outline=color)
-            output_image_draw.text(
-                box[:2], text, font=font, fill=color, width=3
-            )
+            output_image_draw.text(box[:2], text, font=font, fill=color, width=3)
 
         # Return PNG as bytes
         with io.BytesIO() as output_buf:

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -135,9 +135,7 @@ class ObjectDetection:
 
         # Plot bounding boxes
         colors = list(ImageColor.colormap.values())
-        font = ImageFont.truetype(
-            "/usr/share/fonts/truetype/freefont/FreeMono.ttf", 18
-        )
+        font = ImageFont.truetype("/usr/share/fonts/truetype/freefont/FreeMono.ttf", 18)
         output_image = Image.new("RGBA", (image.width, image.height))
         output_image_draw = ImageDraw.Draw(output_image)
         for _score, box, label in zip(scores, boxes, labels):

--- a/06_gpu_and_ml/openai_whisper/batched_whisper.py
+++ b/06_gpu_and_ml/openai_whisper/batched_whisper.py
@@ -129,9 +129,7 @@ class Model:
 
         start = time.monotonic_ns()
         print(f"Transcribing {len(audio_samples)} audio samples")
-        transcriptions = self.pipeline(
-            audio_samples, batch_size=len(audio_samples)
-        )
+        transcriptions = self.pipeline(audio_samples, batch_size=len(audio_samples))
         end = time.monotonic_ns()
         print(
             f"Transcribed {len(audio_samples)} samples in {round((end - start) / 1e9, 2)}s"

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/config.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/config.py
@@ -134,9 +134,7 @@ class DataTrainingArguments:
     )
     preprocessing_num_workers: Optional[int] = field(
         default=None,
-        metadata={
-            "help": "The number of processes to use for the preprocessing."
-        },
+        metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_train_samples: Optional[int] = field(
         default=None,

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/config.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/config.py
@@ -92,9 +92,7 @@ class ModelArguments:
     )
     suppress_tokens: list[int] = field(
         default=None,
-        metadata={
-            "help": "A list of tokens that will be suppressed at generation."
-        },
+        metadata={"help": "A list of tokens that will be suppressed at generation."},
     )
     apply_spec_augment: bool = field(
         default=False,

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/config.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/config.py
@@ -70,15 +70,11 @@ class ModelArguments:
     )
     freeze_feature_encoder: bool = field(
         default=True,
-        metadata={
-            "help": "Whether to freeze the feature encoder layers of the model."
-        },
+        metadata={"help": "Whether to freeze the feature encoder layers of the model."},
     )
     freeze_encoder: bool = field(
         default=False,
-        metadata={
-            "help": "Whether to freeze the entire encoder of the seq2seq model."
-        },
+        metadata={"help": "Whether to freeze the entire encoder of the seq2seq model."},
     )
     forced_decoder_ids: list[list[int]] = field(
         default=None,
@@ -110,9 +106,7 @@ class DataTrainingArguments:
 
     dataset_name: str = field(
         default=None,
-        metadata={
-            "help": "The name of the dataset to use (via the datasets library)."
-        },
+        metadata={"help": "The name of the dataset to use (via the datasets library)."},
     )
     dataset_config_name: Optional[str] = field(
         default=None,

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
@@ -18,9 +18,9 @@ persistent_volume = modal.Volume.from_name(
     create_if_missing=True,
 )
 
-image = modal.Image.debian_slim(
-    python_version="3.12"
-).pip_install_from_requirements("requirements.txt")
+image = modal.Image.debian_slim(python_version="3.12").pip_install_from_requirements(
+    "requirements.txt"
+)
 app = modal.App(
     name="example-whisper-fine-tune",
     image=image,
@@ -126,8 +126,7 @@ def train(
             # different padding methods
             model_input_name = self.processor.model_input_names[0]
             input_features = [
-                {model_input_name: feature[model_input_name]}
-                for feature in features
+                {model_input_name: feature[model_input_name]} for feature in features
             ]
             label_features = [
                 {"input_ids": feature["labels"]} for feature in features
@@ -161,9 +160,7 @@ def train(
             return batch
 
     logger.info("Starting training run")
-    logger.info(
-        f"Finetuned model will be persisted to '{training_args.output_dir}'"
-    )
+    logger.info(f"Finetuned model will be persisted to '{training_args.output_dir}'")
     setup_logging(
         logger=logger,
         log_level=training_args.get_process_log_level(),
@@ -186,10 +183,7 @@ def train(
         and not overwrite_output_dir
     ):
         last_checkpoint = get_last_checkpoint(training_args.output_dir)
-        if (
-            last_checkpoint is None
-            and len(os.listdir(training_args.output_dir)) > 0
-        ):
+        if last_checkpoint is None and len(os.listdir(training_args.output_dir)) > 0:
             print(os.listdir(training_args.output_dir))
             raise ValueError(
                 f"Output directory ({training_args.output_dir}) already exists and is not empty. "
@@ -306,9 +300,7 @@ def train(
 
     if data_args.language is not None:
         # We only need to set the task id when the language is specified (i.e. in a multilingual setting)
-        tokenizer.set_prefix_tokens(
-            language=data_args.language, task=data_args.task
-        )
+        tokenizer.set_prefix_tokens(language=data_args.language, task=data_args.task)
 
     logger.info("6. Resample speech dataset if necessary")
     dataset_sampling_rate = (

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
@@ -320,9 +320,7 @@ def train(
         logger.info("Resampling necessary")
         raw_datasets = raw_datasets.cast_column(
             data_args.audio_column_name,
-            datasets.features.Audio(
-                sampling_rate=feature_extractor.sampling_rate
-            ),
+            datasets.features.Audio(sampling_rate=feature_extractor.sampling_rate),
         )
 
     logger.info("7. Preprocessing the datasets.")

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
@@ -24,9 +24,7 @@ image = modal.Image.debian_slim(python_version="3.12").pip_install_from_requirem
 app = modal.App(
     name="example-whisper-fine-tune",
     image=image,
-    secrets=[
-        modal.Secret.from_name("huggingface-secret", required_keys=["HF_TOKEN"])
-    ],
+    secrets=[modal.Secret.from_name("huggingface-secret", required_keys=["HF_TOKEN"])],
 )
 
 logger = get_logger(__name__)
@@ -128,9 +126,7 @@ def train(
             input_features = [
                 {model_input_name: feature[model_input_name]} for feature in features
             ]
-            label_features = [
-                {"input_ids": feature["labels"]} for feature in features
-            ]
+            label_features = [{"input_ids": feature["labels"]} for feature in features]
 
             batch = self.processor.feature_extractor.pad(
                 input_features, return_tensors="pt"

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
@@ -439,9 +439,7 @@ def train(
         train_dataset=(
             vectorized_datasets["train"] if training_args.do_train else None
         ),
-        eval_dataset=(
-            vectorized_datasets["eval"] if training_args.do_eval else None
-        ),
+        eval_dataset=(vectorized_datasets["eval"] if training_args.do_eval else None),
         tokenizer=feature_extractor,
         data_collator=data_collator,
         compute_metrics=(

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
@@ -415,9 +415,7 @@ def train(
 
         pred_str = tokenizer.batch_decode(pred_ids, skip_special_tokens=True)
         # we do not want to group tokens when computing the metrics
-        label_str = tokenizer.batch_decode(
-            pred.label_ids, skip_special_tokens=True
-        )
+        label_str = tokenizer.batch_decode(pred.label_ids, skip_special_tokens=True)
 
         wer = metric.compute(predictions=pred_str, references=label_str)
 

--- a/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
+++ b/06_gpu_and_ml/openai_whisper/finetuning/train/train.py
@@ -186,8 +186,7 @@ def train(
                 "Use --overwrite_output_dir to overcome."
             )
         elif (
-            last_checkpoint is not None
-            and training_args.resume_from_checkpoint is None
+            last_checkpoint is not None and training_args.resume_from_checkpoint is None
         ):
             logger.info(
                 f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -52,9 +52,7 @@ async def get_episode(podcast_id: str, episode_guid_hash: str):
 
 @web_app.get("/api/podcast/{podcast_id}")
 async def get_podcast(podcast_id: str):
-    pod_metadata_path = (
-        config.PODCAST_METADATA_DIR / podcast_id / "metadata.json"
-    )
+    pod_metadata_path = config.PODCAST_METADATA_DIR / podcast_id / "metadata.json"
     previously_stored = True
     if not pod_metadata_path.exists():
         previously_stored = False

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -61,9 +61,7 @@ async def get_podcast(podcast_id: str):
         # to propogate.
         raw_populate_podcast_metadata = populate_podcast_metadata.get_raw_f()
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None, raw_populate_podcast_metadata, podcast_id
-        )
+        await loop.run_in_executor(None, raw_populate_podcast_metadata, podcast_id)
 
     with open(pod_metadata_path, "r") as f:
         pod_metadata = json.load(f)
@@ -117,9 +115,7 @@ async def transcribe_job(podcast_id: str, episode_id: str):
         pass
 
     call = process_episode.spawn(podcast_id, episode_id)
-    in_progress[episode_id] = InProgressJob(
-        call_id=call.object_id, start_time=now
-    )
+    in_progress[episode_id] = InProgressJob(call_id=call.object_id, start_time=now)
 
     return {"call_id": call.object_id}
 

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -146,9 +146,7 @@ async def poll_status(call_id: str):
 
     leaves = map_root.children
     tasks = len(set([leaf.task_id for leaf in leaves]))
-    done_segments = len(
-        [leaf for leaf in leaves if leaf.status == InputStatus.SUCCESS]
-    )
+    done_segments = len([leaf for leaf in leaves if leaf.status == InputStatus.SUCCESS])
     total_segments = len(leaves)
     finished = map_root.status == InputStatus.SUCCESS
 

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -30,9 +30,7 @@ class InProgressJob(NamedTuple):
 
 @web_app.get("/api/episode/{podcast_id}/{episode_guid_hash}")
 async def get_episode(podcast_id: str, episode_guid_hash: str):
-    episode_metadata_path = get_episode_metadata_path(
-        podcast_id, episode_guid_hash
-    )
+    episode_metadata_path = get_episode_metadata_path(podcast_id, episode_guid_hash)
     transcription_path = get_transcript_path(episode_guid_hash)
 
     with open(episode_metadata_path, "r") as f:

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -159,9 +159,7 @@ def refresh_index():
                 with open(filepath, "r") as f:
                     data = json.load(f)
             except json.decoder.JSONDecodeError:
-                logger.warning(
-                    f"Removing corrupt JSON metadata file: {filepath}."
-                )
+                logger.warning(f"Removing corrupt JSON metadata file: {filepath}.")
                 filepath.unlink()
 
             ep = dacite.from_dict(data_class=podcast.EpisodeMetadata, data=data)

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -74,9 +74,7 @@ def populate_podcast_metadata(podcast_id: str):
     metadata_dir.mkdir(parents=True, exist_ok=True)
 
     metadata_path = config.PODCAST_METADATA_DIR / podcast_id / "metadata.json"
-    pod_metadata: podcast.PodcastMetadata = podcast.fetch_podcast(
-        gql, podcast_id
-    )
+    pod_metadata: podcast.PodcastMetadata = podcast.fetch_podcast(gql, podcast_id)
 
     with open(metadata_path, "w") as f:
         json.dump(dataclasses.asdict(pod_metadata), f)

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -14,9 +14,7 @@ import modal
 from . import config, podcast, search
 
 logger = config.get_logger(__name__)
-volume = modal.NetworkFileSystem.from_name(
-    "dataset-cache-vol", create_if_missing=True
-)
+volume = modal.NetworkFileSystem.from_name("dataset-cache-vol", create_if_missing=True)
 
 app_image = (
     modal.Image.debian_slim(python_version="3.10")
@@ -102,9 +100,7 @@ def fastapi_app():
 
     from .api import web_app
 
-    web_app.mount(
-        "/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True)
-    )
+    web_app.mount("/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True))
 
     return web_app
 

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -117,9 +117,7 @@ def search_podcast(name):
 
     logger.info(f"Searching for '{name}'")
     client = podcast.create_podchaser_client()
-    podcasts_raw = podcast.search_podcast_name(
-        gql, client, name, max_results=10
-    )
+    podcasts_raw = podcast.search_podcast_name(gql, client, name, max_results=10)
     logger.info(f"Found {len(podcasts_raw)} results for '{name}'")
     return [
         podcast.PodcastMetadata(
@@ -199,9 +197,7 @@ def refresh_index():
             # Prepare records for JSON serialization
             indexed_episodes.append(dataclasses.asdict(idxd_episode))
 
-    logger.info(
-        f"Matched {len(search_records)} transcripts to episode records."
-    )
+    logger.info(f"Matched {len(search_records)} transcripts to episode records.")
 
     filepath = config.SEARCH_DIR / "all.json"
     logger.info(f"writing {filepath}")

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -369,9 +369,7 @@ def process_episode(podcast_id: str, episode_id: str):
         metadata_path = get_episode_metadata_path(podcast_id, episode_id)
         with open(metadata_path, "r") as f:
             data = json.load(f)
-            episode = dacite.from_dict(
-                data_class=podcast.EpisodeMetadata, data=data
-            )
+            episode = dacite.from_dict(data_class=podcast.EpisodeMetadata, data=data)
 
         destination_path = config.RAW_AUDIO_DIR / episode_id
         podcast.store_original_audio(

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/podcast.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/podcast.py
@@ -163,9 +163,7 @@ def search_podcast_name(gql, client, name, max_results=5) -> list[dict]:
     return podcasts_in_page
 
 
-def fetch_episodes_data(
-    gql, client, podcast_id, max_episodes=100
-) -> list[dict]:
+def fetch_episodes_data(gql, client, podcast_id, max_episodes=100) -> list[dict]:
     """
     Use the Podchaser API to grab a podcast's episodes.
     """

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/podcast.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/podcast.py
@@ -270,9 +270,7 @@ def store_original_audio(
                 f"Audio file exists at {destination} but overwrite option is specified."
             )
         else:
-            logger.info(
-                f"Audio file exists at {destination}, skipping download."
-            )
+            logger.info(f"Audio file exists at {destination}, skipping download.")
             return
 
     podcast_download_result = download_podcast_file(url=url)

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/podcast.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/podcast.py
@@ -209,9 +209,7 @@ def fetch_episodes_data(gql, client, podcast_id, max_episodes=100) -> list[dict]
 
         logger.info(f"Fetching {max_episodes_per_request} episodes from API.")
         result = client.execute(list_episodes_query)
-        has_more_pages = result["podcast"]["episodes"]["paginatorInfo"][
-            "hasMorePages"
-        ]
+        has_more_pages = result["podcast"]["episodes"]["paginatorInfo"]["hasMorePages"]
         episodes_in_page = result["podcast"]["episodes"]["data"]
         episodes.extend(episodes_in_page)
         current_page += 1

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
@@ -113,9 +113,7 @@ def calculate_similarity_with_svm(X, ntake=40):
         )
         clf.fit(X, y)
         s = clf.decision_function(X)
-        ix = np.argsort(s)[
-            : -ntake - 1 : -1
-        ]  # take last ntake sorted backwards
+        ix = np.argsort(s)[: -ntake - 1 : -1]  # take last ntake sorted backwards
         IX[i] = ix
     return IX.tolist()
 
@@ -140,9 +138,7 @@ def build_search_index(records: list[SearchRecord], v):
                 if w in vocab:
                     idfval = idf[vocab[w]]  # we have a computed idf for this
                 else:
-                    idfval = (
-                        1.0  # some word we don't know; assume idf 1.0 (low)
-                    )
+                    idfval = 1.0  # some word we don't know; assume idf 1.0 (low)
             else:
                 idfval = forceidf
             idfd[w] = idfval

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
@@ -124,7 +124,9 @@ def build_search_index(records: list[SearchRecord], v):
     # construct a reverse index for supporting search
     vocab = v.vocabulary_
     idf = v.idf_
-    punc = "'!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~'"  # removed hyphen from string.punctuation
+    punc = (
+        "'!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~'"  # removed hyphen from string.punctuation
+    )
     trans_table = {ord(c): None for c in punc}
 
     def makedict(s, forceidf=None):

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
@@ -81,9 +81,7 @@ def calculate_sim_dot_product(X, ntake=40):
     from numpy import np
 
     S = np.dot(X, X.T)
-    IX = np.argsort(S, axis=1)[
-        :, : -ntake - 1 : -1
-    ]  # take last ntake sorted backwards
+    IX = np.argsort(S, axis=1)[:, : -ntake - 1 : -1]  # take last ntake sorted backwards
     return IX.tolist()
 
 

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/search.py
@@ -129,9 +129,7 @@ def build_search_index(records: list[SearchRecord], v):
 
     def makedict(s, forceidf=None):
         words = set(s.lower().translate(trans_table).strip().split())
-        words = set(
-            w for w in words if len(w) > 1 and (w not in ENGLISH_STOP_WORDS)
-        )
+        words = set(w for w in words if len(w) > 1 and (w not in ENGLISH_STOP_WORDS))
         idfd = {}
         for w in words:
             if forceidf is None:

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/transcribe_check.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/transcribe_check.py
@@ -101,9 +101,7 @@ def test_transcribe_handles_dangling_segment():
     end = problem_segment[1]
     logger.info(f"Problem segment time range is ({start}, {end})")
     try:
-        transcribe_segment(
-            start=start, end=end, audio_filepath=audio_path, model=model
-        )
+        transcribe_segment(start=start, end=end, audio_filepath=audio_path, model=model)
     except Exception:
         logger.info(
             "Writing the problem segment to the network file system for further debugging."

--- a/06_gpu_and_ml/openai_whisper/streaming/main.py
+++ b/06_gpu_and_ml/openai_whisper/streaming/main.py
@@ -25,9 +25,7 @@ image = (
 )
 app = modal.App(name="example-whisper-streaming", image=image)
 web_app = FastAPI()
-CHARLIE_CHAPLIN_DICTATOR_SPEECH_URL = (
-    "https://www.youtube.com/watch?v=J7GY1Xg6X20"
-)
+CHARLIE_CHAPLIN_DICTATOR_SPEECH_URL = "https://www.youtube.com/watch?v=J7GY1Xg6X20"
 
 
 def load_audio(data: bytes, start=None, end=None, sr: int = 16000):
@@ -213,9 +211,7 @@ async def transcribe(url: str):
     try:
         audio_data = download_mp3_from_youtube.remote(url)
     except pytube.exceptions.RegexMatchError:
-        raise HTTPException(
-            status_code=422, detail=f"Could not process url {url}"
-        )
+        raise HTTPException(status_code=422, detail=f"Could not process url {url}")
     print(f"streaming transcription of {url} audio to client...")
     return StreamingResponse(
         stream_whisper(audio_data), media_type="text/event-stream"

--- a/06_gpu_and_ml/openai_whisper/streaming/main.py
+++ b/06_gpu_and_ml/openai_whisper/streaming/main.py
@@ -213,9 +213,7 @@ async def transcribe(url: str):
     except pytube.exceptions.RegexMatchError:
         raise HTTPException(status_code=422, detail=f"Could not process url {url}")
     print(f"streaming transcription of {url} audio to client...")
-    return StreamingResponse(
-        stream_whisper(audio_data), media_type="text/event-stream"
-    )
+    return StreamingResponse(stream_whisper(audio_data), media_type="text/event-stream")
 
 
 @app.function()

--- a/06_gpu_and_ml/protein-folding/boltz1.py
+++ b/06_gpu_and_ml/protein-folding/boltz1.py
@@ -133,9 +133,7 @@ def boltz1_inference(boltz_input_yaml: str, msas: list["MSA"], args="") -> bytes
     )
 
     print("🧬 packaging up outputs")
-    output_bytes = package_outputs(
-        f"boltz_results_{input_path.with_suffix('').name}"
-    )
+    output_bytes = package_outputs(f"boltz_results_{input_path.with_suffix('').name}")
 
     return output_bytes
 

--- a/06_gpu_and_ml/protein-folding/boltz1.py
+++ b/06_gpu_and_ml/protein-folding/boltz1.py
@@ -118,9 +118,7 @@ models_dir = Path("/models/boltz1")
     timeout=10 * MINUTES,
     gpu="H100",
 )
-def boltz1_inference(
-    boltz_input_yaml: str, msas: list["MSA"], args=""
-) -> bytes:
+def boltz1_inference(boltz_input_yaml: str, msas: list["MSA"], args="") -> bytes:
     import shlex
     import subprocess
 

--- a/06_gpu_and_ml/protein-folding/boltz1.py
+++ b/06_gpu_and_ml/protein-folding/boltz1.py
@@ -47,9 +47,7 @@ app = modal.App(name="example-boltz1-inference")
 
 
 @app.local_entrypoint()
-def main(
-    force_download: bool = False, input_yaml_path: str = None, args: str = ""
-):
+def main(force_download: bool = False, input_yaml_path: str = None, args: str = ""):
     print("🧬 loading model remotely")
     download_model.remote(force_download)
 
@@ -94,9 +92,7 @@ image = modal.Image.debian_slim(python_version="3.12").run_commands(
 # For more on storing model weights on Modal, see [this guide](https://modal.com/docs/guide/model-weights).
 # For details on how we download the weights in this case, see the [Addenda](#addenda).
 
-boltz_model_volume = modal.Volume.from_name(
-    "boltz1-models", create_if_missing=True
-)
+boltz_model_volume = modal.Volume.from_name("boltz1-models", create_if_missing=True)
 models_dir = Path("/models/boltz1")
 
 # ## Running Boltz-1 on Modal

--- a/06_gpu_and_ml/protein-folding/chai1.py
+++ b/06_gpu_and_ml/protein-folding/chai1.py
@@ -89,9 +89,7 @@ def main(
 
     print(f"🧬 saving results to disk locally in {output_dir}")
     for ii, (scores, cif) in enumerate(results):
-        (Path(output_dir) / f"{run_id}-scores.model_idx_{ii}.npz").write_bytes(
-            scores
-        )
+        (Path(output_dir) / f"{run_id}-scores.model_idx_{ii}.npz").write_bytes(scores)
         (Path(output_dir) / f"{run_id}-preds.model_idx_{ii}.cif").write_text(cif)
 
 

--- a/06_gpu_and_ml/protein-folding/chai1.py
+++ b/06_gpu_and_ml/protein-folding/chai1.py
@@ -92,9 +92,7 @@ def main(
         (Path(output_dir) / f"{run_id}-scores.model_idx_{ii}.npz").write_bytes(
             scores
         )
-        (Path(output_dir) / f"{run_id}-preds.model_idx_{ii}.cif").write_text(
-            cif
-        )
+        (Path(output_dir) / f"{run_id}-preds.model_idx_{ii}.cif").write_text(cif)
 
 
 # ## Installing Chai-1 Python dependencies on Modal
@@ -157,9 +155,7 @@ image = image.env(  # update the environment variables in the image to...
 # We attach a Volume to a Modal Function that runs Chai-1 and the inference code
 # saves the results to distributed storage, without any fuss or source code changes.
 
-chai_preds_volume = modal.Volume.from_name(
-    "chai1-preds", create_if_missing=True
-)
+chai_preds_volume = modal.Volume.from_name("chai1-preds", create_if_missing=True)
 preds_dir = Path("/preds")
 
 # ## Running Chai-1 on Modal

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -35,9 +35,7 @@ app = modal.App("example-esm3-dashboard")
 # [this guide](https://modal.com/docs/guide/model-weights).
 # We'll use this same distributed storage primitive to store sequence data.
 
-volume = modal.Volume.from_name(
-    "example-esm3-dashboard", create_if_missing=True
-)
+volume = modal.Volume.from_name("example-esm3-dashboard", create_if_missing=True)
 VOLUME_PATH = Path("/vol")
 MODELS_PATH = VOLUME_PATH / "models"
 DATA_PATH = VOLUME_PATH / "data"
@@ -288,9 +286,7 @@ def ui():
                 with gr.Row():
                     half_len = int(len(example_uniprots) / 2)
                     with gr.Column():
-                        for i, uniprot in enumerate(
-                            example_uniprots[:half_len]
-                        ):
+                        for i, uniprot in enumerate(example_uniprots[:half_len]):
                             btn = gr.Button(uniprot, variant="secondary")
                             btn.click(
                                 fn=lambda j=i: extract_uniprot_num(j),
@@ -298,14 +294,10 @@ def ui():
                             )
 
                     with gr.Column():
-                        for i, uniprot in enumerate(
-                            example_uniprots[half_len:]
-                        ):
+                        for i, uniprot in enumerate(example_uniprots[half_len:]):
                             btn = gr.Button(uniprot, variant="secondary")
                             btn.click(
-                                fn=lambda j=i + half_len: extract_uniprot_num(
-                                    j
-                                ),
+                                fn=lambda j=i + half_len: extract_uniprot_num(j),
                                 outputs=uniprot_num_box,
                             )
 

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -262,9 +262,7 @@ def ui():
                     "Retrieve Sequence from UniProt ID", variant="primary"
                 )
 
-                uniprot_link_button = gr.Button(
-                    value="View protein on UniProt website"
-                )
+                uniprot_link_button = gr.Button(value="View protein on UniProt website")
                 uniprot_link_button.click(
                     fn=None,
                     inputs=uniprot_num_box,

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -248,9 +248,7 @@ def ui():
 
     title = "Predict & Visualize Protein Structures"
 
-    with gr.Blocks(
-        theme=theme, css=css, title=title, js=always_dark()
-    ) as interface:
+    with gr.Blocks(theme=theme, css=css, title=title, js=always_dark()) as interface:
         gr.Markdown(f"# {title}")
 
         with gr.Row():

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -73,9 +73,7 @@ esm3_image = (
 
 web_app_image = (
     modal.Image.debian_slim(python_version="3.11")
-    .pip_install(
-        "gradio~=4.44.0", "biotite==0.41.2", "fastapi[standard]==0.115.4"
-    )
+    .pip_install("gradio~=4.44.0", "biotite==0.41.2", "fastapi[standard]==0.115.4")
     .add_local_dir(Path(__file__).parent / "frontend", remote_path="/assets")
 )
 
@@ -315,9 +313,7 @@ def ui():
         gr.Markdown("## ESM3 Predicted Structure")
         molstar_html = gr.HTML()
 
-        run_esm_button.click(
-            fn=run_esm, inputs=sequence_box, outputs=molstar_html
-        )
+        run_esm_button.click(fn=run_esm, inputs=sequence_box, outputs=molstar_html)
 
     # return a FastAPI app for Modal to serve
     return mount_gradio_app(app=web_app, blocks=interface, path="/")

--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -261,9 +261,7 @@ def save_segmented_frames(video_segments, frames_dir, out_dir, frame_names, stri
         frame = Image.open(frames_dir / frame_names[out_frame_idx])
         width, height = frame.size
         width, height = width - width % 2, height - height % 2
-        fig, ax = plt.subplots(
-            figsize=(width * inches_per_px, height * inches_per_px)
-        )
+        fig, ax = plt.subplots(figsize=(width * inches_per_px, height * inches_per_px))
         ax.axis("off")
         ax.imshow(frame)
 

--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -29,7 +29,9 @@ from pathlib import Path
 import modal
 
 MODEL_TYPE = "facebook/sam2-hiera-large"
-SAM2_GIT_SHA = "c2ec8e14a185632b0a5d8b161928ceb50197eddc"  # pin commit! research code is fragile
+SAM2_GIT_SHA = (
+    "c2ec8e14a185632b0a5d8b161928ceb50197eddc"  # pin commit! research code is fragile
+)
 
 image = (
     modal.Image.debian_slim(python_version="3.10")
@@ -79,9 +81,7 @@ class Model:
         self.video_predictor = SAM2VideoPredictor.from_pretrained(MODEL_TYPE)
 
     @modal.method()
-    def generate_video_masks(
-        self, video="/root/videos/input.mp4", point_coords=None
-    ):
+    def generate_video_masks(self, video="/root/videos/input.mp4", point_coords=None):
         """Generate masks for a video."""
         import ffmpeg
         import numpy as np
@@ -131,9 +131,7 @@ class Model:
                 labels=labels,
             )
 
-            print(
-                f"frame_idx: {frame_idx}, object_ids: {object_ids}, masks: {masks}"
-            )
+            print(f"frame_idx: {frame_idx}, object_ids: {object_ids}, masks: {masks}")
 
             # run propagation throughout the video and collect the results in a dict
             video_segments = {}  # video_segments contains the per-frame segmentation results
@@ -249,9 +247,7 @@ def show_mask(mask, ax, obj_id=None, random_color=False):
     ax.imshow(mask_image)
 
 
-def save_segmented_frames(
-    video_segments, frames_dir, out_dir, frame_names, stride=5
-):
+def save_segmented_frames(video_segments, frames_dir, out_dir, frame_names, stride=5):
     import io
 
     import matplotlib.pyplot as plt

--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -167,9 +167,7 @@ class Model:
             "scale",
             "trunc(iw/2)*2",
             "trunc(ih/2)*2",  # round to even dimensions to encode for "dumb players", https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers
-        ).output(
-            str(out_dir / "out.mp4"), format="mp4", pix_fmt="yuv420p"
-        ).run()
+        ).output(str(out_dir / "out.mp4"), format="mp4", pix_fmt="yuv420p").run()
 
         return (out_dir / "out.mp4").read_bytes()
 

--- a/06_gpu_and_ml/stable_diffusion/a1111_webui.py
+++ b/06_gpu_and_ml/stable_diffusion/a1111_webui.py
@@ -60,9 +60,7 @@ app = modal.App("example-a1111-webui", image=a1111_image)
     timeout=3600,
     min_containers=1,  # Keep at least one instance of the server running.
 )
-@modal.concurrent(
-    max_inputs=100
-)  # Allow 100 concurrent requests per container.
+@modal.concurrent(max_inputs=100)  # Allow 100 concurrent requests per container.
 @modal.web_server(port=PORT, startup_timeout=180)
 def run():
     START_COMMAND = f"""

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -102,9 +102,7 @@ NUM_INFERENCE_STEPS = 4  # use ~50 for [dev], smaller for [schnell]
     scaledown_window=20 * MINUTES,
     timeout=60 * MINUTES,  # leave plenty of time for compilation
     volumes={  # add Volumes to store serializable compilation artifacts, see section on torch.compile below
-        "/cache": modal.Volume.from_name(
-            "hf-hub-cache", create_if_missing=True
-        ),
+        "/cache": modal.Volume.from_name("hf-hub-cache", create_if_missing=True),
         "/root/.nv": modal.Volume.from_name("nv-cache", create_if_missing=True),
         "/root/.triton": modal.Volume.from_name(
             "triton-cache", create_if_missing=True

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -104,9 +104,7 @@ NUM_INFERENCE_STEPS = 4  # use ~50 for [dev], smaller for [schnell]
     volumes={  # add Volumes to store serializable compilation artifacts, see section on torch.compile below
         "/cache": modal.Volume.from_name("hf-hub-cache", create_if_missing=True),
         "/root/.nv": modal.Volume.from_name("nv-cache", create_if_missing=True),
-        "/root/.triton": modal.Volume.from_name(
-            "triton-cache", create_if_missing=True
-        ),
+        "/root/.triton": modal.Volume.from_name("triton-cache", create_if_missing=True),
         "/root/.inductor-cache": modal.Volume.from_name(
             "inductor-cache", create_if_missing=True
         ),

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -102,9 +102,7 @@ class Model:
     def inference(
         self, image_bytes: bytes, prompt: str, strength: float = 0.9
     ) -> bytes:
-        init_image = load_image(Image.open(BytesIO(image_bytes))).resize(
-            (512, 512)
-        )
+        init_image = load_image(Image.open(BytesIO(image_bytes))).resize((512, 512))
         num_inference_steps = 4
         # "When using SDXL-Turbo for image-to-image generation, make sure that num_inference_steps * strength is larger or equal to 1"
         # See: https://huggingface.co/stabilityai/sdxl-turbo

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -47,9 +47,7 @@ image = (
 
 cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 
-app = modal.App(
-    "image-to-image", image=image, volumes={CACHE_DIR: cache_volume}
-)
+app = modal.App("image-to-image", image=image, volumes={CACHE_DIR: cache_volume})
 
 with image.imports():
     import torch

--- a/06_gpu_and_ml/stable_diffusion/stable_video_diffusion.py
+++ b/06_gpu_and_ml/stable_diffusion/stable_video_diffusion.py
@@ -11,9 +11,7 @@ import sys
 import modal
 
 app = modal.App(name="example-stable-video-diffusion-streamlit")
-q = modal.Queue.from_name(
-    "stable-video-diffusion-streamlit", create_if_missing=True
-)
+q = modal.Queue.from_name("stable-video-diffusion-streamlit", create_if_missing=True)
 
 session_timeout = 15 * 60
 

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -104,9 +104,7 @@ class Inference:
         ).to("cuda")
 
     @modal.method()
-    def run(
-        self, prompt: str, batch_size: int = 4, seed: int = None
-    ) -> list[bytes]:
+    def run(self, prompt: str, batch_size: int = 4, seed: int = None) -> list[bytes]:
         seed = seed if seed is not None else random.randint(0, 2**32 - 1)
         print("seeding RNG with", seed)
         torch.manual_seed(seed)

--- a/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
+++ b/06_gpu_and_ml/tensorflow/tensorflow_tutorial.py
@@ -40,9 +40,7 @@ app = modal.App("example-tensorflow-tutorial", image=dockerhub_image)
 # We want to run the web server for TensorBoard at the same time as we are training the TensorFlow model.
 # The easiest way to do this is to set up a shared filesystem between the training and the web server.
 
-fs = modal.NetworkFileSystem.from_name(
-    "tensorflow-tutorial", create_if_missing=True
-)
+fs = modal.NetworkFileSystem.from_name("tensorflow-tutorial", create_if_missing=True)
 logdir = "/tensorboard"
 
 # ## Training function

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -268,9 +268,7 @@ def ui():
     async def generate_music(
         prompt: str, duration: int = 10, format: str = "wav"
     ):
-        audio_bytes = await generate.aio(
-            prompt, duration=duration, format=format
-        )
+        audio_bytes = await generate.aio(prompt, duration=duration, format=format)
 
         audio_path = temp_dir / f"{uuid4()}.{format}"
         audio_path.write_bytes(audio_bytes)

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -265,9 +265,7 @@ def ui():
 
     temp_dir = Path("/dev/shm")
 
-    async def generate_music(
-        prompt: str, duration: int = 10, format: str = "wav"
-    ):
+    async def generate_music(prompt: str, duration: int = 10, format: str = "wav"):
         audio_bytes = await generate.aio(prompt, duration=duration, format=format)
 
         audio_path = temp_dir / f"{uuid4()}.{format}"

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -64,9 +64,7 @@ def load_model(and_return=False):
 # to store the weights in the cloud.
 
 cache_dir = "/cache"
-model_cache = modal.Volume.from_name(
-    "audiocraft-model-cache", create_if_missing=True
-)
+model_cache = modal.Volume.from_name("audiocraft-model-cache", create_if_missing=True)
 
 # We don't need to change any of the model loading code --
 # we just need to make sure the model gets stored in the right directory.

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -144,9 +144,7 @@ class MusicGen:
 
             # generate next segment
             generated_duration = (
-                segment_duration
-                if context is None
-                else (segment_duration - overlap)
+                segment_duration if context is None else (segment_duration - overlap)
             )
             print(f"🎼 generating {generated_duration} seconds of music")
             self.model.set_generation_params(duration=segment_duration)

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/config.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/config.py
@@ -189,9 +189,7 @@ def load_stable_diffusion_pokemon_model():
     return pipe
 
 
-volume = modal.Volume.from_name(
-    "txt-to-pokemon-cache-vol", create_if_missing=True
-)
+volume = modal.Volume.from_name("txt-to-pokemon-cache-vol", create_if_missing=True)
 image = (
     modal.Image.debian_slim()
     .pip_install(

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/config.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/config.py
@@ -176,9 +176,7 @@ def load_stable_diffusion_pokemon_model():
         cache_dir=cache_dir,
         local_files_only=local_files_only,
     )
-    print(
-        f"finished {load_action} model, took {time.time() - load_start_time:.3f}s."
-    )
+    print(f"finished {load_action} model, took {time.time() - load_start_time:.3f}s.")
 
     if DISABLE_SAFETY:
 

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/inpaint.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/inpaint.py
@@ -98,9 +98,7 @@ def new_pokemon_name(card_image: bytes, pokemon_name: str = "Randomon") -> bytes
         mask_img_bytes = buf.getvalue()
         mask, _ = load_img(mask_img_bytes)
 
-    assert img.shape[:2] == mask.shape[:2], (
-        "shapes of base image and mask must match"
-    )
+    assert img.shape[:2] == mask.shape[:2], "shapes of base image and mask must match"
 
     # "No GPU is required, and for simple backgrounds, the results may even be better than AI models."
     cur_res = cv2.inpaint(

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/inpaint.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/inpaint.py
@@ -68,9 +68,7 @@ def numpy_to_bytes(image_numpy, ext: str) -> bytes:
     return image_bytes
 
 
-def new_pokemon_name(
-    card_image: bytes, pokemon_name: str = "Randomon"
-) -> bytes:
+def new_pokemon_name(card_image: bytes, pokemon_name: str = "Randomon") -> bytes:
     import cv2
     from PIL import Image, ImageDraw, ImageFont
 

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -176,9 +176,7 @@ def composite_pokemon_card(
     character_i = Image.open(character_img)
 
     # Fit Pokémon character image to size of base card's character illustration window.
-    character_i.thumbnail(
-        size=(pokecard_window_size[0], pokecard_window_size[0])
-    )
+    character_i.thumbnail(size=(pokecard_window_size[0], pokecard_window_size[0]))
     (left, upper, right, lower) = (
         0,
         0,

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -136,9 +136,7 @@ def fastapi_app():
 
     from .api import web_app
 
-    web_app.mount(
-        "/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True)
-    )
+    web_app.mount("/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True))
 
     return web_app
 
@@ -244,9 +242,7 @@ def create_composite_card(i: int, sample: bytes, prompt: str) -> bytes:
     .starmap over this function to boost performance.
     """
     print(f"Determining base card for generated sample {i}.")
-    closest_card = closest_pokecard_by_color(
-        sample=sample, cards=config.POKEMON_CARDS
-    )
+    closest_card = closest_pokecard_by_color(sample=sample, cards=config.POKEMON_CARDS)
     base_card_url = closest_card["images"]["large"]
     print(f"Closest base card for sample {i} is '{closest_card['name']}'")
     req = urllib.request.Request(

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -201,9 +201,7 @@ def composite_pokemon_card(
     mask_im_blur = mask_im.filter(ImageFilter.GaussianBlur(20))
 
     back_im = base_i.copy()
-    back_im.paste(
-        cropped_character_i, pokecard_window_top_right_crnr, mask_im_blur
-    )
+    back_im.paste(cropped_character_i, pokecard_window_top_right_crnr, mask_im_blur)
 
     # If a (manually uploaded) mini Modal logo exists, paste that discreetly onto the image too :)
     mini_modal_logo = config.CARD_PART_IMGS / "mini-modal-logo.png"

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -272,9 +272,7 @@ def create_pokemon_cards(prompt: str) -> list[dict]:
         print(
             "Cached! - prompt has had cards composed before, returning previous Pokémon card results."
         )
-        cards_data = [
-            card_file.read_bytes() for card_file in final_cards_dir.iterdir()
-        ]
+        cards_data = [card_file.read_bytes() for card_file in final_cards_dir.iterdir()]
     else:
         print("No existing final card outputs for prompts. Proceeding...")
         # Produce the Pokémon character samples with the StableDiffusion model.

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -289,9 +289,7 @@ def create_pokemon_cards(prompt: str) -> list[dict]:
                 (i, sample, norm_prompt) for (i, sample) in enumerate(samples_data)
             )
         )
-        print(
-            f"Persisting {len(cards_data)} results for later disk-cache retrieval."
-        )
+        print(f"Persisting {len(cards_data)} results for later disk-cache retrieval.")
         final_cards_dir.mkdir()
         for i, c_data in enumerate(cards_data):
             c_path = final_cards_dir / f"{i}.png"

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/main.py
@@ -288,8 +288,7 @@ def create_pokemon_cards(prompt: str) -> list[dict]:
         print(f"Compositing {len(samples_data)} samples onto cards...")
         cards_data = list(
             create_composite_card.starmap(
-                (i, sample, norm_prompt)
-                for (i, sample) in enumerate(samples_data)
+                (i, sample, norm_prompt) for (i, sample) in enumerate(samples_data)
             )
         )
         print(

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
@@ -141,9 +141,7 @@ def main() -> int:
     sub_parsers.add_parser(
         "extract-colors", help="Extract colors for all Pokémon base cards."
     )
-    sub_parsers.add_parser(
-        "gen-pokemon-names", help="Generate new Pokémon names."
-    )
+    sub_parsers.add_parser("gen-pokemon-names", help="Generate new Pokémon names.")
     parser_reset_diskcache = sub_parsers.add_parser(
         "reset-diskcache",
         help="Delete all cached Pokémon card parts from volume.",

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
@@ -36,9 +36,7 @@ def reset_diskcache(dry_run=True) -> None:
             if not dry_run:
                 filepath.unlink()
         if files and dry_run:
-            print(
-                f"🏜 dry-run: would have deleted {i + 1} Pokémon character samples"
-            )
+            print(f"🏜 dry-run: would have deleted {i + 1} Pokémon character samples")
         elif files:
             print(f"deleted {i + 1} Pokémon character samples")
         else:

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/ops.py
@@ -129,9 +129,7 @@ def generate_pokemon_names():
         max_sequence_len=max_sequence_len,
     )
 
-    print(
-        f"Storing {desired_generations} generated names. eg. '{new_names[0]}'"
-    )
+    print(f"Storing {desired_generations} generated names. eg. '{new_names[0]}'")
     output_path = rnn_names_output_path
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text("\n".join(new_names))

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
@@ -132,9 +132,7 @@ def generate_names(
     return list(new_names)
 
 
-def prep_dataset(
-    training_names: list[str], max_sequence_len: int
-) -> TrainingDataset:
+def prep_dataset(training_names: list[str], max_sequence_len: int) -> TrainingDataset:
     import numpy as np
 
     step_length = 1  # The step length we take to get our samples from our corpus

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
@@ -137,9 +137,7 @@ def prep_dataset(
 ) -> TrainingDataset:
     import numpy as np
 
-    step_length = (
-        1  # The step length we take to get our samples from our corpus
-    )
+    step_length = 1  # The step length we take to get our samples from our corpus
     # Make it all to a long string
     concat_names = "\n".join(training_names).lower()
 
@@ -214,9 +212,7 @@ def train_rnn(
     )
     model = Sequential()
     model.add(
-        LSTM(
-            latent_dim, input_shape=input_shape, recurrent_dropout=dropout_rate
-        )
+        LSTM(latent_dim, input_shape=input_shape, recurrent_dropout=dropout_rate)
     )
     model.add(Dense(units=dataset.num_unique_chars, activation="softmax"))
 

--- a/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
+++ b/06_gpu_and_ml/text-to-pokemon/text_to_pokemon/pokemon_naming.py
@@ -209,9 +209,7 @@ def train_rnn(
         dataset.num_unique_chars,
     )
     model = Sequential()
-    model.add(
-        LSTM(latent_dim, input_shape=input_shape, recurrent_dropout=dropout_rate)
-    )
+    model.add(LSTM(latent_dim, input_shape=input_shape, recurrent_dropout=dropout_rate))
     model.add(Dense(units=dataset.num_unique_chars, activation="softmax"))
 
     optimizer = RMSprop(learning_rate=0.01)

--- a/06_gpu_and_ml/torch_profiling.py
+++ b/06_gpu_and_ml/torch_profiling.py
@@ -140,9 +140,7 @@ def profile(
 
     if schedule is None:
         if steps < 3:
-            raise ValueError(
-                "Steps must be at least 3 when using default schedule"
-            )
+            raise ValueError("Steps must be at least 3 when using default schedule")
         schedule = {"wait": 1, "warmup": 1, "active": steps - 2, "repeat": 0}
 
     schedule = torch.profiler.schedule(**schedule)

--- a/06_gpu_and_ml/torch_profiling.py
+++ b/06_gpu_and_ml/torch_profiling.py
@@ -162,9 +162,7 @@ def profile(
 
     if print_rows:
         print(
-            prof.key_averages().table(
-                sort_by="cuda_time_total", row_limit=print_rows
-            )
+            prof.key_averages().table(sort_by="cuda_time_total", row_limit=print_rows)
         )
 
     trace_path = sorted(

--- a/06_gpu_and_ml/torch_profiling.py
+++ b/06_gpu_and_ml/torch_profiling.py
@@ -134,9 +134,7 @@ def profile(
     function_name = function.tag
 
     output_dir = (
-        TRACE_DIR
-        / (function_name + (f"_{label}" if label else ""))
-        / str(uuid4())
+        TRACE_DIR / (function_name + (f"_{label}" if label else "")) / str(uuid4())
     )
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -311,9 +311,7 @@ def main(quick_check: bool = True, inference_only: bool = False):
     # let's run inference!
     for model_id, dataset in zip(model_ids, datasets):
         inference = Inference(
-            weights_path=str(
-                volume_path / "runs" / model_id / "weights" / "best.pt"
-            )
+            weights_path=str(volume_path / "runs" / model_id / "weights" / "best.pt")
         )
 
         # predict on a single image and save output to the volume

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -227,9 +227,7 @@ class Inference:
         import os
         import time
 
-        image_files = [
-            os.path.join(batch_dir, f) for f in os.listdir(batch_dir)
-        ]
+        image_files = [os.path.join(batch_dir, f) for f in os.listdir(batch_dir)]
 
         completed, start = 0, time.monotonic_ns()
         for image in read_image.map(image_files):

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -334,9 +334,7 @@ def main(quick_check: bool = True, inference_only: bool = False):
                 break
 
         # streaming inference on images from the test set
-        print(
-            f"{model_id}: Streaming inferences on all images in the test set..."
-        )
+        print(f"{model_id}: Streaming inferences on all images in the test set...")
         count = 0
         for detection in inference.streaming_count.remote_gen(
             batch_dir=f"{volume_path}/dataset/{dataset.id}/test/images"

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -148,9 +148,7 @@ def train(
         else 0.04,  # fraction of dataset to use for training/validation
         # optimization config
         device=list(range(TRAIN_GPU_COUNT)),  # use the GPU(s)
-        epochs=8
-        if not quick_check
-        else 1,  # pass over entire dataset this many times
+        epochs=8 if not quick_check else 1,  # pass over entire dataset this many times
         batch=0.95,  # automatic batch size to target fraction of GPU util
         seed=117,  # set seed for reproducibility
         # data processing config

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -90,9 +90,7 @@ class DatasetConfig:
 
 @app.function(
     secrets=[
-        modal.Secret.from_name(
-            "roboflow-api-key", required_keys=["ROBOFLOW_API_KEY"]
-        )
+        modal.Secret.from_name("roboflow-api-key", required_keys=["ROBOFLOW_API_KEY"])
     ]
 )
 def download_dataset(config: DatasetConfig):

--- a/07_web_endpoints/count_faces.py
+++ b/07_web_endpoints/count_faces.py
@@ -38,9 +38,7 @@ def count_faces(image_bytes: bytes) -> int:
     # Example borrowed from https://towardsdatascience.com/face-detection-in-2-minutes-using-opencv-python-90f89d7c0f81
     # Load the cascade
     face_cascade = cv2.CascadeClassifier(
-        os.path.join(
-            cv2.data.haarcascades, "haarcascade_frontalface_default.xml"
-        )
+        os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml")
     )
     # Read the input image
     np_bytes = np.frombuffer(image_bytes, dtype=np.uint8)

--- a/07_web_endpoints/discord_bot.py
+++ b/07_web_endpoints/discord_bot.py
@@ -70,7 +70,9 @@ async def fetch_api() -> str:
             async with session.get(url) as response:
                 response.raise_for_status()
                 data = await response.json()
-                message = f"# {data.get('emoji') or '🤖'} [{data['title']}]({data['source']})"
+                message = (
+                    f"# {data.get('emoji') or '🤖'} [{data['title']}]({data['source']})"
+                )
                 message += f"\n _{''.join(data['description'].splitlines())}_"
         except Exception as e:
             message = f"# 🤖: Oops! {e}"

--- a/07_web_endpoints/discord_bot.py
+++ b/07_web_endpoints/discord_bot.py
@@ -211,8 +211,7 @@ def create_slash_command(force: bool = False):
 
     commands = response.json()
     command_exists = any(
-        command.get("name") == command_description["name"]
-        for command in commands
+        command.get("name") == command_description["name"] for command in commands
     )
 
     # and only recreate it if the force flag is set

--- a/07_web_endpoints/fastapi_app.py
+++ b/07_web_endpoints/fastapi_app.py
@@ -30,9 +30,7 @@ async def handle_root(user_agent: Optional[str] = Header(None)):
 
 @web_app.post("/foo")
 async def handle_foo(item: Item, user_agent: Optional[str] = Header(None)):
-    print(
-        f"POST /foo - received user_agent={user_agent}, item.name={item.name}"
-    )
+    print(f"POST /foo - received user_agent={user_agent}, item.name={item.name}")
     return item
 
 

--- a/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
+++ b/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
@@ -25,9 +25,7 @@ image = (
         remote_path="/root/constants.py",
     )
 )
-volume = modal.Volume.from_name(
-    "loadtest-checkboxes-results", create_if_missing=True
-)
+volume = modal.Volume.from_name("loadtest-checkboxes-results", create_if_missing=True)
 remote_path = Path("/root") / "loadtests"
 OUT_DIRECTORY = remote_path / datetime.utcnow().replace(microsecond=0).isoformat()
 

--- a/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
+++ b/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
@@ -29,9 +29,7 @@ volume = modal.Volume.from_name(
     "loadtest-checkboxes-results", create_if_missing=True
 )
 remote_path = Path("/root") / "loadtests"
-OUT_DIRECTORY = (
-    remote_path / datetime.utcnow().replace(microsecond=0).isoformat()
-)
+OUT_DIRECTORY = remote_path / datetime.utcnow().replace(microsecond=0).isoformat()
 
 app = modal.App("loadtest-checkbox", image=image, volumes={remote_path: volume})
 

--- a/07_web_endpoints/streaming.py
+++ b/07_web_endpoints/streaming.py
@@ -38,9 +38,7 @@ async def fake_video_streamer():
 
 @web_app.get("/")
 async def main():
-    return StreamingResponse(
-        fake_video_streamer(), media_type="text/event-stream"
-    )
+    return StreamingResponse(fake_video_streamer(), media_type="text/event-stream")
 
 
 @app.function()
@@ -81,9 +79,7 @@ def map_me(i):
 @app.function()
 @modal.fastapi_endpoint()
 def mapped():
-    return StreamingResponse(
-        map_me.map(range(10)), media_type="text/event-stream"
-    )
+    return StreamingResponse(map_me.map(range(10)), media_type="text/event-stream")
 
 
 # To try for yourself, run

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -60,9 +60,7 @@ def setup():
 
     from transformers import AutoModel, AutoTokenizer
 
-    with (
-        warnings.catch_warnings()
-    ):  # filter noisy warnings from GOT modeling code
+    with warnings.catch_warnings():  # filter noisy warnings from GOT modeling code
         warnings.simplefilter("ignore")
         tokenizer = AutoTokenizer.from_pretrained(
             MODEL_NAME, revision=MODEL_REVISION, trust_remote_code=True

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -181,7 +181,9 @@ def main(receipt_filename: str = None):
         image = receipt_filename.read_bytes()
         print(f"running OCR on {receipt_filename}")
     else:
-        receipt_url = "https://nwlc.org/wp-content/uploads/2022/01/Brandys-walmart-receipt-8.webp"
+        receipt_url = (
+            "https://nwlc.org/wp-content/uploads/2022/01/Brandys-walmart-receipt-8.webp"
+        )
         image = requests.get(receipt_url).content
         print(f"running OCR on sample from URL {receipt_url}")
     print(parse_receipt.remote(image))

--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -49,9 +49,7 @@ web_app = fastapi.FastAPI()
 
 @web_app.post("/parse")
 async def parse(request: fastapi.Request):
-    parse_receipt = modal.Function.from_name(
-        "example-doc-ocr-jobs", "parse_receipt"
-    )
+    parse_receipt = modal.Function.from_name("example-doc-ocr-jobs", "parse_receipt")
 
     form = await request.form()
     receipt = await form["receipt"].read()  # type: ignore

--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -95,9 +95,7 @@ image = image.add_local_dir(local_assets_path, remote_path="/assets")
 @app.function(image=image)
 @modal.asgi_app()
 def wrapper():
-    web_app.mount(
-        "/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True)
-    )
+    web_app.mount("/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True))
     return web_app
 
 

--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -318,9 +318,7 @@ def ui():
     iface = gr.Interface(
         go,
         inputs=[  # the inputs to go/our inference function
-            gr.Dropdown(
-                choices=lora_ids, value=default_lora_id, label="👉 LoRA ID"
-            ),
+            gr.Dropdown(choices=lora_ids, value=default_lora_id, label="👉 LoRA ID"),
             gr.Textbox(default_prompt, label="🎨 Prompt"),
             gr.Number(value=8888, label="🎲 Random Seed"),
         ],

--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -289,8 +289,7 @@ def ui():
 
     # determine which loras are available
     lora_ids = [
-        f"{lora_dir.parent.stem}/{lora_dir.stem}"
-        for lora_dir in LORAS_PATH.glob("*/*")
+        f"{lora_dir.parent.stem}/{lora_dir.stem}" for lora_dir in LORAS_PATH.glob("*/*")
     ]
 
     # pick one to be default, set a default prompt

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -136,9 +136,7 @@ def load_report(filepath):
                 or row.get("Province_State")
                 or None
             )
-            country_or_region = row.get("Country_Region") or row.get(
-                "Country/Region"
-            )
+            country_or_region = row.get("Country_Region") or row.get("Country/Region")
             yield {
                 "day": f"{yyyy}-{mm}-{dd}",
                 "country_or_region": (

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -112,9 +112,7 @@ def download_dataset(cache=True):
 def load_daily_reports():
     daily_reports = list(REPORTS_DIR.glob("*.csv"))
     if not daily_reports:
-        raise RuntimeError(
-            f"Could not find any daily reports in {REPORTS_DIR}."
-        )
+        raise RuntimeError(f"Could not find any daily reports in {REPORTS_DIR}.")
 
     # Preload report files to speed up sequential loading
     pool = multiprocessing.Pool(128)

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -89,9 +89,7 @@ def download_dataset(cache=True):
     print("Unpacking archive...")
     prefix = "COVID-19-master/csse_covid_19_data/csse_covid_19_daily_reports"
     with tempfile.TemporaryDirectory() as tmpdir:
-        subprocess.run(
-            f"unzip /tmp/covid-19.zip {prefix}/* -d {tmpdir}", shell=True
-        )
+        subprocess.run(f"unzip /tmp/covid-19.zip {prefix}/* -d {tmpdir}", shell=True)
         REPORTS_DIR.mkdir(parents=True)
         tmpdir_path = pathlib.Path(tmpdir)
         subprocess.run(f"mv {tmpdir_path / prefix}/* {REPORTS_DIR}", shell=True)

--- a/10_integrations/covid_datasette.py
+++ b/10_integrations/covid_datasette.py
@@ -149,9 +149,7 @@ def load_report(filepath):
                 "deaths": int(float(row["Deaths"] or 0)),
                 "recovered": int(float(row["Recovered"] or 0)),
                 "active": int(row["Active"]) if row.get("Active") else None,
-                "last_update": row.get("Last Update")
-                or row.get("Last_Update")
-                or None,
+                "last_update": row.get("Last Update") or row.get("Last_Update") or None,
             }
 
 

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference.py
@@ -104,9 +104,7 @@ def dbt_run() -> None:
         "example-trtllm-Meta-Llama-3-8B-Instruct", "generate_web"
     ).hydrate()
 
-    res = dbtRunner().invoke(
-        ["run", "--vars", f"{{'inference_url': '{ref.web_url}'}}"]
-    )
+    res = dbtRunner().invoke(["run", "--vars", f"{{'inference_url': '{ref.web_url}'}}"])
     if res.exception:
         print(res.exception)
 

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
@@ -56,11 +56,9 @@ def batcher(batch_reader: pa.RecordBatchReader, inference_url: str):
             .tolist()
         )
 
-        res = (
-            requests.post(  # request to the inference service running on Modal
-                inference_url,
-                json={"prompts": prompts},
-            )
+        res = requests.post(  # request to the inference service running on Modal
+            inference_url,
+            json={"prompts": prompts},
         )
 
         df["review_sentiment"] = json.loads(res.content)

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
@@ -50,9 +50,7 @@ def batcher(batch_reader: pa.RecordBatchReader, inference_url: str):
     for batch in batch_reader:
         df = batch.to_pandas()
 
-        prompts = (
-            df["product_review"].apply(lambda review: get_prompt(review)).tolist()
-        )
+        prompts = df["product_review"].apply(lambda review: get_prompt(review)).tolist()
 
         res = requests.post(  # request to the inference service running on Modal
             inference_url,

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
@@ -51,9 +51,7 @@ def batcher(batch_reader: pa.RecordBatchReader, inference_url: str):
         df = batch.to_pandas()
 
         prompts = (
-            df["product_review"]
-            .apply(lambda review: get_prompt(review))
-            .tolist()
+            df["product_review"].apply(lambda review: get_prompt(review)).tolist()
         )
 
         res = requests.post(  # request to the inference service running on Modal

--- a/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
+++ b/10_integrations/dbt_modal_inference/dbt_modal_inference_proj/models/product_reviews_sentiment.py
@@ -84,7 +84,5 @@ def model(dbt, session):
     big_model = dbt.ref("product_reviews")
     batch_reader = big_model.record_batch(100)
     batch_iter = batcher(batch_reader, inference_url)
-    new_schema = batch_reader.schema.append(
-        pa.field("review_sentiment", pa.string())
-    )
+    new_schema = batch_reader.schema.append(pa.field("review_sentiment", pa.string()))
     return pa.RecordBatchReader.from_batches(new_schema, batch_iter)

--- a/10_integrations/multion_news_agent.py
+++ b/10_integrations/multion_news_agent.py
@@ -41,9 +41,7 @@ multion_image = modal.Image.debian_slim().pip_install("multion")
 # and store it as a Modal sEcret on [the dashboard](https://modal.com/secrets)
 
 
-@app.function(
-    image=multion_image, secrets=[modal.Secret.from_name("MULTION_API_KEY")]
-)
+@app.function(image=multion_image, secrets=[modal.Secret.from_name("MULTION_API_KEY")])
 def news_tweet_agent():
     # Import MultiOn
     import multion

--- a/10_integrations/s3_bucket_mount.py
+++ b/10_integrations/s3_bucket_mount.py
@@ -184,9 +184,7 @@ def plot(dataset) -> bytes:
 @app.local_entrypoint()
 def main():
     # List of tuples[year, month].
-    inputs = [
-        (year, month) for year in range(2018, 2023) for month in range(1, 13)
-    ]
+    inputs = [(year, month) for year in range(2018, 2023) for month in range(1, 13)]
 
     # List of file paths in S3.
     parquet_files: list[str] = []

--- a/10_integrations/s3_bucket_mount.py
+++ b/10_integrations/s3_bucket_mount.py
@@ -63,9 +63,7 @@ with image.imports():
 
 @app.function(
     volumes={
-        MOUNT_PATH: modal.CloudBucketMount(
-            "modal-s3mount-test-bucket", secret=secret
-        ),
+        MOUNT_PATH: modal.CloudBucketMount("modal-s3mount-test-bucket", secret=secret),
     },
 )
 def download_data(year: int, month: int) -> str:

--- a/10_integrations/streamlit/app.py
+++ b/10_integrations/streamlit/app.py
@@ -42,9 +42,7 @@ def main():
         st.write(data)
 
     st.subheader("Number of pickups by hour")
-    hist_values = np.histogram(data[DATE_COLUMN].dt.hour, bins=24, range=(0, 24))[
-        0
-    ]
+    hist_values = np.histogram(data[DATE_COLUMN].dt.hour, bins=24, range=(0, 24))[0]
     st.bar_chart(hist_values)
 
     # Some number in the range 0-23

--- a/10_integrations/streamlit/app.py
+++ b/10_integrations/streamlit/app.py
@@ -42,9 +42,9 @@ def main():
         st.write(data)
 
     st.subheader("Number of pickups by hour")
-    hist_values = np.histogram(
-        data[DATE_COLUMN].dt.hour, bins=24, range=(0, 24)
-    )[0]
+    hist_values = np.histogram(data[DATE_COLUMN].dt.hour, bins=24, range=(0, 24))[
+        0
+    ]
     st.bar_chart(hist_values)
 
     # Some number in the range 0-23

--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -42,9 +42,7 @@ with image.imports():
 # Run your function adding a Tailscale secret. We suggest creating a [reusable and ephemeral key](https://tailscale.com/kb/1111/ephemeral-nodes).
 @app.function(
     secrets=[
-        modal.Secret.from_name(
-            "tailscale-auth", required_keys=["TAILSCALE_AUTHKEY"]
-        ),
+        modal.Secret.from_name("tailscale-auth", required_keys=["TAILSCALE_AUTHKEY"]),
         modal.Secret.from_dict(
             {
                 "ALL_PROXY": "socks5://localhost:1080/",

--- a/12_datasets/coco.py
+++ b/12_datasets/coco.py
@@ -50,9 +50,7 @@ def start_monitoring_disk_space(interval: int = 120) -> None:
             )
             time.sleep(interval)
 
-    monitoring_thread = threading.Thread(
-        target=log_disk_space, args=(interval,)
-    )
+    monitoring_thread = threading.Thread(target=log_disk_space, args=(interval,))
     monitoring_thread.daemon = True
     monitoring_thread.start()
 
@@ -100,9 +98,7 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
             self.pool.join()
 
     with MultithreadedCopier(max_threads=48) as copier:
-        shutil.copytree(
-            src, dest, copy_function=copier.copy, dirs_exist_ok=True
-        )
+        shutil.copytree(src, dest, copy_function=copier.copy, dirs_exist_ok=True)
 
 
 # This script uses wget to download ZIP files over HTTP because while the official

--- a/12_datasets/coco.py
+++ b/12_datasets/coco.py
@@ -129,9 +129,7 @@ def _do_part(url: str) -> None:
     )  # extract into /tmp/
     zip_path.unlink()  # free up disk space by deleting the zip
     print(f"Copying extract {name} data to volume.")
-    copy_concurrent(
-        extract_tmp_path, dest_path
-    )  # copy from /tmp/ into mounted volume
+    copy_concurrent(extract_tmp_path, dest_path)  # copy from /tmp/ into mounted volume
 
 
 # We can process each part of the dataset in parallel, using a 'parent' Function just to execute

--- a/12_datasets/imagenet.py
+++ b/12_datasets/imagenet.py
@@ -31,9 +31,7 @@ volume = modal.CloudBucketMount(
     bucket_name,
     secret=bucket_creds,
 )
-image = (
-    modal.Image.debian_slim().apt_install("tree").pip_install("kaggle", "tqdm")
-)
+image = modal.Image.debian_slim().apt_install("tree").pip_install("kaggle", "tqdm")
 app = modal.App(
     "example-imagenet-dataset-import",
     image=image,

--- a/12_datasets/imagenet.py
+++ b/12_datasets/imagenet.py
@@ -55,9 +55,7 @@ def start_monitoring_disk_space(interval: int = 30) -> None:
             )
             time.sleep(interval)
 
-    monitoring_thread = threading.Thread(
-        target=log_disk_space, args=(interval,)
-    )
+    monitoring_thread = threading.Thread(target=log_disk_space, args=(interval,))
     monitoring_thread.daemon = True
     monitoring_thread.start()
 
@@ -94,9 +92,7 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
             self.pool.join()
 
     with MultithreadedCopier(max_threads=24) as copier:
-        shutil.copytree(
-            src, dest, copy_function=copier.copy, dirs_exist_ok=True
-        )
+        shutil.copytree(src, dest, copy_function=copier.copy, dirs_exist_ok=True)
 
 
 def extractall(fzip, dest, desc="Extracting"):
@@ -162,9 +158,7 @@ def import_transform_load() -> None:
     print(f"Extracting .zip into {extracted_dataset_path}...")
     extractall(dataset_path, extracted_dataset_path)
     print(f"Extracted {dataset_path} to {extracted_dataset_path}")
-    subprocess.run(
-        f"tree -L 3 {extracted_dataset_path}", shell=True, check=True
-    )
+    subprocess.run(f"tree -L 3 {extracted_dataset_path}", shell=True, check=True)
 
     final_dataset_path = vol_path / "extracted"
     final_dataset_path.mkdir(exist_ok=True)

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -41,9 +41,7 @@ volume = modal.CloudBucketMount(
     secret=bucket_creds,
 )
 
-image = (
-    modal.Image.debian_slim().apt_install("wget").pip_install("img2dataset~=1.45.0")
-)
+image = modal.Image.debian_slim().apt_install("wget").pip_install("img2dataset~=1.45.0")
 
 app = modal.App("example-laion400-dataset-import", image=image)
 

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -64,9 +64,7 @@ def start_monitoring_disk_space(interval: int = 30) -> None:
             )
             time.sleep(interval)
 
-    monitoring_thread = threading.Thread(
-        target=log_disk_space, args=(interval,)
-    )
+    monitoring_thread = threading.Thread(target=log_disk_space, args=(interval,))
     monitoring_thread.daemon = True
     monitoring_thread.start()
 
@@ -103,9 +101,7 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
             self.pool.join()
 
     with MultithreadedCopier(max_threads=24) as copier:
-        shutil.copytree(
-            src, dest, copy_function=copier.copy, dirs_exist_ok=True
-        )
+        shutil.copytree(src, dest, copy_function=copier.copy, dirs_exist_ok=True)
 
 
 @app.function(

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -42,9 +42,7 @@ volume = modal.CloudBucketMount(
 )
 
 image = (
-    modal.Image.debian_slim()
-    .apt_install("wget")
-    .pip_install("img2dataset~=1.45.0")
+    modal.Image.debian_slim().apt_install("wget").pip_install("img2dataset~=1.45.0")
 )
 
 app = modal.App("example-laion400-dataset-import", image=image)
@@ -170,7 +168,5 @@ def import_transform_load() -> None:
     print(f"Stored {len(parquet_files)} parquet files into {laion400m_meta_path}.")
     print(f"Spawning {len(parquet_files)} to enrich dataset...")
     list(
-        run_img2dataset_on_part.starmap(
-            (i, f) for i, f in enumerate(parquet_files)
-        )
+        run_img2dataset_on_part.starmap((i, f) for i, f in enumerate(parquet_files))
     )

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -167,9 +167,7 @@ def import_transform_load() -> None:
         copy_concurrent(tmp_laion400m_meta_path, laion400m_meta_path)
 
     parquet_files = list(laion400m_meta_path.glob("**/*.parquet"))
-    print(
-        f"Stored {len(parquet_files)} parquet files into {laion400m_meta_path}."
-    )
+    print(f"Stored {len(parquet_files)} parquet files into {laion400m_meta_path}.")
     print(f"Spawning {len(parquet_files)} to enrich dataset...")
     list(
         run_img2dataset_on_part.starmap(

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -167,6 +167,4 @@ def import_transform_load() -> None:
     parquet_files = list(laion400m_meta_path.glob("**/*.parquet"))
     print(f"Stored {len(parquet_files)} parquet files into {laion400m_meta_path}.")
     print(f"Spawning {len(parquet_files)} to enrich dataset...")
-    list(
-        run_img2dataset_on_part.starmap((i, f) for i, f in enumerate(parquet_files))
-    )
+    list(run_img2dataset_on_part.starmap((i, f) for i, f in enumerate(parquet_files)))

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -109,9 +109,7 @@ def _do_part(url: str) -> None:
     p = subprocess.Popen(cmd, shell=True)
     returncode = p.wait()
     if returncode != 0:
-        raise RuntimeError(
-            f"Error in downloading. {p.args!r} failed {returncode=}"
-        )
+        raise RuntimeError(f"Error in downloading. {p.args!r} failed {returncode=}")
     decompressed = pathlib.Path("/tmp/rosettafold/", name)
 
     # Decompression is much faster against the container's local SSD disk

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -49,9 +49,7 @@ def start_monitoring_disk_space(interval: int = 30) -> None:
             )
             time.sleep(interval)
 
-    monitoring_thread = threading.Thread(
-        target=log_disk_space, args=(interval,)
-    )
+    monitoring_thread = threading.Thread(target=log_disk_space, args=(interval,))
     monitoring_thread.daemon = True
     monitoring_thread.start()
 
@@ -97,9 +95,7 @@ def copy_concurrent(src: pathlib.Path, dest: pathlib.Path) -> None:
             self.pool.join()
 
     with MultithreadedCopier(max_threads=24) as copier:
-        shutil.copytree(
-            src, dest, copy_function=copier.copy, dirs_exist_ok=True
-        )
+        shutil.copytree(src, dest, copy_function=copier.copy, dirs_exist_ok=True)
 
 
 @app.function(

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -54,9 +54,7 @@ def start_monitoring_disk_space(interval: int = 30) -> None:
     monitoring_thread.start()
 
 
-def decompress_tar_gz(
-    file_path: pathlib.Path, extract_dir: pathlib.Path
-) -> None:
+def decompress_tar_gz(file_path: pathlib.Path, extract_dir: pathlib.Path) -> None:
     print(f"Decompressing {file_path} into {extract_dir}...")
     with tarfile.open(file_path, "r:gz") as tar:
         tar.extractall(path=extract_dir)

--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -48,9 +48,7 @@ app = modal.App(
 def create_sandbox(app) -> modal.Sandbox:
     # Change this image (and the retrieval logic in the retrieval module)
     # if you want the agent to give coding advice on other libraries!
-    agent_image = modal.Image.debian_slim(
-        python_version=PYTHON_VERSION
-    ).pip_install(
+    agent_image = modal.Image.debian_slim(python_version=PYTHON_VERSION).pip_install(
         "torch==2.5.0",
         "transformers==4.46.0",
     )

--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -32,9 +32,7 @@ app = modal.App(
     image=image,
     secrets=[
         modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"]),
-        modal.Secret.from_name(
-            "langsmith-secret", required_keys=["LANGCHAIN_API_KEY"]
-        ),
+        modal.Secret.from_name("langsmith-secret", required_keys=["LANGCHAIN_API_KEY"]),
     ],
 )
 

--- a/13_sandboxes/codelangchain/agent.py
+++ b/13_sandboxes/codelangchain/agent.py
@@ -31,9 +31,7 @@ app = modal.App(
     "example-code-langchain",
     image=image,
     secrets=[
-        modal.Secret.from_name(
-            "openai-secret", required_keys=["OPENAI_API_KEY"]
-        ),
+        modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"]),
         modal.Secret.from_name(
             "langsmith-secret", required_keys=["LANGCHAIN_API_KEY"]
         ),

--- a/13_sandboxes/codelangchain/langserve.py
+++ b/13_sandboxes/codelangchain/langserve.py
@@ -29,9 +29,7 @@ image = image.pip_install("langserve[all]==0.3.0")
     image=image,
     secrets=[  # see the agent.py file for more information on Secrets
         modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"]),
-        modal.Secret.from_name(
-            "langsmith-secret", required_keys=["LANGCHAIN_API_KEY"]
-        ),
+        modal.Secret.from_name("langsmith-secret", required_keys=["LANGCHAIN_API_KEY"]),
     ],
 )
 @modal.asgi_app()

--- a/13_sandboxes/codelangchain/langserve.py
+++ b/13_sandboxes/codelangchain/langserve.py
@@ -28,9 +28,7 @@ image = image.pip_install("langserve[all]==0.3.0")
 @app.function(
     image=image,
     secrets=[  # see the agent.py file for more information on Secrets
-        modal.Secret.from_name(
-            "openai-secret", required_keys=["OPENAI_API_KEY"]
-        ),
+        modal.Secret.from_name("openai-secret", required_keys=["OPENAI_API_KEY"]),
         modal.Secret.from_name(
             "langsmith-secret", required_keys=["LANGCHAIN_API_KEY"]
         ),

--- a/13_sandboxes/codelangchain/src/nodes.py
+++ b/13_sandboxes/codelangchain/src/nodes.py
@@ -315,9 +315,7 @@ Here is the user question:
         class ExecutionEvaluation(BaseModel):
             """Evaluation of code execution"""
 
-            decision: Decision = Field(
-                description="Decision to finish or retry"
-            )
+            decision: Decision = Field(description="Decision to finish or retry")
             explanation: str = Field(description="Explanation for the decision")
 
         llm = ChatOpenAI(temperature=0, model=self.model)

--- a/13_sandboxes/codelangchain/src/nodes.py
+++ b/13_sandboxes/codelangchain/src/nodes.py
@@ -352,9 +352,7 @@ Provide a brief explanation for your decision.
 
         chain = prompt | llm_with_tool | parser_tool
 
-        evaluation = chain.invoke(
-            {"code": code, "output": output, "error": error}
-        )
+        evaluation = chain.invoke({"code": code, "output": output, "error": error})
 
         return {
             "keys": {

--- a/13_sandboxes/codelangchain/src/nodes.py
+++ b/13_sandboxes/codelangchain/src/nodes.py
@@ -62,9 +62,7 @@ class Nodes:
 
             prefix: str = Field(description="Description of the problem and approach")
             imports: str = Field(description="Code block import statements")
-            code: str = Field(
-                description="Code block not including import statements"
-            )
+            code: str = Field(description="Code block not including import statements")
 
         ## LLM
         llm = ChatOpenAI(temperature=0, model=self.model, streaming=True)

--- a/13_sandboxes/codelangchain/src/nodes.py
+++ b/13_sandboxes/codelangchain/src/nodes.py
@@ -25,9 +25,7 @@ class Nodes:
     ):
         self.context = context
         self.debug = debug
-        self.model = (
-            "gpt-4o-2024-08-06" if not self.debug else "gpt-4o-mini-2024-07-18"
-        )
+        self.model = "gpt-4o-2024-08-06" if not self.debug else "gpt-4o-mini-2024-07-18"
         self.node_map = {
             "generate": self.generate,
             "check_code_imports": self.check_code_imports,

--- a/13_sandboxes/codelangchain/src/nodes.py
+++ b/13_sandboxes/codelangchain/src/nodes.py
@@ -60,9 +60,7 @@ class Nodes:
         class Code(BaseModel):
             """Code output"""
 
-            prefix: str = Field(
-                description="Description of the problem and approach"
-            )
+            prefix: str = Field(description="Description of the problem and approach")
             imports: str = Field(description="Code block import statements")
             code: str = Field(
                 description="Code block not including import statements"
@@ -267,8 +265,7 @@ Here is the user question:
             if "error" in state_dict:
                 error_prev_runs = state_dict["error"]
                 error = (
-                    error_prev_runs
-                    + "\n --- Most recent run output and error --- \n"
+                    error_prev_runs + "\n --- Most recent run output and error --- \n"
                     " ------ output ------ \n"
                     + output
                     + "\n ------ error ------ \n"

--- a/13_sandboxes/codelangchain/src/retrieval.py
+++ b/13_sandboxes/codelangchain/src/retrieval.py
@@ -11,9 +11,7 @@ def retrieve_docs(url: str = docs_url, debug=False):
         RecursiveUrlLoader,
     )
 
-    print(
-        f"{COLOR['HEADER']}📜: Retrieving documents from {url}{COLOR['ENDC']}"
-    )
+    print(f"{COLOR['HEADER']}📜: Retrieving documents from {url}{COLOR['ENDC']}")
     loader = RecursiveUrlLoader(
         url=docs_url,
         max_depth=2 // (int(debug) + 1),  # retrieve fewer docs in debug mode

--- a/13_sandboxes/jupyter_sandbox.py
+++ b/13_sandboxes/jupyter_sandbox.py
@@ -87,9 +87,7 @@ print(f"🏖️  Jupyter notebook is running at: {url}")
 
 def is_jupyter_up():
     try:
-        response = urllib.request.urlopen(
-            f"{tunnel.url}/api/status?token={token}"
-        )
+        response = urllib.request.urlopen(f"{tunnel.url}/api/status?token={token}")
         if response.getcode() == 200:
             data = json.loads(response.read().decode())
             return data.get("started", False)

--- a/14_clusters/simple_torch_cluster_script.py
+++ b/14_clusters/simple_torch_cluster_script.py
@@ -58,9 +58,7 @@ def run(backend):
         tensor = tensor.to(device)
 
     if WORLD_RANK == MASTER_RANK:
-        print(
-            f"{container_name(WORLD_RANK)} sending data to all other containers...\n"
-        )
+        print(f"{container_name(WORLD_RANK)} sending data to all other containers...\n")
         for rank_recv in range(1, WORLD_SIZE):
             dist.send(tensor=tensor, dst=rank_recv)
             print(
@@ -105,9 +103,7 @@ if __name__ == "__main__":
         type=int,
         help="Local rank. Necessary for using the torch.distributed.launch utility.",
     )
-    parser.add_argument(
-        "--backend", type=str, default="gloo", choices=["nccl", "gloo"]
-    )
+    parser.add_argument("--backend", type=str, default="gloo", choices=["nccl", "gloo"])
     args = parser.parse_args()
 
     with init_processes(backend=args.backend):

--- a/internal/deploy.py
+++ b/internal/deploy.py
@@ -77,9 +77,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             "INFO: dry-run is active. Intended deployments will be displayed to console."
         )
 
-    example_modules = (
-        ex for ex in get_examples() if ex.type == ExampleType.MODULE
-    )
+    example_modules = (ex for ex in get_examples() if ex.type == ExampleType.MODULE)
     filter_pttrn = (r".*" + arguments.filter + r".*") if arguments.filter else None
     results = [
         deploy(

--- a/internal/deploy.py
+++ b/internal/deploy.py
@@ -47,9 +47,7 @@ def deploy(
                 file=sys.stderr,
             )
             print(r.stderr)
-            return DeployError(
-                stdout=r.stdout, stderr=r.stderr, code=r.returncode
-            )
+            return DeployError(stdout=r.stdout, stderr=r.stderr, code=r.returncode)
         else:
             print(f"✔️ deployed '{module_with_app.name}")
     return None
@@ -82,9 +80,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     example_modules = (
         ex for ex in get_examples() if ex.type == ExampleType.MODULE
     )
-    filter_pttrn = (
-        (r".*" + arguments.filter + r".*") if arguments.filter else None
-    )
+    filter_pttrn = (r".*" + arguments.filter + r".*") if arguments.filter else None
     results = [
         deploy(
             deployable=bool(ex_mod.metadata.get("deploy")),

--- a/internal/typecheck.py
+++ b/internal/typecheck.py
@@ -46,9 +46,7 @@ def main() -> int:
     errors = []
 
     # Type-check scripts
-    topic_dirs = sorted(
-        [d for d in repo_root.iterdir() if d.name[:2].isdigit()]
-    )
+    topic_dirs = sorted([d for d in repo_root.iterdir() if d.name[:2].isdigit()])
 
     with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
         future_to_path = {}

--- a/internal/typecheck.py
+++ b/internal/typecheck.py
@@ -63,9 +63,7 @@ def main() -> int:
                     )
                     future_to_path[future] = pth
 
-        for future in concurrent.futures.as_completed(
-            future_to_path, timeout=60
-        ):
+        for future in concurrent.futures.as_completed(future_to_path, timeout=60):
             pth = future_to_path[future]
             try:
                 output = future.result()

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -114,9 +114,7 @@ def gather_example_files(
                 else:
                     module = f"{subdir.stem}.{filename.stem}"
                 data = jupytext.read(open(filename_abs), config=config)
-                metadata = data["metadata"]["jupytext"].get(
-                    "root_level_metadata", {}
-                )
+                metadata = data["metadata"]["jupytext"].get("root_level_metadata", {})
                 cmd = metadata.get("cmd", ["modal", "run", repo_filename])
                 args = metadata.get("args", [])
                 tags = metadata.get("tags", [])

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -34,9 +34,7 @@ class Example(BaseModel):
     cli_args: Optional[list] = None  # Full command line args to run it
     stem: Optional[str] = None  # stem of path
     tags: Optional[list[str]] = None  # metadata tags for the example
-    env: Optional[dict[str, str]] = (
-        None  # environment variables for the example
-    )
+    env: Optional[dict[str, str]] = None  # environment variables for the example
 
 
 _RE_NEWLINE = re.compile(r"\r?\n")

--- a/misc/batch_inference/batch_inference_using_huggingface.py
+++ b/misc/batch_inference/batch_inference_using_huggingface.py
@@ -133,9 +133,7 @@ def main():
     predictor = SentimentAnalysis()
     for review, label in data[:5]:
         prediction = predictor.predict.remote(review)
-        print(
-            f"Sample prediction with positivity score {prediction}:\n{review}\n\n"
-        )
+        print(f"Sample prediction with positivity score {prediction}:\n{review}\n\n")
 
     # Now, let's run batch inference over it
     print("Running batch prediction...")

--- a/misc/batch_inference/batch_inference_using_huggingface.py
+++ b/misc/batch_inference/batch_inference_using_huggingface.py
@@ -62,9 +62,7 @@ class SentimentAnalysis:
 
     @modal.method()
     def predict(self, phrase: str):
-        pred = self.sentiment_pipeline(
-            phrase, truncation=True, max_length=512, top_k=2
-        )
+        pred = self.sentiment_pipeline(phrase, truncation=True, max_length=512, top_k=2)
         # pred will look like: [{'label': 'NEGATIVE', 'score': 0.99}, {'label': 'POSITIVE', 'score': 0.01}]
         probs = {p["label"]: p["score"] for p in pred}
         return probs["POSITIVE"]

--- a/misc/falcon_bitsandbytes.py
+++ b/misc/falcon_bitsandbytes.py
@@ -132,9 +132,7 @@ class Falcon40B_4bit:
             max_new_tokens=512,
         )
 
-        streamer = TextIteratorStreamer(
-            self.tokenizer, skip_special_tokens=True
-        )
+        streamer = TextIteratorStreamer(self.tokenizer, skip_special_tokens=True)
         generate_kwargs = dict(
             input_ids=input_ids,
             generation_config=generation_config,

--- a/misc/falcon_gptq.py
+++ b/misc/falcon_gptq.py
@@ -78,9 +78,7 @@ class Falcon40BGPTQ:
         from auto_gptq import AutoGPTQForCausalLM
         from transformers import AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            IMAGE_MODEL_DIR, use_fast=True
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(IMAGE_MODEL_DIR, use_fast=True)
         print("Loaded tokenizer.")
 
         self.model = AutoGPTQForCausalLM.from_quantized(

--- a/misc/falcon_gptq.py
+++ b/misc/falcon_gptq.py
@@ -100,9 +100,7 @@ class Falcon40BGPTQ:
         from transformers import TextIteratorStreamer
 
         inputs = self.tokenizer(prompt, return_tensors="pt")
-        streamer = TextIteratorStreamer(
-            self.tokenizer, skip_special_tokens=True
-        )
+        streamer = TextIteratorStreamer(self.tokenizer, skip_special_tokens=True)
         generation_kwargs = dict(
             inputs=inputs.input_ids.cuda(),
             attention_mask=inputs.attention_mask,

--- a/misc/lmdeploy_oai_compatible.py
+++ b/misc/lmdeploy_oai_compatible.py
@@ -77,9 +77,7 @@ TOKEN = "secret12345"
     gpu=gpu.A10G(count=NO_GPU),
     scaledown_window=20 * SECONDS,
 )
-@modal.concurrent(
-    max_inputs=256
-)  # https://modal.com/docs/guide/concurrent-inputs
+@modal.concurrent(max_inputs=256)  # https://modal.com/docs/guide/concurrent-inputs
 @modal.web_server(port=23333, startup_timeout=60 * SECONDS)
 def serve():
     cmd = f"""

--- a/misc/news_summarizer.py
+++ b/misc/news_summarizer.py
@@ -101,9 +101,7 @@ def latest_science_stories(n_stories: int = 5) -> List[NYArticle]:
     articles = [
         NYArticle(
             title=u["title"],
-            image_url=(
-                u.get("multimedia")[0]["url"] if u.get("multimedia") else ""
-            ),
+            image_url=(u.get("multimedia")[0]["url"] if u.get("multimedia") else ""),
             url=u.get("url"),
         )
         for u in results["results"]

--- a/misc/run_fooocus.py
+++ b/misc/run_fooocus.py
@@ -14,9 +14,7 @@ import modal
 # We then download the Fooocus repository.
 
 image = (
-    modal.Image.from_registry(
-        "nvidia/cuda:12.3.1-base-ubuntu22.04", add_python="3.10"
-    )
+    modal.Image.from_registry("nvidia/cuda:12.3.1-base-ubuntu22.04", add_python="3.10")
     .apt_install(
         "software-properties-common",
         "git",

--- a/misc/stable_lm.py
+++ b/misc/stable_lm.py
@@ -27,9 +27,7 @@ def build_models():
         device_map="auto",
         local_files_only=True,
     )
-    m.save_pretrained(
-        model_path, safe_serialization=True, max_shard_size="24GB"
-    )
+    m.save_pretrained(model_path, safe_serialization=True, max_shard_size="24GB")
     tok = AutoTokenizer.from_pretrained(model_path)
     tok.save_pretrained(model_path)
     [p.unlink() for p in Path(model_path).rglob("*.bin")]  # type: ignore

--- a/misc/stable_lm.py
+++ b/misc/stable_lm.py
@@ -73,9 +73,7 @@ app = modal.App(
     name="example-stability-lm",
     image=image,
     secrets=[
-        modal.Secret.from_dict(
-            {"REPO_ID": "stabilityai/stablelm-tuned-alpha-7b"}
-        )
+        modal.Secret.from_dict({"REPO_ID": "stabilityai/stablelm-tuned-alpha-7b"})
     ],
 )
 
@@ -153,9 +151,7 @@ class StabilityLM:
         )
         self.generator.model = torch.compile(self.generator.model)
 
-    def get_config(
-        self, completion_request: CompletionRequest
-    ) -> Dict[str, Any]:
+    def get_config(self, completion_request: CompletionRequest) -> Dict[str, Any]:
         return dict(
             pad_token_id=self.generator.tokenizer.eos_token_id,
             eos_token_id=list(
@@ -204,9 +200,7 @@ class StabilityLM:
         return "".join(self.generate_completion(completion_request))
 
     @modal.method()
-    def generate_stream(
-        self, completion_request: CompletionRequest
-    ) -> Generator:
+    def generate_stream(self, completion_request: CompletionRequest) -> Generator:
         for text in self.generate_completion(completion_request):
             yield text
 

--- a/misc/stable_lm.py
+++ b/misc/stable_lm.py
@@ -130,9 +130,7 @@ class StabilityLM:
         import torch
         from transformers import AutoTokenizer, TextIteratorStreamer, pipeline
 
-        tokenizer = AutoTokenizer.from_pretrained(
-            self.model_url, local_files_only=True
-        )
+        tokenizer = AutoTokenizer.from_pretrained(self.model_url, local_files_only=True)
         self.stop_ids = tokenizer.convert_tokens_to_ids(self.stop_tokens)
         self.streamer = TextIteratorStreamer(
             tokenizer,

--- a/misc/stable_lm.py
+++ b/misc/stable_lm.py
@@ -117,9 +117,7 @@ class StabilityLM:
         "<|padding|>",
         "<|endoftext|>",
     ]
-    model_url: str = modal.parameter(
-        default="stabilityai/stablelm-tuned-alpha-7b"
-    )
+    model_url: str = modal.parameter(default="stabilityai/stablelm-tuned-alpha-7b")
 
     @modal.enter()
     def setup_model(self):

--- a/misc/tgi_oai_compatible.py
+++ b/misc/tgi_oai_compatible.py
@@ -77,9 +77,7 @@ TOKEN = "secret12345"
     gpu=gpu.A10G(count=NO_GPU),
     scaledown_window=20 * SECONDS,
 )
-@modal.concurrent(
-    max_inputs=256
-)  # https://modal.com/docs/guide/concurrent-inputs
+@modal.concurrent(max_inputs=256)  # https://modal.com/docs/guide/concurrent-inputs
 @modal.web_server(port=3000, startup_timeout=60 * SECONDS)
 def serve():
     cmd = f"""

--- a/misc/trellis3d.py
+++ b/misc/trellis3d.py
@@ -188,9 +188,7 @@ class Model:
                     texture_size=texture_size,
                 )
 
-                temp_glb = tempfile.NamedTemporaryFile(
-                    suffix=".glb", delete=False
-                )
+                temp_glb = tempfile.NamedTemporaryFile(suffix=".glb", delete=False)
                 temp_path = temp_glb.name
                 logger.info(f"Exporting mesh to: {temp_path}")
                 glb.export(temp_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 85
+line-length = 86
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 83
+line-length = 84
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 81
+line-length = 82
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 80
+line-length = 81
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 87
+line-length = 88
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 82
+line-length = 83
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 84
+line-length = 85
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".venv", "venv", "__pycache__"]
-line-length = 86
+line-length = 87
 # TODO: Add when available: "E266", "E203"
 lint.ignore = ["E501", "E741", "E402"]
 lint.select = ['E', 'F', 'W', 'I']


### PR DESCRIPTION
Following up on a suggestion by @mwaskom in #1122, this PR extends the line length limit in this repo from 80 to 88, which is the current default of black and ruff.

The larger line length still fits in the width of the code block element of our docs without horizontal scroll at normal zoom on my Macbook running Firefox with full screen width and at half-width on my wider monitor. There's room to spare for a gutter as well (helps to balance with Python's left padding).

I incremented the limit by one character per commit to track the impact. I scrolled through and felt that almost all of the changes were an improvement.

Unfortunately, "[in the interest of pragmatism](https://docs.astral.sh/ruff/rules/line-too-long/)" the wrapping behavior is pretty complicated, and incrementing the line length can cause lines that didn't previously wrap to start wrapping, like [this one](https://github.com/modal-labs/modal-examples/compare/charlesfrye/longer-lines?expand=1#diff-7514951712f24006f2c50445f06ba9218b3c650cc2f6521abca75850a45bdd74R52-R54). It has 93 characters, suspiciously five above the limit for the commit where it was changed. I wasn't able to track down the logic in the Ruff code though.

| Char limit | Files changed | LOC impact |
|----------|---------------|------------|
|            81 |            41  |       -111 |
|            82 |           22  |       -45 |
|            83 |           36  |        -70 |
|            84 |           23  |        -54 |
|            85 |           26  |        -56 |
|            86 |           29  |        -57 |
|            87 |           23  |        -44 |
|            88 |           33  |        -56 |

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)