### PR TITLE
minor text fixes

### DIFF
--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -222,7 +222,7 @@ def run_esm(sequence: str) -> str:
     volumes={VOLUME_PATH: volume},
     max_containers=1,  # Gradio requires sticky sessions
 )
-@modal.concurrent(max_inputs=1000)  # but can handle many async inputs
+@modal.concurrent(max_inputs=1000)  # Gradio can handle many async inputs
 @modal.asgi_app()
 def ui():
     import gradio as gr


### PR DESCRIPTION
We switched from a "comment continuation" to two comments when we added the concurrent decorator in #1122.

I think a parallel structure "Gradio requires ..." and "Gradio can ..." is the right way to do it with two comments.