### PR TITLE
use concurrent, bump hf version

### DIFF
--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -106,7 +106,7 @@ vol = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 
 image = (
     # install huggingface_hub with hf_transfer support to speed up downloads
-    image.pip_install("huggingface_hub[hf_transfer]==0.26.2")
+    image.pip_install("huggingface_hub[hf_transfer]==0.30.0")
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
     .run_function(
         hf_download,


### PR DESCRIPTION
from [this issue](https://github.com/modal-labs/modal-examples/issues/1124), wasn't personally able to reproduce it but doesn't hurt to update.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
