### PR TITLE
fix: proxy authentication error is 401 not 407

### DIFF
--- a/07_web_endpoints/basic_web.py
+++ b/07_web_endpoints/basic_web.py
@@ -175,7 +175,7 @@ class WebApp:
 # add the `requires_proxy_auth=True` flag to the `fastapi_endpoint` decorator.
 
 
-@app.function(gpu="h100")
+@app.function()
 @modal.fastapi_endpoint(requires_proxy_auth=True, docs=False)
 def expensive_secret():
     return "I didn't care for 'The Godfather'. It insists upon itself."
@@ -184,7 +184,7 @@ def expensive_secret():
 # The `expensive-secret` endpoint URL will still be printed to the output when you `modal serve` or `modal deploy`,
 # along with a "🔑" emoji indicating that it is secured with proxy authentication.
 # If you head to that URL via the browser, you will get a
-# [`407 Proxy Authentication Required`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407) error code in response.
+# [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/401) error code in response.
 # You should also check the dashboard page for this app (at the URL printed at the very top of the `modal` command output)
 # so you can see that no containers were spun up to handle the request -- this authorization is handled entirely inside Modal's infrastructure.
 


### PR DESCRIPTION
> If you head to that URL via the browser, you will get a `407 Proxy
> Authentication Required` error code in response.

I get 401 not 407.

```bash
$ curl -I https://dxia--example-lifecycle-web-expensive-secret-dev.modal.run
HTTP/2 401
alt-svc: h3=":443"; ma=2592000
date: Sat, 26 Apr 2025 15:18:42 GMT
vary: accept-encoding
content-length: 56
```


### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

Seems like 407 would be more specific, but maybe 401 is enough and the intended status code. Lmk, also happy to write a test if someone can link me to example or docs on how to do so.