### PR TITLE
docs: remove unecessary GPU H100 usage

### DIFF
--- a/07_web_endpoints/basic_web.py
+++ b/07_web_endpoints/basic_web.py
@@ -175,7 +175,7 @@ class WebApp:
 # add the `requires_proxy_auth=True` flag to the `fastapi_endpoint` decorator.
 
 
-@app.function(gpu="h100")
+@app.function()
 @modal.fastapi_endpoint(requires_proxy_auth=True, docs=False)
 def expensive_secret():
     return "I didn't care for 'The Godfather'. It insists upon itself."


### PR DESCRIPTION
in simple web endpoint that just returns static text. It's also not relevant for the proxy authentication content.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)