### PR TITLE
fix: use openai client 1.76.0 in vllm_inference.py

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -151,7 +151,7 @@ def serve():
 # to take it for a spin:
 
 # ```bash
-# # pip install openai==1.13.3
+# # pip install openai==1.76.0
 # python openai_compatible/client.py
 # ```
 


### PR DESCRIPTION
The suggested 1.13.3 is incompatible with httpx 0.28.0 and higher. With Python 3.13.3, my `pip install openai==1.13.3` installed httpx 0.28.1. Then `python openai_compatible/client.py` failed with `TypeError: Client.__init__() got an unexpected keyword argument 'proxies'`.

This is a bug in older versions of openai. It was first reported in https://github.com/openai/openai-python/issues/1902 and fixed in https://github.com/openai/openai-python/pull/1905

`pip install openai==1.76.0 && python openai_compatible/client.py` worked.


### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`