### PR TITLE
fix: set default environment for local `load_test.py`

### DIFF
--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -6,7 +6,7 @@ import modal
 
 if modal.is_local():
     workspace = modal.config._profile
-    environment = modal.config.config["environment"]
+    environment = modal.config.config.get("environment") or ""
 else:
     workspace = os.environ["MODAL_WORKSPACE"]
     environment = os.environ["MODAL_ENVIRONMENT"]
@@ -28,9 +28,8 @@ OUT_DIRECTORY = remote_path / datetime.utcnow().replace(microsecond=0).isoformat
 app = modal.App("loadtest-vllm-oai", image=image, volumes={remote_path: volume})
 
 workers = 8
-host = (
-    f"https://{workspace}-{environment}--example-vllm-openai-compatible-serve.modal.run"
-)
+prefix = workspace + (f"-{environment}" if environment else "")
+host = f"https://{prefix}--example-vllm-openai-compatible-serve.modal.run"
 csv_file = OUT_DIRECTORY / "stats.csv"
 default_args = [
     "-H",


### PR DESCRIPTION
Right now running `modal run openai_compatible/load_test.py` as instructed on
https://modal.com/docs/examples/vllm_inference#testing-the-server fails with
`InvalidError: Image ENV variables must be strings. Invalid keys:
['MODAL_ENVIRONMENT']`.

This happens when `environment` is `None`. Users reading these docs may not
have configured a modal environment yet. This change uses an empty string as
the fallback which is consistent with
`06_gpu_and_ml/llm-serving/openai_compatible/client.py`.

```bash
$ modal run openai_compatible/load_test.py
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/dxia/src/github.com/modal-labs/modal-examples/06_gpu_and_ml/llm-serving/openai_compatible │
│ /load_test.py:18 in <module>                                                                     │
│                                                                                                  │
│   17 │   .pip_install("locust~=2.29.1", "openai~=1.37.1")                                        │
│ ❱ 18 │   .env({"MODAL_WORKSPACE": workspace, "MODAL_ENVIRONMENT": environment})                  │
│   19 │   .add_local_file(                                                                        │
│                                                                                                  │
│ /Users/dxia/.pyenv/versions/3.13.3/envs/modal-examples/lib/python3.13/site-packages/modal/image. │
│ py:2002 in env                                                                                   │
│                                                                                                  │
│   2001 │   │   if non_str_keys:                                                                  │
│ ❱ 2002 │   │   │   raise InvalidError(f"Image ENV variables must be strings. Invalid keys: {non  │
│   2003                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
InvalidError: Image ENV variables must be strings. Invalid keys: ['MODAL_ENVIRONMENT']
```

We also fix the host string to take the environment into account. This is
consistent with `06_gpu_and_ml/llm-serving/openai_compatible/client.py` too.
Currently, `modal run openai_compatible/load_test.py` also results in this error.

```
[2025-04-26 20:49:14,561] modal/INFO/locust.runners: Sending spawn jobs of 36 users at 1.00 spawn rate to 8 ready workers
[2025-04-26 20:49:14,752] modal/ERROR/locust.user.task: 404 Client Error: Not Found for url: https://davidxia---example-vllm-openai-compatible-serve.modal.run/v1/chat/completions
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/locust/user/task.py", line 340, in run
    self.execute_next_task()
  File "/usr/local/lib/python3.11/site-packages/locust/user/task.py", line 373, in execute_next_task
    self.execute_task(self._task_queue.popleft())
  File "/usr/local/lib/python3.11/site-packages/locust/user/task.py", line 490, in execute_task
    task(self.user)
  File "/root/locustfile.py", line 35, in chat_completion
    response.raise_for_status()
  File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://davidxia---example-vllm-openai-compatible-serve.modal.run/v1/chat/completions
```

Signed-off-by: David Xia <david@davidxia.com>

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`