### PR TITLE
fix: `openai_compatible/load_test.py` errors

### DIFF
--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -21,6 +21,7 @@ image = (
         remote_path="/root/locustfile.py",
     )
 )
+
 volume = modal.Volume.from_name("loadtest-vllm-oai-results", create_if_missing=True)
 remote_path = Path("/root") / "loadtests"
 OUT_DIRECTORY = (
@@ -86,7 +87,7 @@ def main(
         "--autoquit",  # stop once finished...
         "10",  # ...but wait ten seconds
         "--html",  # output an HTML-formatted report
-        html_report_file,  # to this location
+        str(html_report_file),  # to this location
     ]
 
     if exit_code := run_locust.remote(args, wait=True):

--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,9 +13,7 @@ else:
 
 
 image = (
-    modal.Image.debian_slim(
-        python_version=f"{sys.version_info.major}.{sys.version_info.minor}"
-    )
+    modal.Image.debian_slim(python_version="3.11")
     .pip_install("locust~=2.36.2", "openai~=1.37.1")
     .env({"MODAL_WORKSPACE": workspace, "MODAL_ENVIRONMENT": environment})
     .add_local_file(
@@ -36,6 +33,7 @@ workers = 8
 host = (
     f"https://{workspace}-{environment}--example-vllm-openai-compatible-serve.modal.run"
 )
+
 csv_file = OUT_DIRECTORY / "stats.csv"
 default_args = [
     "-H",

--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import modal
 
@@ -80,14 +80,14 @@ def main(
         t,
     ]
 
-    html_report_file = OUT_DIRECTORY / "report.html"
+    html_report_file = str(PosixPath(OUT_DIRECTORY / "report.html"))
     args += [
         "--headless",  # run without browser UI
         "--autostart",  # start test immediately
         "--autoquit",  # stop once finished...
         "10",  # ...but wait ten seconds
         "--html",  # output an HTML-formatted report
-        str(html_report_file),  # to this location
+        html_report_file,  # to this location
     ]
 
     if exit_code := run_locust.remote(args, wait=True):


### PR DESCRIPTION
Upgrade `locust` in the image to 2.36.2 to fix `ValueError: StatsEntry.use_response_times_cache must be set to True` error. Reported in https://github.com/locustio/locust/issues/2908 and fixed in https://github.com/locustio/locust/commit/1954b26b7000ffe73a70a6dea99c3a33534bd988.

Otherwise `modal run openai_compatible/load_test.py` shows this error.

<details>
<summary>before</summary>

```
[2025-04-26 22:16:07,792] modal/INFO/locust.main: --run-time limit reached, shutting down
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:16:07,793] modal/INFO/locust.runners: Got quit message from master, shutting down...
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 8, in <module>
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 8, in <module>
    sys.exit(main())
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 8, in <module>
Traceback (most recent call last):
    sys.exit(main())
             ^^^^^^
  File "/usr/local/bin/locust", line 8, in <module>
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
    sys.exit(main())
    sys.exit(main())
             ^^^^^^
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
    save_html_report()
    save_html_report()
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 8, in <module>
    save_html_report()
    save_html_report()
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
    html_report = get_html_report(environment, show_download_link=False)
Traceback (most recent call last):
    html_report = get_html_report(environment, show_download_link=False)
  File "/usr/local/bin/locust", line 8, in <module>
    sys.exit(main())
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
    update_stats_history(environment.runner)
    html_report = get_html_report(environment, show_download_link=False)
    sys.exit(main())
    html_report = get_html_report(environment, show_download_link=False)
    update_stats_history(environment.runner)
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
    update_stats_history(environment.runner)
    update_stats_history(environment.runner)
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
    save_html_report()
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
    current_response_time_percentiles = {
    current_response_time_percentiles = {
                                        ^
    save_html_report()
                                        ^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
Traceback (most recent call last):
    current_response_time_percentiles = {
  File "/usr/local/bin/locust", line 8, in <module>
    current_response_time_percentiles = {
                                        ^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
                                        ^
    html_report = get_html_report(environment, show_download_link=False)
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
    html_report = get_html_report(environment, show_download_link=False)
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
    sys.exit(main())
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
    update_stats_history(environment.runner)
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
    update_stats_history(environment.runner)
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
    raise ValueError(
    raise ValueError(
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
    current_response_time_percentiles = {
    save_html_report()
                                        ^
    raise ValueError(
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
    raise ValueError(
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
    current_response_time_percentiles = {
                                        ^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
    html_report = get_html_report(environment, show_download_link=False)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
    update_stats_history(environment.runner)
    raise ValueError(
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 8, in <module>
    raise ValueError(
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
    sys.exit(main())
    current_response_time_percentiles = {
             ^^^^^^
                                        ^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 672, in main
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
    save_html_report()
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
  File "/usr/local/lib/python3.11/site-packages/locust/main.py", line 656, in save_html_report
    raise ValueError(
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
    html_report = get_html_report(environment, show_download_link=False)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/html.py", line 56, in get_html_report
    update_stats_history(environment.runner)
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 918, in update_stats_history
    current_response_time_percentiles = {
                                        ^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 919, in <dictcomp>
    f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/locust/stats.py", line 610, in get_current_response_time_percentile
    raise ValueError(
ValueError: StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile
[2025-04-26 22:16:08,312] modal/INFO/locust.main: writing html report to file: /root/loadtests/2025-04-26T22:15:01/report.html
[2025-04-26 22:16:08,819] modal/INFO/locust.main: Shutting down (exit code 0)
Type     Name                                                                          # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /v1/chat/completions                                                             273     0(0.00%) |   2693     463   32440   2300 |    4.56        0.00
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated                                                                       273     0(0.00%) |   2693     463   32440   2300 |    4.56        0.00

Response time percentiles (approximated)
Type     Name                                                                                  50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
POST     /v1/chat/completions                                                                 2300   2500   2600   2700   3000   3200   4900  18000  32000  32000  32000    273
--------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
         Aggregated                                                                           2300   2500   2600   2700   3000   3200   4900  18000  32000  32000  32000    273

finished successfully
Stopping app - local entrypoint completed.
✓ App completed. View run at https://modal.com/apps/davidxia/main/ap-C3Hm9VQ8ttvoSnFfzFC7IB
```
</details>

<details>
<summary>after</summary>

```
[2025-04-26 22:17:38,682] modal/INFO/locust.main: --run-time limit reached, shutting down
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
[2025-04-26 22:17:38,683] modal/INFO/locust.runners: Got quit message from master, shutting down...
Type     Name                                                                          # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /v1/chat/completions                                                              20     0(0.00%) |   2420    1707    5824   2300 |    1.30        0.00
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated                                                                        20     0(0.00%) |   2420    1707    5824   2300 |    1.30        0.00

[2025-04-26 22:17:38,759] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,760] modal/INFO/locust.runners: Worker 'modal_6c4808f4af114362941b0324ddae8206' (index 0) quit. 0 workers ready.
[2025-04-26 22:17:38,760] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,760] modal/INFO/locust.runners: Worker 'modal_802565c8d2864a9ba6c4a1e5a15f4082' (index 5) quit. 0 workers ready.
[2025-04-26 22:17:38,760] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,760] modal/INFO/locust.runners: Worker 'modal_cda3c7138076444da1102d8494421a9a' (index 2) quit. 0 workers ready.
[2025-04-26 22:17:38,761] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,761] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,761] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,761] modal/INFO/locust.runners: Worker 'modal_381dcdfd88fd4db68fc2e016ad62c1fc' (index 4) quit. 0 workers ready.
[2025-04-26 22:17:38,761] modal/INFO/locust.runners: Worker 'modal_4cd5555fc14d4deda0cc9a302696699d' (index 3) quit. 0 workers ready.
[2025-04-26 22:17:38,762] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,762] modal/INFO/locust.runners: Worker 'modal_abcb0945977540ffa692a44b839fd64f' (index 1) quit. 0 workers ready.
[2025-04-26 22:17:38,762] modal/INFO/locust.main: Shutting down (exit code 0)
[2025-04-26 22:17:38,762] modal/INFO/locust.runners: Worker 'modal_c0c64461c02b4ede838fb359984d8004' (index 7) quit. 0 workers ready.
[2025-04-26 22:17:38,762] modal/INFO/locust.runners: Worker 'modal_00393742654a4ff490900ce77e2ff1ef' (index 6) quit. 0 workers ready.
[2025-04-26 22:17:38,762] modal/INFO/locust.runners: The last worker quit, stopping test.
[2025-04-26 22:17:39,297] modal/INFO/locust.main: writing html report to file: /root/loadtests/2025-04-26T22:17:17+00:00/report.html
[2025-04-26 22:17:39,806] modal/INFO/locust.main: Shutting down (exit code 0)
Type     Name                                                                          # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /v1/chat/completions                                                              23     0(0.00%) |   2681    1707    8756   2300 |    1.55        0.00
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated                                                                        23     0(0.00%) |   2681    1707    8756   2300 |    1.55        0.00

Response time percentiles (approximated)
Type     Name                                                                                  50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
POST     /v1/chat/completions                                                                 2300   2400   2600   2600   3000   5800   8800   8800   8800   8800   8800     23
--------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
         Aggregated                                                                           2300   2400   2600   2600   3000   5800   8800   8800   8800   8800   8800     23

finished successfully
Stopping app - local entrypoint completed.
Runner terminated.
✓ App completed. View run at https://modal.com/apps/davidxia/main/ap-q1CgdHDbr9Jgn2GfwAHPF6
```
</details>

Detect local Python version and use the same version in the image to prevent this serialization error when local Python is 3.13.

<details>
<summary>serialization error</summary>

```
Built image im-jP1f7oVqujSiNXmIZEbZBW in 1.36s

✓ Created objects.
├── 🔨 Created mount /Users/dxia/src/github.com/modal-labs/modal-examples/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
├── 🔨 Created mount /Users/dxia/src/github.com/modal-labs/modal-examples/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
├── 🔨 Created web function serve => https://davidxia--loadtest-vllm-oai-serve-dev.modal.run
└── 🔨 Created function run_locust.
Traceback (most recent call last):
Stopping app - uncaught exception raised locally: DeserializationError("Deserialization failed because the 'pathlib._local' module is not available in the remote environment.").
  File "/pkg/modal/_serialization.py", line 103, in deserialize
    return Unpickler(client, io.BytesIO(s)).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pathlib._local'; 'pathlib' is not a package

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/pkg/modal/_runtime/container_io_manager.py", line 742, in handle_input_exception
    yield
  File "/pkg/modal/_container_entrypoint.py", line 244, in run_input_sync
    res = io_context.call_finalized_function()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/modal/_runtime/container_io_manager.py", line 193, in call_finalized_function
    args, kwargs = self._args_and_kwargs()
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/modal/_runtime/container_io_manager.py", line 151, in _args_and_kwargs
    deserialized_args = [
                        ^
  File "/pkg/modal/_runtime/container_io_manager.py", line 152, in <listcomp>
    deserialize(input.args, self._client) if input.args else ((), {}) for input in self.function_inputs
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/modal/_serialization.py", line 120, in deserialize
    raise DeserializationError(
modal.exception.DeserializationError: Deserialization failed because the 'pathlib._local' module is not available in the remote environment.
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/dxia/src/github.com/modal-labs/modal-examples/06_gpu_and_ml/llm-serving/openai_compatible │
│ /load_test.py:88 in main                                                                         │
│                                                                                                  │
│   87 │                                                                                           │
│ ❱ 88 │   if exit_code := run_locust.remote(args, wait=True):                                     │
│   89 │   │   SystemExit(exit_code)                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
DeserializationError: Deserialization failed because the 'pathlib._local' module is not available in the remote environment.
```
</details>

Also use [recommended way] to create timezone-aware `datetime` object.

> As such, the recommended way to create an object representing the current
> time in UTC is by calling `datetime.now(timezone.utc)`.

[recommended way]: https://docs.python.org/3.11/library/datetime.html#datetime.datetime.utcnow

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [ ] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [ ] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [ ] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
