### PR TITLE
adds fastapi to the development requirements

### DIFF
--- a/internal/requirements.txt
+++ b/internal/requirements.txt
@@ -6,3 +6,4 @@ jupytext~=1.16.1
 pydantic~=1.10.14
 mypy==1.2.0
 ruff==0.9.6
+fastapi


### PR DESCRIPTION
A few of the examples `import fastapi` in the global scope, which is important for properly using the `fastapi_endpoint` decorator.

Would prefer to find a different way to solve this (e.g. via an `extra` dependency of `modal`) long-term, but this will prevent all tests from failing while we do so.