### PR TITLE
properly type Optionals in args of Modal Functions/local entrypoints

### DIFF
--- a/06_gpu_and_ml/embeddings/qdrant.py
+++ b/06_gpu_and_ml/embeddings/qdrant.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import modal
 
 app = modal.App("example-qdrant-in-memory")
@@ -36,7 +38,7 @@ def query(inpt):
 
 
 @app.local_entrypoint()
-def main(inpt: str = None):
+def main(inpt: Optional[str] = None):
     if not inpt:
         inpt = "alpaca"
 

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -50,6 +50,7 @@ import logging as L
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path, PosixPath
+from typing import Optional
 
 import modal
 from pydantic import BaseModel
@@ -285,8 +286,8 @@ class ModelHyperparameters:
 @app.local_entrypoint()
 def main(
     n_steps: int = 3000,
-    n_steps_before_checkpoint: int = None,
-    n_steps_before_eval: int = None,
+    n_steps_before_checkpoint: Optional[int] = None,
+    n_steps_before_eval: Optional[int] = None,
 ):
     from datetime import datetime
     from itertools import product

--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -25,7 +25,7 @@ import io
 import random
 import time
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
 import fastapi
 import modal
@@ -142,10 +142,10 @@ class Inference:
         self,
         image_bytes: bytes,
         prompt: str,
-        negative_prompt: str = None,
-        num_frames: int = None,
-        num_inference_steps: int = None,
-        seed: int = None,
+        negative_prompt: Optional[str] = None,
+        num_frames: Optional[int] = None,
+        num_inference_steps: Optional[int] = None,
+        seed: Optional[int] = None,
     ) -> str:
         negative_prompt = (
             negative_prompt
@@ -184,10 +184,10 @@ class Inference:
         self,
         image_bytes: Annotated[bytes, fastapi.File()],
         prompt: str,
-        negative_prompt: str = None,
-        num_frames: int = None,
-        num_inference_steps: int = None,
-        seed: int = None,
+        negative_prompt: Optional[str] = None,
+        num_frames: Optional[int] = None,
+        num_inference_steps: Optional[int] = None,
+        seed: Optional[int] = None,
     ) -> fastapi.Response:
         mp4_name = self.run.local(  # run in the same container
             image_bytes=image_bytes,
@@ -223,10 +223,10 @@ class Inference:
 def entrypoint(
     image_path: str,
     prompt: str,
-    negative_prompt: str = None,
-    num_frames: int = None,
-    num_inference_steps: int = None,
-    seed: int = None,
+    negative_prompt: Optional[str] = None,
+    num_frames: Optional[int] = None,
+    num_inference_steps: Optional[int] = None,
+    seed: Optional[int] = None,
     twice: bool = True,
 ):
     import os

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -14,6 +14,7 @@
 # First, we’ll import the libraries we need locally and define some constants.
 
 from pathlib import Path
+from typing import Optional
 from urllib.request import urlopen
 from uuid import uuid4
 
@@ -341,7 +342,11 @@ def convert_pdf_to_images(pdf_bytes):
 
 
 @app.local_entrypoint()
-def main(question: str = None, pdf_path: str = None, session_id: str = None):
+def main(
+    question: Optional[str] = None,
+    pdf_path: Optional[str] = None,
+    session_id: Optional[str] = None,
+):
     model = Model()
     if session_id is None:
         session_id = str(uuid4())

--- a/06_gpu_and_ml/long-training.py
+++ b/06_gpu_and_ml/long-training.py
@@ -32,6 +32,7 @@
 # We check for this file and resume training from it if it exists.
 
 from pathlib import Path
+from typing import Optional
 
 import modal
 
@@ -136,7 +137,7 @@ def train_interruptible(*args, **kwargs):
 
 
 @app.local_entrypoint()
-def main(experiment: str = None):
+def main(experiment: Optional[str] = None):
     if experiment is None:
         from uuid import uuid4
 

--- a/06_gpu_and_ml/openai_whisper/batched_whisper.py
+++ b/06_gpu_and_ml/openai_whisper/batched_whisper.py
@@ -14,6 +14,8 @@
 # Let's start by importing the Modal client and defining the model that we want to serve.
 
 
+from typing import Optional
+
 import modal
 
 MODEL_DIR = "/model"
@@ -166,7 +168,7 @@ async def transcribe_hf_dataset(dataset_name):
 
 
 @app.local_entrypoint()
-async def main(dataset_name: str = None):
+async def main(dataset_name: Optional[str] = None):
     if dataset_name is None:
         dataset_name = "hf-internal-testing/librispeech_asr_dummy"
     for result in transcribe_hf_dataset.remote_gen(dataset_name):

--- a/06_gpu_and_ml/protein-folding/boltz1.py
+++ b/06_gpu_and_ml/protein-folding/boltz1.py
@@ -10,6 +10,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import modal
 
@@ -47,7 +48,9 @@ app = modal.App(name="example-boltz1-inference")
 
 
 @app.local_entrypoint()
-def main(force_download: bool = False, input_yaml_path: str = None, args: str = ""):
+def main(
+    force_download: bool = False, input_yaml_path: Optional[str] = None, args: str = ""
+):
     print("🧬 loading model remotely")
     download_model.remote(force_download)
 

--- a/06_gpu_and_ml/protein-folding/chai1.py
+++ b/06_gpu_and_ml/protein-folding/chai1.py
@@ -27,6 +27,7 @@
 import hashlib
 import json
 from pathlib import Path
+from typing import Optional
 from uuid import uuid4
 
 import modal
@@ -59,10 +60,10 @@ app = modal.App(name="example-chai1-inference")
 @app.local_entrypoint()
 def main(
     force_redownload: bool = False,
-    fasta_file: str = None,
-    inference_config_file: str = None,
-    output_dir: str = None,
-    run_id: str = None,
+    fasta_file: Optional[str] = None,
+    inference_config_file: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    run_id: Optional[str] = None,
 ):
     print("🧬 checking inference dependencies")
     download_inference_dependencies.remote(force=force_redownload)

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -20,6 +20,7 @@
 import base64
 import io
 from pathlib import Path
+from typing import Optional
 
 import modal
 
@@ -330,10 +331,7 @@ def ui():
 
 
 @app.local_entrypoint()
-def main(
-    sequence: str = None,
-    output_dir: str = None,
-):
+def main(sequence: Optional[str] = None, output_dir: Optional[str] = None):
     if sequence is None:
         print("using sequence for insulin [P01308]")
         sequence = "MRTPMLLALLALATLCLAGRADAKPGDAESGKGAAFVSKQEGSEVVKRLRRYLDHWLGAPAPYPDPLEPKREVCELNPDCDELADHIGFQEAYRRFYGPV"

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -23,6 +23,7 @@ import io
 import random
 import time
 from pathlib import Path
+from typing import Optional
 
 import modal
 
@@ -104,7 +105,9 @@ class Inference:
         ).to("cuda")
 
     @modal.method()
-    def run(self, prompt: str, batch_size: int = 4, seed: int = None) -> list[bytes]:
+    def run(
+        self, prompt: str, batch_size: int = 4, seed: Optional[int] = None
+    ) -> list[bytes]:
         seed = seed if seed is not None else random.randint(0, 2**32 - 1)
         print("seeding RNG with", seed)
         torch.manual_seed(seed)
@@ -125,7 +128,7 @@ class Inference:
         return image_output
 
     @modal.fastapi_endpoint(docs=True)
-    def web(self, prompt: str, seed: int = None):
+    def web(self, prompt: str, seed: Optional[int] = None):
         return Response(
             content=self.run.local(  # run in the same container
                 prompt, batch_size=1, seed=seed
@@ -156,7 +159,7 @@ def entrypoint(
     samples: int = 4,
     prompt: str = "A princess riding on a pony",
     batch_size: int = 4,
-    seed: int = None,
+    seed: Optional[int] = None,
 ):
     print(
         f"prompt => {prompt}",

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -11,6 +11,7 @@
 # ## Setting up dependencies
 
 from pathlib import Path
+from typing import Optional
 from uuid import uuid4
 
 import modal
@@ -195,7 +196,7 @@ class MusicGen:
 
 @app.local_entrypoint()
 def main(
-    prompt: str = None,
+    prompt: Optional[str] = None,
     duration: int = 10,
     overlap: int = 15,
     format: str = "wav",  # or mp3

--- a/06_gpu_and_ml/torch_profiling.py
+++ b/06_gpu_and_ml/torch_profiling.py
@@ -31,6 +31,7 @@
 
 
 from pathlib import Path
+from typing import Optional
 
 import modal
 
@@ -115,7 +116,7 @@ def underutilize(scale=1):
 @app.function(volumes={TRACE_DIR: traces}, **config)
 def profile(
     function,
-    label: str = None,
+    label: Optional[str] = None,
     steps: int = 3,
     schedule=None,
     record_shapes: bool = False,
@@ -189,14 +190,14 @@ def profile(
 @app.local_entrypoint()
 def main(
     function: str = "underutilize",
-    label: str = None,
+    label: Optional[str] = None,
     steps: int = 3,
     schedule=None,
     record_shapes: bool = False,
     profile_memory: bool = False,
     with_stack: bool = False,
     print_rows: int = 10,
-    kwargs_json_path: str = None,
+    kwargs_json_path: Optional[str] = None,
 ):
     if kwargs_json_path is not None:  # use to pass arguments to function
         import json

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -25,6 +25,8 @@
 # Let's first import `modal` and define an [`App`](https://modal.com/docs/reference/modal.App).
 # Later, we'll use the name provided for our `App` to find it from our web app and submit tasks to it.
 
+from typing import Optional
+
 import modal
 
 app = modal.App("example-doc-ocr-jobs")
@@ -167,7 +169,7 @@ def parse_receipt(image: bytes) -> str:
 
 
 @app.local_entrypoint()
-def main(receipt_filename: str = None):
+def main(receipt_filename: Optional[str] = None):
     from pathlib import Path
 
     import requests

--- a/misc/deepseek_openai_server.py
+++ b/misc/deepseek_openai_server.py
@@ -60,6 +60,7 @@ import subprocess
 
 # Standard library imports
 from pathlib import Path
+from typing import Optional
 
 # Third-party imports
 import modal
@@ -153,7 +154,7 @@ download_image = (
 @app.function(
     image=download_image, volumes={cache_dir: model_cache}, timeout=30 * MINUTES
 )
-def download_model(repo_id, allow_patterns, revision: str = None):
+def download_model(repo_id, allow_patterns, revision: Optional[str] = None):
     from huggingface_hub import snapshot_download
 
     print(f"🦙 downloading model from {repo_id} if not present")

--- a/misc/falcon_bitsandbytes.py
+++ b/misc/falcon_bitsandbytes.py
@@ -17,6 +17,8 @@
 #
 # First we import the components we need from `modal`.
 
+from typing import Optional
+
 import modal
 
 
@@ -165,7 +167,7 @@ prompt_template = (
 
 
 @app.local_entrypoint()
-def cli(prompt: str = None):
+def cli(prompt: Optional[str] = None):
     question = (
         prompt
         or "What are the main differences between Python and JavaScript programming languages?"


### PR DESCRIPTION
As pointed out by @davidxia in #1146, `Optional` is in fact supported by `typer` for CLIs.

This PR updates all of the places where we used `str = None` and `int = None` to express Optionals of those types. A quick-and-dirty grep didn't reveal any other types with this pattern.

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)