### PR TITLE
Fix typo in `flux.py`

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -249,7 +249,7 @@ def optimize(pipe, compile=True):
     )
 
     # trigger torch compilation
-    print("🔦 running torch compiliation (may take up to 20 minutes)...")
+    print("🔦 running torch compilation (may take up to 20 minutes)...")
 
     pipe(
         "dummy prompt to trigger torch compilation",


### PR DESCRIPTION
Noticed this when reading through the docs.

### Type of Change

- [ ] New example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)