### PR TITLE
WebRTC and YOLO example  (#1176)

### DIFF
--- a/07_web_endpoints/webrtc/frontend/index.html
+++ b/07_web_endpoints/webrtc/frontend/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>WebRTC YOLO Demo</title>
+    <style>
+        video {
+            width: 320px;
+            height: 240px;
+            margin: 10px;
+            border: 1px solid black;
+        }
+        button {
+            margin: 10px;
+            padding: 10px;
+        }
+        #videos {
+            display: flex;
+            flex-wrap: wrap;
+        }
+        .radio-group {
+            margin: 10px;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        .radio-group label {
+            margin-right: 15px;
+        }
+        #statusDisplay {
+            margin: 10px;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background-color: #f5f5f5;
+            min-height: 20px;
+            max-height: 150px;
+            overflow-y: auto;
+            font-family: monospace;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
+        .status-line {
+            margin: 2px 0;
+            padding: 2px;
+            border-bottom: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="radio-group">
+        <label>
+            <input type="radio" name="iceServer" value="stun" checked> STUN Server
+        </label>
+        <label>
+            <input type="radio" name="iceServer" value="turn"> TURN Server
+        </label>
+    </div>
+    <div id="videos">
+        <video id="localVideo" autoplay playsinline muted></video>
+        <video id="remoteVideo" autoplay playsinline></video>
+    </div>
+    <div>
+        <button id="startWebcamButton">Start Webcam</button>
+        <button id="startStreamingButton" disabled>Stream YOLO</button>
+        <button id="stopStreamingButton" disabled>Stop Streaming</button>
+    </div>
+    <div id="statusDisplay"></div>
+    <script type="module" src="/static/webcam_webrtc.js"></script>
+</body>
+</html> 

--- a/07_web_endpoints/webrtc/frontend/modal_webrtc.js
+++ b/07_web_endpoints/webrtc/frontend/modal_webrtc.js
@@ -1,0 +1,223 @@
+export class ModalWebRtcClient extends EventTarget {
+    constructor() {
+        super();
+        this.ws = null;
+        this.localStream = null;
+        this.peerConnection = null;
+        this.iceServers = null;
+        this.peerID = null;
+        this.iceServerType = 'stun';
+    }
+
+    updateStatus(message) {
+        this.dispatchEvent(new CustomEvent('status', { 
+            detail: { message }
+        }));
+        console.log(message);
+    }
+
+    // Get webcam media stream
+    async startWebcam() {
+        try {
+            this.localStream = await navigator.mediaDevices.getUserMedia({ 
+                video: {
+                    facingMode: { ideal: "environment" }
+                }, 
+                audio: false
+            });
+            this.dispatchEvent(new CustomEvent('localStream', { 
+                detail: { stream: this.localStream }
+            }));
+            return this.localStream;
+        } catch (err) {
+            console.error('Error accessing media devices:', err);
+            this.dispatchEvent(new CustomEvent('error', { 
+                detail: { error: err }
+            }));
+            throw err;
+        }
+    }
+
+    // Create and set up peer connection
+    async startStreaming() {
+        this.peerID = this.generateShortUUID();
+        this.updateStatus('Loading YOLO GPU inference in the cloud (this can take up to 20 seconds)...');
+        await this.negotiate();
+    }
+
+    async negotiate() {
+        try {
+            // setup websocket connection
+            this.ws = new WebSocket(`/ws/${this.peerID}`);
+
+            this.ws.onerror = (error) => {
+                console.error('WebSocket error:', error);
+                this.dispatchEvent(new CustomEvent('error', { 
+                    detail: { error }
+                }));
+            };
+        
+            this.ws.onclose = () => {
+                console.log('WebSocket connection closed');
+                this.dispatchEvent(new CustomEvent('websocketClosed'));
+            };
+
+            this.ws.onmessage = (event) => {
+                const msg = JSON.parse(event.data);
+                
+                if (msg.type === 'answer') {
+                    this.updateStatus('Establishing WebRTC connection...');
+                    this.peerConnection.setRemoteDescription(msg);
+                } else if (msg.type === 'turn_servers') {
+                    this.iceServers = msg.ice_servers;
+                } else {
+                    console.error('Unexpected response from server:', msg);
+                }
+            };
+
+            console.log('Waiting for websocket to open...');
+            await new Promise((resolve) => {
+                if (this.ws.readyState === WebSocket.OPEN) {
+                    resolve();
+                } else {
+                    this.ws.addEventListener('open', () => resolve(), { once: true });
+                }
+            });
+
+            if (this.iceServerType === 'turn') {
+                this.ws.send(JSON.stringify({type: 'get_turn_servers', peer_id: this.peerID}));
+            } else {
+                this.iceServers = [
+                    {
+                        urls: ["stun:stun.l.google.com:19302"],
+                    },
+                ];
+            }
+
+            // Wait until we have ICE servers
+            if (this.iceServerType === 'turn') {
+                await new Promise((resolve) => {
+                    const checkIceServers = () => {
+                        if (this.iceServers) {
+                            resolve();
+                        } else {
+                            setTimeout(checkIceServers, 100);
+                        }
+                    };
+                    checkIceServers();
+                });
+            }
+
+            const rtcConfiguration = {
+                iceServers: this.iceServers,
+            }
+            this.peerConnection = new RTCPeerConnection(rtcConfiguration);
+
+            // Add local stream to peer connection
+            this.localStream.getTracks().forEach(track => {
+                console.log('Adding track:', track);
+                this.peerConnection.addTrack(track, this.localStream);
+            });
+
+            // Handle remote stream when triggered
+            this.peerConnection.ontrack = event => {
+                console.log('Received remote stream:', event.streams[0]);
+                this.dispatchEvent(new CustomEvent('remoteStream', { 
+                    detail: { stream: event.streams[0] }
+                }));
+            };
+
+            // Handle ICE candidates using Trickle ICE pattern
+            this.peerConnection.onicecandidate = async (event) => {
+                if (!event.candidate || !event.candidate.candidate) {
+                    return;
+                }
+                
+                const iceCandidate = {
+                    peer_id: this.peerID,
+                    candidate_sdp: event.candidate.candidate,
+                    sdpMid: event.candidate.sdpMid,
+                    sdpMLineIndex: event.candidate.sdpMLineIndex,
+                    usernameFragment: event.candidate.usernameFragment
+                };
+
+                console.log('Sending ICE candidate: ', iceCandidate.candidate_sdp);
+                
+                // send ice candidate over ws
+                this.ws.send(JSON.stringify({type: 'ice_candidate', candidate: iceCandidate}));
+            };
+
+            this.peerConnection.onconnectionstatechange = async () => {
+                const state = this.peerConnection.connectionState;
+                this.updateStatus(`WebRTCConnection state: ${state}`);
+                this.dispatchEvent(new CustomEvent('connectionStateChange', { 
+                    detail: { state }
+                }));
+                
+                if (state === 'connected') {
+                    if (this.ws.readyState === WebSocket.OPEN) {
+                        this.ws.close();
+                    }
+                }
+            };
+
+            // set local description and send as offer to peer
+            console.log('Setting local description...');
+            await this.peerConnection.setLocalDescription();
+            var offer = this.peerConnection.localDescription;
+            
+            console.log('Sending offer...');
+            // send offer over ws
+            this.ws.send(JSON.stringify({peer_id: this.peerID, type: 'offer', sdp: offer.sdp}));
+
+        } catch (e) {
+            console.error('Error negotiating:', e);
+            this.dispatchEvent(new CustomEvent('error', { 
+                detail: { error: e }
+            }));
+            throw e;
+        }
+    }
+
+    // Stop streaming
+    async stopStreaming() {
+        await this.cleanup();
+        this.updateStatus('Streaming stopped.');
+        this.dispatchEvent(new CustomEvent('streamingStopped'));
+    }
+
+    // cleanup
+    async cleanup() {
+        console.log('Cleaning up...');
+        this.iceServers = null;
+        if (this.peerConnection) {
+            console.log('Peer Connection state:', this.peerConnection.connectionState);
+            await this.peerConnection.close();
+            this.peerConnection = null;
+        }
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+            await this.ws.close();
+            this.ws = null;
+        }
+        this.dispatchEvent(new CustomEvent('cleanup'));
+    }
+
+    setIceServerType(type) {
+        this.iceServerType = type;
+        console.log('ICE server type changed to:', this.iceServerType);
+        this.dispatchEvent(new CustomEvent('iceServerTypeChanged', { 
+            detail: { type }
+        }));
+    }
+
+    // Generate a short, URL-safe UUID
+    generateShortUUID() {
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+        let result = '';
+        // Generate 22 characters (similar to short-uuid's default length)
+        for (let i = 0; i < 22; i++) {
+            result += chars.charAt(Math.floor(Math.random() * chars.length));
+        }
+        return result;
+    }
+} 

--- a/07_web_endpoints/webrtc/frontend/webcam_webrtc.js
+++ b/07_web_endpoints/webrtc/frontend/webcam_webrtc.js
@@ -1,0 +1,119 @@
+import { ModalWebRtcClient } from './modal_webrtc.js';
+
+// Add status display element
+const statusDisplay = document.getElementById('statusDisplay');
+const MAX_STATUS_HISTORY = 100;
+let statusHistory = [];
+
+
+// DOM elements
+const localVideo = document.getElementById('localVideo');
+const remoteVideo = document.getElementById('remoteVideo');
+const startWebcamButton = document.getElementById('startWebcamButton');
+const startStreamingButton = document.getElementById('startStreamingButton');
+const stopStreamingButton = document.getElementById('stopStreamingButton');
+
+// Initialize WebRTC client
+const webrtcClient = new ModalWebRtcClient();
+
+// Set up event listeners
+webrtcClient.addEventListener('status', (event) => {
+    // Add timestamp to message
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString();
+    const statusLine = `[${timestamp}] ${event.detail.message}`;
+    
+    // Add to history
+    statusHistory.push(statusLine);
+    
+    // Keep only last MAX_STATUS_HISTORY messages
+    if (statusHistory.length > MAX_STATUS_HISTORY) {
+        statusHistory.shift();
+    }
+    
+    // Update display
+    statusDisplay.innerHTML = statusHistory.map(line => 
+        `<div class="status-line">${line}</div>`
+    ).join('');
+    
+    // Scroll to bottom
+    statusDisplay.scrollTop = statusDisplay.scrollHeight;
+});
+
+webrtcClient.addEventListener('localStream', (event) => {
+    localVideo.srcObject = event.detail.stream;
+});
+
+webrtcClient.addEventListener('remoteStream', (event) => {
+    remoteVideo.srcObject = event.detail.stream;
+});
+
+webrtcClient.addEventListener('error', (event) => {
+    console.error('WebRTC error:', event.detail.error);
+});
+
+webrtcClient.addEventListener('connectionStateChange', (event) => {
+    if (event.detail.state === 'connected') {
+        startStreamingButton.disabled = true;
+        stopStreamingButton.disabled = false;
+    }
+});
+
+webrtcClient.addEventListener('streamingStopped', () => {
+    stopStreamingButton.disabled = true;
+    startStreamingButton.disabled = false;
+    remoteVideo.srcObject = null;
+});
+
+// Initialize button states
+startWebcamButton.disabled = false;
+startStreamingButton.disabled = true;
+stopStreamingButton.disabled = true;
+
+// Event handlers
+async function handleStartWebcam() {
+    try {
+        await webrtcClient.startWebcam();
+        startWebcamButton.disabled = true;
+        startStreamingButton.disabled = false;
+    } catch (err) {
+        console.error('Error starting webcam:', err);
+    }
+}
+
+async function handleStartStreaming() {
+    startWebcamButton.disabled = true;
+    startStreamingButton.disabled = true;
+    stopStreamingButton.disabled = false;
+    await webrtcClient.startStreaming();
+}
+
+async function handleStopStreaming() {
+    await webrtcClient.stopStreaming();
+}
+
+// Add event listener for STUN/TURN server radio buttons
+document.querySelectorAll('input[name="iceServer"]').forEach(radio => {
+    radio.addEventListener('change', (e) => {
+        webrtcClient.setIceServerType(e.target.value);
+    });
+});
+
+// Event listeners
+startWebcamButton.addEventListener('click', handleStartWebcam);
+startStreamingButton.addEventListener('click', handleStartStreaming);
+stopStreamingButton.addEventListener('click', handleStopStreaming);
+
+// Add cleanup handler for when browser tab is closed
+window.addEventListener('beforeunload', async () => {
+    await webrtcClient.cleanup();
+    // ensure stun/turn radio and iceServerType are reset
+    document.querySelectorAll('input[name="iceServer"]').forEach(radio => {
+        if (radio.value == "turn") {
+            radio.checked = false;
+        } else {
+            radio.checked = true;
+        }
+    });
+    webrtcClient.setIceServerType('stun');
+});

--- a/07_web_endpoints/webrtc/modal_webrtc.py
+++ b/07_web_endpoints/webrtc/modal_webrtc.py
@@ -1,0 +1,289 @@
+import asyncio
+import json
+from abc import ABC, abstractmethod
+from typing import ClassVar, Optional
+
+import modal
+from fastapi import FastAPI, WebSocket
+from fastapi.websockets import WebSocketState
+
+
+class ModalWebRtcServer:
+    """Connect a ModalWebRtcPeer with a client by passing signaling WebSocket messages over a Queue."""
+
+    modal_peer_cls: ClassVar = None
+
+    @modal.enter()
+    def _initialize(self):
+        self.web_app = FastAPI()
+
+        # handle signaling through websocket endpoint
+        @self.web_app.websocket("/ws/{peer_id}")
+        async def ws(client_websocket: WebSocket, peer_id: str):
+            await client_websocket.accept()
+            await self._mediate_negotiation(client_websocket, peer_id)
+
+        self.initialize()
+
+    def initialize(self):
+        pass
+
+    @modal.asgi_app()
+    def web(self):
+        return self.web_app
+
+    async def _mediate_negotiation(self, websocket: WebSocket, peer_id: str):
+        if self.modal_peer_cls:
+            modal_peer = self.modal_peer_cls()
+        else:
+            print("Modal peer class not set")
+            return
+
+        with modal.Queue.ephemeral() as q:
+            print(f"Spawning modal peer instance for client peer {peer_id}...")
+            modal_peer.run_with_queue.spawn(q, peer_id)
+
+            await asyncio.gather(
+                relay_client(websocket, q, peer_id),
+                relay_modal_peer(websocket, q, peer_id),
+            )
+
+
+async def relay_client(websocket: WebSocket, q: modal.Queue, peer_id: str):
+    while True:
+        try:
+            # get websocket message off queue and parse as json
+            msg = await asyncio.wait_for(websocket.receive_text(), timeout=0.5)
+            await q.put.aio(msg, partition=peer_id)
+
+        except Exception:
+            if WebSocketState.DISCONNECTED in [
+                websocket.application_state,
+                websocket.client_state,
+            ]:
+                return
+
+
+async def relay_modal_peer(websocket: WebSocket, q: modal.Queue, peer_id: str):
+    while True:
+        try:
+            # get websocket message off queue and parse from json
+            modal_peer_msg = await asyncio.wait_for(
+                q.get.aio(partition="server"), timeout=0.5
+            )
+
+            if modal_peer_msg.startswith("close"):
+                await websocket.close()
+                return
+
+            await websocket.send_text(modal_peer_msg)
+
+        except Exception:
+            if WebSocketState.DISCONNECTED in [
+                websocket.application_state,
+                websocket.client_state,
+            ]:
+                return
+
+
+class ModalWebRtcPeer(ABC):
+    """
+    Base class for WebRTC peer connections using aiortc
+    that handles connection setup, negotiation, and stream management.
+
+    This class provides the core WebRTC functionality including:
+    - Peer connection initialization and cleanup
+    - Signaling handling via `modal.Queue`
+      - SDP offer/answer exchange
+      - Trickle ICE candidate handling
+
+    Subclasses can implement the following methods:
+    - initialize(): Any custom initialization logic
+    - setup_streams(): Required logic for setting up media tracks and streams (this is where the main business logic goes)
+    - run_streams(): Logic for starting streams (not always necessary)
+    - get_turn_servers(): Logic for supplying TURN servers to client
+    - exit(): Any custom cleanup logic
+    """
+
+    @modal.enter()
+    async def _initialize(self):
+        import shortuuid
+
+        self.id = shortuuid.uuid()
+        self.pcs = {}
+        self.pending_candidates = {}
+
+        # call custom init logic
+        await self.initialize()
+
+    async def initialize(self):
+        """Override to add custom logic when creating a peer"""
+
+    @abstractmethod
+    async def setup_streams(self, peer_id):
+        """Override to add custom logic when creating a connection and setting up streams"""
+        raise NotImplementedError
+
+    async def run_streams(self, peer_id):
+        """Override to add custom logic when running streams"""
+
+    async def get_turn_servers(self, peer_id=None, msg=None) -> Optional[list]:
+        """Override to customize TURN servers"""
+
+    async def _setup_peer_connection(self, peer_id):
+        """Creates an RTC peer connection via an ICE server"""
+        from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
+
+        # aiortc automatically uses google's STUN server,
+        # but we can also specify our own
+        config = RTCConfiguration(
+            iceServers=[RTCIceServer(urls="stun:stun.l.google.com:19302")]
+        )
+        self.pcs[peer_id] = RTCPeerConnection(configuration=config)
+        self.pending_candidates[peer_id] = []
+        await self.setup_streams(peer_id)
+
+        print(f"Created peer connection and setup streams from {self.id} to {peer_id}")
+
+    @modal.method()
+    async def run_with_queue(self, queue: modal.Queue, peer_id: str):
+        """Run the RTC peer after establishing a connection by passing WebSocket messages over a Queue."""
+        print(f"Running modal peer instance for client peer {peer_id}...")
+
+        await self._connect_over_queue(queue, peer_id)
+        await self._run_streams(peer_id)
+
+    async def _connect_over_queue(self, queue, peer_id):
+        """Connect this peer to another by passing messages along a Modal Queue."""
+
+        msg_handlers = {  # message types we need to handle
+            "offer": self.handle_offer,  # SDP offer
+            "ice_candidate": self.handle_ice_candidate,  # trickled ICE candidate
+            "identify": self.get_identity,  # identify challenge
+            "get_turn_servers": self.get_turn_servers,  # TURN server request
+        }
+
+        while True:
+            try:
+                if self.pcs.get(peer_id) and (
+                    self.pcs[peer_id].connectionState
+                    in ["connected", "closed", "failed"]
+                ):
+                    await queue.put.aio("close", partition="server")
+                    break
+
+                # read and parse websocket message passed over queue
+                msg = json.loads(
+                    await asyncio.wait_for(
+                        queue.get.aio(partition=peer_id), timeout=0.5
+                    )
+                )
+
+                # dispatch the message to its handler
+                if handler := msg_handlers.get(msg.get("type")):
+                    response = await handler(peer_id, msg)
+                else:
+                    print(f"Unknown message type: {msg.get('type')}")
+                    response = None
+
+                # pass the message back over the queue to the server
+                if response is not None:
+                    await queue.put.aio(json.dumps(response), partition="server")
+
+            except Exception:
+                continue
+
+    async def _run_streams(self, peer_id):
+        """Run WebRTC streaming with a peer."""
+        print(f"Modal peer {self.id} running streams for {peer_id}...")
+
+        await self.run_streams(peer_id)
+
+        # run until connection is closed or broken
+        while self.pcs[peer_id].connectionState == "connected":
+            await asyncio.sleep(0.1)
+
+        print(f"Modal peer {self.id} ending streaming for {peer_id}")
+
+    async def handle_offer(self, peer_id, msg):
+        """Handles a peers SDP offer message by producing an SDP answer."""
+        from aiortc import RTCSessionDescription
+
+        print(f"Peer {self.id} handling SDP offer from {peer_id}...")
+
+        await self._setup_peer_connection(peer_id)
+        await self.pcs[peer_id].setRemoteDescription(
+            RTCSessionDescription(msg["sdp"], msg["type"])
+        )
+
+        answer = await self.pcs[peer_id].createAnswer()
+        await self.pcs[peer_id].setLocalDescription(answer)
+        sdp = self.pcs[peer_id].localDescription.sdp
+
+        return {"sdp": sdp, "type": answer.type, "peer_id": self.id}
+
+    async def handle_ice_candidate(self, peer_id, msg):
+        """Add an ICE candidate sent by a peer."""
+        from aiortc import RTCIceCandidate
+        from aiortc.sdp import candidate_from_sdp
+
+        candidate = msg.get("candidate")
+
+        if not candidate:
+            raise ValueError
+
+        print(
+            f"Modal peer {self.id} received ice candidate from {peer_id}: {candidate['candidate_sdp']}..."
+        )
+
+        # parse ice candidate
+        ice_candidate: RTCIceCandidate = candidate_from_sdp(candidate["candidate_sdp"])
+        ice_candidate.sdpMid = candidate["sdpMid"]
+        ice_candidate.sdpMLineIndex = candidate["sdpMLineIndex"]
+
+        if not self.pcs.get(peer_id):
+            self.pending_candidates[peer_id].append(ice_candidate)
+        else:
+            if len(self.pending_candidates[peer_id]) > 0:
+                [
+                    await self.pcs[peer_id].addIceCandidate(c)
+                    for c in self.pending_candidates[peer_id]
+                ]
+                self.pending_candidates[peer_id] = []
+            await self.pcs[peer_id].addIceCandidate(ice_candidate)
+
+    async def get_identity(self, peer_id=None, msg=None):
+        """Reply to an identify message with own id."""
+        return {"type": "identify", "peer_id": self.id}
+
+    async def generate_offer(self, peer_id):
+        print(f"Peer {self.id} generating offer for {peer_id}...")
+
+        await self._setup_peer_connection(peer_id)
+        offer = await self.pcs[peer_id].createOffer()
+        await self.pcs[peer_id].setLocalDescription(offer)
+        sdp = self.pcs[peer_id].localDescription.sdp
+
+        return {"sdp": sdp, "type": offer.type, "peer_id": self.id}
+
+    async def handle_answer(self, peer_id, answer):
+        from aiortc import RTCSessionDescription
+
+        print(f"Peer {self.id} handling answer from {peer_id}...")
+        # set remote peer description
+        await self.pcs[peer_id].setRemoteDescription(
+            RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
+        )
+
+    @modal.exit()
+    async def _exit(self):
+        print(f"Shutting down peer: {self.id}...")
+        await self.exit()
+
+        if self.pcs:
+            print(f"Closing peer connections for peer {self.id}...")
+            await asyncio.gather(*[pc.close() for pc in self.pcs.values()])
+            self.pcs = {}
+
+    async def exit(self):
+        """Override with any custom logic when shutting down container."""

--- a/07_web_endpoints/webrtc/webrtc_yolo.py
+++ b/07_web_endpoints/webrtc/webrtc_yolo.py
@@ -1,0 +1,511 @@
+# ---
+# deploy: true
+# ---
+
+# # Real-time Webcam Object Detection with WebRTC
+
+# This example combines WebRTC's peer-to-peer media streaming capabilities with Modal's efficient GPU scaling to deploy a real-time object detection app.
+
+# ## What is WebRTC?
+
+# WebRTC (Web Real-Time Communication) is a protocol and API specification for real-time media streaming between peers.
+# What makes it so effective and different from other low latency web-based communications (e.g. WebSockets) is that its stack and API are purpose built for media streaming.
+# It's primarily designed for browser applications using the Javascript API, but [APIs exist for other languages](https://www.webrtc-developers.com/did-i-choose-the-right-webrtc-stack/).
+# We'll build our app using the [Python `aiortc` library](https://aiortc.readthedocs.io/en/latest/) to run a peer in the cloud.
+
+# A simple WebRTC app generally consists of three players:
+# 1. a peer that initiates the connection
+# 2. a peer that responds to the connection, and
+# 3. a server that passes messages between the two peers.
+
+# First, the initating peer offers up a description of itself - its media sources, codec capabilities, IP information, etc - which is relayed to another peer through the server.
+# The other peer then either accepts the offer by providing a compatible description of its own capabilities or rejects it if no compatible configuration is possible.
+
+# Once the peers have agreed on a configuration there's a brief pause... and then you're live.
+
+# <figure align="middle">
+#   <img src="https://modal-cdn.com/cdnbot/just_webrtcnhhr0n2h_412df868.webp" width="95%" />
+#   <figcaption>Your basic WebRTC app.</figcaption>
+# </figure>
+
+# Obviously there’s more going on under the hood.
+# If you want to deep dive, we recommend checking out the [RFCs](https://www.rfc-editor.org/rfc/rfc8825) or a [more-thorough explainer](https://webrtcforthecurious.com/).
+# In this document, we'll focus on the Modal-specific details.
+
+# ## A stateless negotiation
+
+# Modal let's you turn your functions into GPU-powered cloud services.
+# When you call a Modal function, you get a GPU.
+# When you call 1000 Modal functions, you get 1000 GPUs.
+# When your functions return, you have 0 GPUs.
+
+# A core feature of Modal's design that makes this possible is that function calls are assumed to be independent and self-contained.
+# In other words, Modal functions are _stateless_ and they shouldn't launch other processes or tasks which continue working after the function call returns.
+
+# WebRTC apps, on the other hand, require passing messages back and forth and APIs spawn several "agents" which do work behind the scenes - including managing the P2P connection itself.
+# This means that streaming may only just have just begun when our application logic has finished.
+
+# <figure align="middle">
+#     <img src="https://modal-cdn.com/cdnbot/sequence_diagramsyt1upmqk_bdb00440.webp" width="95%" />
+#     <figcaption>Modal's stateless autoscaling (left) and WebRTC's stateful P2P negotiation (right).</figcaption>
+# </figure>
+
+# If we don't carefully reconcile this disparity, we won't be able to properly leverage Modal's auto-scaling or concurrency features, and could end up with bugs like prematurely cancelled streams.
+# For example, we can't use HTTP for signaling because each message requires a new call.
+# We also need to ensure that the cloud peer doesn't return when the negotiation finishes.
+
+# To align our WebRTC app with Modal's assumptions, it needs to meet the following requirements:
+
+# - **The client peer only makes one call to the signaling server which returns after the connection is established.**
+
+#     We'll use a WebSocket for persistant, bidirectional communication between the client peer and the signaling server running on Modal.
+# When the client detects that the P2P connection has been established, it closes the WebSocket.
+
+# - **The server only makes one call to the cloud peer which returns once the P2Pconnection has been closed.**
+
+#     To meet this requirement, the server will the call the cloud peer using Modal's [`.spawn` method](https://modal.com/docs/reference/modal.Function#spawn).
+# `spawn` doesn't block which decouples the server and cloud peer function calls.
+# We also pass a [`modal.Queue`](https://modal.com/docs/reference/modal.Queue) to the cloud peer in the spawned function call which we use to pass messages between it and the server.
+# When signaling finishes, the function we spawned goes into a loop until it detects that the P2P connection has been closed.
+
+# <figure align="middle">
+#   <img src="https://modal-cdn.com/cdnbot/modal_webrtcjngux8vw_02988d57.webp" width="95%" />
+#   <figcaption>Connecting with Modal using WebRTC.</figcaption>
+# </figure>
+
+# We wrote two classes, `ModalWebRtcPeer` and `ModalWebRtcServer`, to abstract away most of the boilerplate and ensure things happens in the correct order.
+# The server class handles signaling and the peer class handles the WebRTC/`aiortc` stuff.
+# They are also decorated with Modal [lifetime hooks](https://modal.com/docs/guide/lifecycle-functions).
+# Add the [`app.cls`](https://modal.com/docs/reference/modal.App#cls) decorator and some custom logic, and you're ready to deploy on Modal.
+
+# ## Building the app
+
+# You can find the `ModalWebRtcPeer` and `ModalWebRtcServer` classes in the `modal_webrtc.py` file provided alongside this example in the Github repo.
+
+import os
+from pathlib import Path
+
+import modal
+
+from .modal_webrtc import ModalWebRtcPeer, ModalWebRtcServer
+
+# ### Implementing the YOLO `ModalWebRtcPeer`
+
+# We're going to run YOLO in the cloud on an A100 GPU with the ONNX Runtime and TensorRT.
+# With this setup, we can achieve inference times between 2-4 milliseconds per frame and RTTs below video frame rates (usually around 30 milliseconds per frame).
+
+# #### Setting up the containers and runtime environments
+
+# We'll start with a simple [`modal.Image`](https://modal.com/docs/reference/modal.Image) and then
+# - set it up to properly use TensorRT and the ONNX Runtime,
+# - install the necessary libs for processing video, `opencv` and `ffmpeg`, and
+# - install the necessary Python packages.
+
+py_version = "3.12"
+tensorrt_ld_path = f"/usr/local/lib/python{py_version}/site-packages/tensorrt_libs"
+
+video_processing_image = (
+    modal.Image.debian_slim(python_version=py_version)  # matching ld path
+    # update locale as required by onnx
+    .apt_install("locales")
+    .run_commands(
+        "sed -i '/^#\\s*en_US.UTF-8 UTF-8/ s/^#//' /etc/locale.gen",  # uncomment w sed
+        "locale-gen en_US.UTF-8",  # set locale
+        "update-locale LANG=en_US.UTF-8",
+    )
+    .env({"LD_LIBRARY_PATH": tensorrt_ld_path, "LANG": "en_US.UTF-8"})
+    # install system dependencies
+    .apt_install("python3-opencv", "ffmpeg")
+    .pip_install(
+        "aiortc==1.11.0",
+        "fastapi==0.115.12",
+        "huggingface-hub==0.30.2",
+        "onnxruntime-gpu==1.21.0",
+        "opencv-python==4.11.0.86",
+        "tensorrt==10.9.0.34",
+        "torch==2.7.0",
+        "shortuuid==1.0.13",
+    )
+)
+
+# We also need to create an output volume to store the model weights,
+# ONNX inference graph, and other artifacts like a video file where
+# we'll write out the processed video stream for testing.
+
+# The very first time we run the app, downloading the model and building the ONNX inference graph will take a few minutes.
+# After that, the we can load the cached
+# weights and graph which reduces the startup time to about 15 seconds per container.
+
+CACHE_VOLUME = modal.Volume.from_name("webrtc-yolo-cache", create_if_missing=True)
+CACHE_PATH = Path("/cache")
+cache = {CACHE_PATH: CACHE_VOLUME}
+
+app = modal.App("example-yolo-webrtc")
+
+# Let's implement our `ModalWebRtcPeer` class to process an incoming video track with YOLO and return an annotated video track to the source peer.
+
+# To implement a `ModalWebRtcPeer`, we need to:
+# - Decorate our subclass with `@app.cls`.
+# We'll use an A100 GPU and grab some secrets from Modal (you'll see what they're for in a moment).
+# - Implement the method `setup_streams`.
+# This is where we'll use `aiortc` to add the logic for processing the incoming video track with YOLO and returning an annotated video track to the source peer.
+
+# `ModalWebRtcPeer` has a few other methods that users can optionally implement:
+# - `initialize()`: Any custom initialization logic, called when `@modal.enter()` is called
+# - `run_streams()`: Logic for starting streams. This is necessary when the peer is the source of the stream.
+# This is where you'd ensure a webcam was running or start playing a video file (see the TestPeer class)
+# - `get_turn_servers()`: We haven't talked about TURN servers yet, so for now just know that it's necessary if you want to use WebRTC behind strict NAT or firewall configurations.
+# - `exit()`: Any custom cleanup logic, called when `@modal.exit()` is called.
+
+# In our case, we'll load the YOLO model in `initialize` and also demonstrate how to provide TURN server information with `get_turn_servers`.
+# We're also going to use the `@modal.concurrent` decorator to allow multiple instances of our peer to run on one GPU.
+
+
+@app.cls(
+    image=video_processing_image,
+    gpu="A100-40GB",
+    volumes=cache,
+    secrets=[modal.Secret.from_name("turn-credentials", environment_name="examples")],
+)
+@modal.concurrent(
+    target_inputs=3,
+    max_inputs=4,
+)
+class ObjDet(ModalWebRtcPeer):
+    async def initialize(self):
+        self.yolo_model = get_yolo_model(CACHE_PATH)
+
+    async def setup_streams(self, peer_id: str):
+        from aiortc import MediaStreamTrack
+
+        # keep us notified on connection state changes
+        @self.pcs[peer_id].on("connectionstatechange")
+        async def on_connectionstatechange() -> None:
+            if self.pcs[peer_id]:
+                print(
+                    f"Video Processor, {self.id}, connection state to {peer_id}: {self.pcs[peer_id].connectionState}"
+                )
+
+        # when we receive a track from the source peer
+        # we create a processed track and add it to the peer connection
+        @self.pcs[peer_id].on("track")
+        def on_track(track: MediaStreamTrack) -> None:
+            print(
+                f"Video Processor, {self.id}, received {track.kind} track from {peer_id}"
+            )
+
+            output_track = get_yolo_track(track, self.yolo_model)  # see Addenda
+            self.pcs[peer_id].addTrack(output_track)
+
+            # keep us notified when the incoming track ends
+            @track.on("ended")
+            async def on_ended() -> None:
+                print(
+                    f"Video Processor, {self.id}, incoming video track from {peer_id} ended"
+                )
+
+    # some free turn servers we signed up forthat can handle up to 5 GB of traffic
+    # when they hit the limit they'll stop working
+    async def get_turn_servers(self, peer_id=None, msg=None) -> dict:
+        import os
+
+        creds = {
+            "username": os.environ["TURN_USERNAME"],
+            "credential": os.environ["TURN_CREDENTIAL"],
+        }
+
+        turn_servers = [
+            {"urls": "stun:stun.relay.metered.ca:80"},
+            {"urls": "turn:standard.relay.metered.ca:80"} | creds,
+            {"urls": "turn:standard.relay.metered.ca:80?transport=tcp"} | creds,
+            {"urls": "turn:standard.relay.metered.ca:443"} | creds,
+            {"urls": "turns:standard.relay.metered.ca:443?transport=tcp"} | creds,
+        ]
+
+        return {"type": "turn_servers", "ice_servers": turn_servers}
+
+
+# ### Implementing the `ModalWebRtcServer`
+
+# The `ModalWebRtcServer` class is much simpler to implement.
+# The only thing you need to do is provide the `ModalWebRtcPeer` subclass you want to use as the cloud peer.
+# It also has an `initialize()` you can optionally override which is called when `@modal.enter()` is called - like in `ModalWebRtcPeer`.
+
+# We're also going to add a frontend to the server which uses the JavaScript API to send a peer's webcam using a web browser.
+# The `ModalWebRtcServer` class has a `web_app` property which is a `fastapi.FastAPI` instance that will be handled by Modal.
+# We'll add the endpoints in the `initialize` method.
+#
+# The JavaScript and HTML files are alongside this example in the Github repo.
+
+base_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("python3-opencv", "ffmpeg")
+    .pip_install(
+        "fastapi[standard]==0.115.4",
+        "aiortc==1.11.0",
+        "opencv-python==4.11.0.86",
+        "shortuuid==1.0.13",
+    )
+)  # we'll resuse this base image for the testing peer
+
+assets_parent_directory = Path(__file__).parent.resolve()
+
+server_image = base_image.add_local_dir(
+    os.path.join(assets_parent_directory, "frontend"), remote_path="/frontend"
+)
+
+
+@app.cls(image=server_image)
+class WebcamObjDet(ModalWebRtcServer):
+    modal_peer_cls = ObjDet  # <---- setting the cloud peer
+
+    def initialize(self):
+        from fastapi.responses import HTMLResponse
+        from fastapi.staticfiles import StaticFiles
+
+        self.web_app.mount("/static", StaticFiles(directory="/frontend"))
+
+        @self.web_app.get("/")
+        async def root():
+            html = open("/frontend/index.html").read()
+            return HTMLResponse(content=html)
+
+
+# ### YOLO helper functions
+
+# You'll need these two functions to get the app to run.
+
+# The first, `get_yolo_model` sets up the ONNXRuntime and loads the model weights.
+# We call this in the `initialize` method of the `ModalWebRtcPeer` class
+# so it only happens once per container (i.e. when `@modal.enter()` methods are called).
+
+
+def get_yolo_model(cache_path):
+    import onnxruntime
+
+    from .yolo import YOLOv10
+
+    onnxruntime.preload_dlls()
+    return YOLOv10(cache_path)
+
+
+# The second, `get_yolo_track` creates a custom `MediaStreamTrack` that performs object detection on the video stream.
+#
+# We call this in the `setup_streams` method of the `ModalWebRtcPeer` class
+# so it happens once per peer connection.
+
+
+def get_yolo_track(track, yolo_model=None):
+    import numpy as np
+    import onnxruntime
+    from aiortc import MediaStreamTrack
+    from aiortc.contrib.media import VideoFrame
+
+    from .yolo import YOLOv10
+
+    class YOLOTrack(MediaStreamTrack):
+        """
+        Custom media stream track performs object detection
+        on the video stream and passes it back to the source peer
+        """
+
+        kind: str = "video"
+        conf_threshold: float = 0.15
+
+        def __init__(self, track: MediaStreamTrack, yolo_model=None) -> None:
+            super().__init__()
+
+            self.track = track
+            if yolo_model is None:
+                onnxruntime.preload_dlls()
+                self.yolo_model = YOLOv10(CACHE_PATH)
+            else:
+                self.yolo_model = yolo_model
+
+        def detection(self, image: np.ndarray) -> np.ndarray:
+            import cv2
+
+            orig_shape = image.shape[:-1]
+
+            image = cv2.resize(
+                image,
+                (self.yolo_model.input_width, self.yolo_model.input_height),
+            )
+
+            image = self.yolo_model.detect_objects(image, self.conf_threshold)
+
+            image = cv2.resize(image, (orig_shape[1], orig_shape[0]))
+
+            return image
+
+        # this is the essential method we need to implement
+        # to create a custom MediaStreamTrack
+        async def recv(self) -> VideoFrame:
+            frame = await self.track.recv()
+            img = frame.to_ndarray(format="bgr24")
+
+            processed_img = self.detection(img)
+
+            # VideoFrames are from a really nice package called av
+            # which is a pythonic wrapper around ffmpeg
+            # and a dependency of aiortc
+            new_frame = VideoFrame.from_ndarray(processed_img, format="bgr24")
+            new_frame.pts = frame.pts
+            new_frame.time_base = frame.time_base
+
+            return new_frame
+
+    return YOLOTrack(track)
+
+
+# ## Testing
+
+# First we define a `local_entrypoint` to run and evaluate the test.
+# Our test will stream an .mp4 file to the cloud peer and record the annoated video to a new file.
+# The test itself ensurse that the new video is no more than five frames shorter than the source file.
+# The difference is due to dropped frames while the connection is starting up.
+
+
+@app.local_entrypoint()
+def test():
+    input_frames, output_frames = TestPeer().run_video_processing_test.remote()
+    # allow a few dropped frames from the connection starting up
+    assert input_frames - output_frames < 5, "Streaming failed"
+
+
+# Because our test will require Python dependencies outside the standard library, we'll run the test itself in a container on Modal.
+# In fact, this will be another `ModalWebRtcPeer` class. So the test will also demonstrate how to setup WebRTC between Modal containers.
+# There are some details in here regarding the use of `aiortc`'s `MediaPlayer` and `MediaRecorder` classes that won't cover here.
+# Just know that these are `aiortc` specific classes - not a WebRTC thing.
+
+# That said, using these classes does require us to manually `start` and `stop` streams.
+# For example, we'll need to override the `run_streams` method to start the source stream, and we'll make use of the `on_ended` callback to stop the recording.
+
+
+@app.cls(image=base_image, volumes=cache)
+class TestPeer(ModalWebRtcPeer):
+    TEST_VIDEO_SOURCE_URL = "https://modal-cdn.com/cliff_jumping.mp4"
+    TEST_VIDEO_RECORD_FILE = CACHE_PATH / "test_video.mp4"
+    # extra time to run streams beyond input video duration
+    VIDEO_DURATION_BUFFER_SECS = 5.0
+    # allow time for container to spin up (can timeout with default 10)
+    WS_OPEN_TIMEOUT = 30
+
+    async def initialize(self) -> None:
+        import cv2
+
+        # get input video duration in seconds
+        self.input_video = cv2.VideoCapture(self.TEST_VIDEO_SOURCE_URL)
+        self.input_video_duration_frames = self.input_video.get(
+            cv2.CAP_PROP_FRAME_COUNT
+        )
+        self.input_video_duration_seconds = (
+            self.input_video_duration_frames / self.input_video.get(cv2.CAP_PROP_FPS)
+        )
+        self.input_video.release()
+
+        # set streaming duration to input video duration plus a buffer
+        self.stream_duration = (
+            self.input_video_duration_seconds + self.VIDEO_DURATION_BUFFER_SECS
+        )
+
+        self.player = None  # video stream source
+        self.recorder = None  # processed video stream sink
+
+    async def setup_streams(self, peer_id: str) -> None:
+        from aiortc import MediaStreamTrack
+        from aiortc.contrib.media import MediaPlayer, MediaRecorder
+
+        # setup video player and to peer connection
+        self.video_src = MediaPlayer(self.TEST_VIDEO_SOURCE_URL)
+        self.pcs[peer_id].addTrack(self.video_src.video)
+
+        # setup video recorder
+        if os.path.exists(self.TEST_VIDEO_RECORD_FILE):
+            os.remove(self.TEST_VIDEO_RECORD_FILE)
+        self.recorder = MediaRecorder(self.TEST_VIDEO_RECORD_FILE)
+
+        # keep us notified on connection state changes
+        @self.pcs[peer_id].on("connectionstatechange")
+        async def on_connectionstatechange() -> None:
+            print(
+                f"Video Tester connection state updated: {self.pcs[peer_id].connectionState}"
+            )
+
+        # when we receive a track back from
+        # the video processing peer we record it
+        # to the output file
+        @self.pcs[peer_id].on("track")
+        def on_track(track: MediaStreamTrack) -> None:
+            print(f"Video Tester received {track.kind} track from {peer_id}")
+            # record track to file
+            self.recorder.addTrack(track)
+
+            @track.on("ended")
+            async def on_ended() -> None:
+                print("Video Tester's processed video stream ended")
+                # stop recording when incoming track ends to finish writing video
+                await self.recorder.stop()
+                # reset recorder and player
+                self.recorder = None
+                self.video_src = None
+
+    async def run_streams(self, peer_id: str) -> None:
+        import asyncio
+
+        print(f"Video Tester running streams for {peer_id}...")
+
+        # MediaRecorders need to be started manually
+        # but in most cases the track is already streaming
+        await self.recorder.start()
+
+        # run until sufficient time has passed
+        await asyncio.sleep(self.stream_duration)
+
+        # close peer connection manually
+        await self.pcs[peer_id].close()
+
+    def count_frames(self):
+        import cv2
+
+        # compare output video length to input video length
+        output_video = cv2.VideoCapture(self.TEST_VIDEO_RECORD_FILE)
+        output_video_duration_frames = int(output_video.get(cv2.CAP_PROP_FRAME_COUNT))
+        output_video.release()
+
+        return self.input_video_duration_frames, output_video_duration_frames
+
+    @modal.method()
+    async def run_video_processing_test(self) -> bool:
+        import json
+
+        import websockets
+
+        peer_id = None
+        # connect to server via websocket
+        ws_uri = WebcamObjDet().web.web_url.replace("http", "ws") + f"/ws/{self.id}"
+        print(f"ws_uri: {ws_uri}")
+        async with websockets.connect(
+            ws_uri, open_timeout=self.WS_OPEN_TIMEOUT
+        ) as websocket:
+            await websocket.send(json.dumps({"type": "identify", "peer_id": self.id}))
+            peer_id = json.loads(await websocket.recv())["peer_id"]
+
+            offer_msg = await self.generate_offer(peer_id)
+            await websocket.send(json.dumps(offer_msg))
+
+            try:
+                # receive answer
+                answer = json.loads(await websocket.recv())
+
+                if answer.get("type") == "answer":
+                    await self.handle_answer(peer_id, answer)
+
+            except websockets.exceptions.ConnectionClosed:
+                await websocket.close()
+
+        # loop until video player is finished
+        if peer_id:
+            await self.run_streams(peer_id)
+
+        return self.count_frames()

--- a/07_web_endpoints/webrtc/yolo/__init__.py
+++ b/07_web_endpoints/webrtc/yolo/__init__.py
@@ -1,0 +1,1 @@
+from .yolo import YOLOv10 as YOLOv10

--- a/07_web_endpoints/webrtc/yolo/yolo.py
+++ b/07_web_endpoints/webrtc/yolo/yolo.py
@@ -1,0 +1,212 @@
+# ---
+# lambda-test: false
+# ---
+from pathlib import Path
+
+import cv2
+import numpy as np
+import onnxruntime
+
+this_dir = Path(__file__).parent.resolve()
+
+
+class YOLOv10:
+    def __init__(self, cache_dir):
+        from huggingface_hub import hf_hub_download
+
+        # Initialize model
+        self.cache_dir = cache_dir
+        print(f"Initializing YOLO model from {self.cache_dir}")
+        model_file = hf_hub_download(
+            repo_id="onnx-community/yolov10n",
+            filename="onnx/model.onnx",
+            cache_dir=self.cache_dir,
+        )
+        self.initialize_model(model_file)
+        print("YOLO model initialized")
+
+    def initialize_model(self, model_file):
+        self.session = onnxruntime.InferenceSession(
+            model_file,
+            providers=[
+                (
+                    "TensorrtExecutionProvider",
+                    {
+                        "trt_engine_cache_enable": True,
+                        "trt_engine_cache_path": self.cache_dir / "onnx.cache",
+                    },
+                ),
+                "CUDAExecutionProvider",
+            ],
+        )
+        # Get model info
+        self.get_input_details()
+        self.get_output_details()
+
+        # get class names
+        with open(this_dir / "yolo_classes.txt", "r") as f:
+            self.class_names = f.read().splitlines()
+        rng = np.random.default_rng(3)
+        self.colors = rng.uniform(0, 255, size=(len(self.class_names), 3))
+
+    def detect_objects(self, image, conf_threshold=0.3):
+        input_tensor = self.prepare_input(image)
+
+        # Perform inference on the image
+        new_image = self.inference(image, input_tensor, conf_threshold)
+
+        return new_image
+
+    def prepare_input(self, image):
+        self.img_height, self.img_width = image.shape[:2]
+
+        input_img = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+        # Resize input image
+        input_img = cv2.resize(input_img, (self.input_width, self.input_height))
+
+        # Scale input pixel values to 0 to 1
+        input_img = input_img / 255.0
+        input_img = input_img.transpose(2, 0, 1)
+        input_tensor = input_img[np.newaxis, :, :, :].astype(np.float32)
+
+        return input_tensor
+
+    def inference(self, image, input_tensor, conf_threshold=0.3):
+        # set seed to potentially create smoother output in RT setting
+        onnxruntime.set_seed(42)
+        # start = time.perf_counter()
+        outputs = self.session.run(
+            self.output_names, {self.input_names[0]: input_tensor}
+        )
+
+        # print(f"Inference time: {(time.perf_counter() - start) * 1000:.2f} ms")
+        (
+            boxes,
+            scores,
+            class_ids,
+        ) = self.process_output(outputs, conf_threshold)
+        return self.draw_detections(image, boxes, scores, class_ids)
+
+    def process_output(self, output, conf_threshold=0.3):
+        predictions = np.squeeze(output[0])
+
+        # Filter out object confidence scores below threshold
+        scores = predictions[:, 4]
+        predictions = predictions[scores > conf_threshold, :]
+        scores = scores[scores > conf_threshold]
+
+        if len(scores) == 0:
+            return [], [], []
+
+        # Get the class with the highest confidence
+        class_ids = predictions[:, 5].astype(int)
+
+        # Get bounding boxes for each object
+        boxes = self.extract_boxes(predictions)
+
+        return boxes, scores, class_ids
+
+    def extract_boxes(self, predictions):
+        # Extract boxes from predictions
+        boxes = predictions[:, :4]
+
+        # Scale boxes to original image dimensions
+        boxes = self.rescale_boxes(boxes)
+
+        # Convert boxes to xyxy format
+        # boxes = xywh2xyxy(boxes)
+
+        return boxes
+
+    def rescale_boxes(self, boxes):
+        # Rescale boxes to original image dimensions
+        input_shape = np.array(
+            [
+                self.input_width,
+                self.input_height,
+                self.input_width,
+                self.input_height,
+            ]
+        )
+        boxes = np.divide(boxes, input_shape, dtype=np.float32)
+        boxes *= np.array(
+            [self.img_width, self.img_height, self.img_width, self.img_height]
+        )
+        return boxes
+
+    def draw_detections(
+        self, image, boxes, scores, class_ids, draw_scores=True, mask_alpha=0.4
+    ):
+        det_img = image.copy()
+
+        img_height, img_width = image.shape[:2]
+        font_size = min([img_height, img_width]) * 0.0012
+        text_thickness = int(min([img_height, img_width]) * 0.004)
+
+        # Draw bounding boxes and labels of detections
+        for class_id, box, score in zip(class_ids, boxes, scores):
+            color = self.colors[class_id]
+
+            self.draw_box(det_img, box, color)  # type: ignore
+
+            label = self.class_names[class_id]
+            caption = f"{label} {int(score * 100)}%"
+            self.draw_text(det_img, caption, box, color, font_size, text_thickness)  # type: ignore
+
+        return det_img
+
+    def get_input_details(self):
+        model_inputs = self.session.get_inputs()
+        self.input_names = [model_inputs[i].name for i in range(len(model_inputs))]
+
+        self.input_shape = model_inputs[0].shape
+        self.input_height = self.input_shape[2]
+        self.input_width = self.input_shape[3]
+
+    def get_output_details(self):
+        model_outputs = self.session.get_outputs()
+        self.output_names = [model_outputs[i].name for i in range(len(model_outputs))]
+
+    def draw_box(
+        self,
+        image: np.ndarray,
+        box: np.ndarray,
+        color: tuple[int, int, int] = (0, 0, 255),
+        thickness: int = 5,
+    ) -> np.ndarray:
+        x1, y1, x2, y2 = box.astype(int)
+        return cv2.rectangle(image, (x1, y1), (x2, y2), color, thickness)
+
+    def draw_text(
+        self,
+        image: np.ndarray,
+        text: str,
+        box: np.ndarray,
+        color: tuple[int, int, int] = (0, 0, 255),
+        font_size: float = 0.100,
+        text_thickness: int = 5,
+        box_thickness: int = 5,
+    ) -> np.ndarray:
+        x1, y1, x2, y2 = box.astype(int)
+        (tw, th), _ = cv2.getTextSize(
+            text=text,
+            fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+            fontScale=font_size,
+            thickness=text_thickness,
+        )
+        x1 = x1 - box_thickness
+        th = int(th * 1.2)
+
+        cv2.rectangle(image, (x1, y1), (x1 + tw, y1 - th), color, -1)
+
+        return cv2.putText(
+            image,
+            text,
+            (x1, y1),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            font_size,
+            (255, 255, 255),
+            text_thickness,
+            cv2.LINE_AA,
+        )

--- a/07_web_endpoints/webrtc/yolo/yolo_classes.txt
+++ b/07_web_endpoints/webrtc/yolo/yolo_classes.txt
@@ -1,0 +1,80 @@
+person
+bicycle
+car
+motorcycle
+airplane
+bus
+train
+truck
+boat
+traffic light
+fire hydrant
+stop sign
+parking meter
+bench
+bird
+cat
+dog
+horse
+sheep
+cow
+elephant
+bear
+zebra
+giraffe
+backpack
+umbrella
+handbag
+tie
+suitcase
+frisbee
+skis
+snowboard
+sports ball
+kite
+baseball bat
+baseball glove
+skateboard
+surfboard
+tennis racket
+bottle
+wine glass
+cup
+fork
+knife
+spoon
+bowl
+banana
+apple
+sandwich
+orange
+broccoli
+carrot
+hot dog
+pizza
+donut
+cake
+chair
+couch
+potted plant
+bed
+dining table
+toilet
+tv
+laptop
+mouse
+remote
+keyboard
+cell phone
+microwave
+oven
+toaster
+sink
+refrigerator
+book
+clock
+vase
+scissors
+teddy bear
+hair drier
+toothbrush

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -168,4 +168,4 @@ def get_examples_json():
 
 if __name__ == "__main__":
     for example in get_examples():
-        print(example.json())
+        print(example.model_dump_json())


### PR DESCRIPTION
Summary
Our "low-level" WebRTC example that relies only on aiortc. The app lets a user stream their webcam and run YOLO in the cloud in "real time."

We wrote two base classes to abstract away a lot of the complexity: ModalWebRtcPeer and ModalWebRtcServer. A client can connect to a Modal peer in Python by implementing their own ModalWebRtcPeer or by connecting to the server over a WebSocket endpoint and using the Javascript WebRTC API.

This example required a bit more exposition than most - and even then we removed a more detailed review of WebRTC itself. We could consider bringing this back as a blog post.

STUN and TURN servers
Modal containers seem happy to use Google's STUN servers. Clients may need to use a TURN server. @shababo signed up for a free one (shuts off at 5 GB). If you want to try switching between the two, you can deploy the app and hit the frontend.

Pipecat
We are considering updating this example to use Pipecat's open source [SmallWebRTCTransport](https://docs.pipecat.ai/server/services/transport/small-webrtc) which is a more mature wrapper around aiortc than our classes. It's possible there are blockers or something we misunderstood, but otherwise it seems like a good idea.

Javascript
The Javascript API logic is in its own .js file. Ngl, this was heavily gen AI. Would be worth getting more experienced eyes on this.

### Type of Change

- [x] New example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter (`---`)
  - [x] Example is tested by executing with `modal run` or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "deploy"]`)
  - [x] Example is tested by running with no arguments or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally, except `fastapi`
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside contributors

You're great! Thanks for your contribution.
