### PR TITLE
resolve or document monitoring opt-outs

### DIFF
--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # missing-secret
 # ---
 
 # # Run cron jobs in the cloud to search Hacker News

--- a/06_gpu_and_ml/llm-structured/jsonformer_generate.py
+++ b/06_gpu_and_ml/llm-structured/jsonformer_generate.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # deprecated
 # ---
 # # Structured output generation with Jsonformer
 #

--- a/06_gpu_and_ml/stable_diffusion/a1111_webui.py
+++ b/06_gpu_and_ml/stable_diffusion/a1111_webui.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # deprecated
 # ---
 # # Stable Diffusion (A1111)
 #

--- a/07_web_endpoints/fastapi_app.py
+++ b/07_web_endpoints/fastapi_app.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# cmd: ["modal", "serve", "07_web_endpoints/fastapi_app.py"]
 # ---
 
 # # Deploy FastAPI app with Modal

--- a/07_web_endpoints/fasthtml-checkboxes/cbx_locustfile.py
+++ b/07_web_endpoints/fasthtml-checkboxes/cbx_locustfile.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # auxiliary-file
 # pytest: false
 # ---
 import random

--- a/07_web_endpoints/fasthtml-checkboxes/constants.py
+++ b/07_web_endpoints/fasthtml-checkboxes/constants.py
@@ -1,4 +1,4 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # auxiliary-file
 # ---
 N_CHECKBOXES = 100_000  # feel free to increase, if you dare!

--- a/07_web_endpoints/fastrtc_flip_webcam.py
+++ b/07_web_endpoints/fastrtc_flip_webcam.py
@@ -1,6 +1,5 @@
 # ---
-# deploy: true
-# lambda-test: false
+# cmd: ["modal", "serve", "07_web_endpoints/fastrtc_flip_webcam.py"]
 # ---
 
 # # Run a FastRTC app on Modal

--- a/07_web_endpoints/flask_app.py
+++ b/07_web_endpoints/flask_app.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# cmd: ["modal", "serve", "07_web_endpoints/flask_app.py"]
 # ---
 
 # # Deploy Flask app with Modal

--- a/08_advanced/poll_delayed_result.py
+++ b/08_advanced/poll_delayed_result.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# cmd: ["modal", "serve", "08_advanced/poll_delayed_result.py"]
 # ---
 
 # # Polling for a delayed result on Modal

--- a/10_integrations/multion_news_agent.py
+++ b/10_integrations/multion_news_agent.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # missing-secret
 # ---
 
 # # MultiOn: Twitter News Agent

--- a/10_integrations/streamlit/app.py
+++ b/10_integrations/streamlit/app.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # auxiliary-file
 # ---
 # ## Demo Streamlit application.
 #

--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # missing-secret
 # ---
 
 # # Add Modal Apps to Tailscale

--- a/12_datasets/coco.py
+++ b/12_datasets/coco.py
@@ -1,6 +1,5 @@
 # ---
-# deploy: true
-# lambda-test: false
+# lambda-test: false  # long-running
 # ---
 #
 # This script demonstrates ingestion of the [COCO](https://cocodataset.org/#download) (Common Objects in Context)

--- a/12_datasets/imagenet.py
+++ b/12_datasets/imagenet.py
@@ -1,6 +1,5 @@
 # ---
-# deploy: true
-# lambda-test: false
+# lambda-test: false  # long-running
 # ---
 #
 # This scripts demonstrates how to ingest the famous ImageNet (https://www.image-net.org/)

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -1,6 +1,6 @@
 # ---
-# deploy: true
-# lambda-test: false
+# lambda-test: false  # long-running
+
 # ---
 #
 # https://laion.ai/blog/laion-400-open-dataset/

--- a/12_datasets/laion400.py
+++ b/12_datasets/laion400.py
@@ -1,6 +1,5 @@
 # ---
 # lambda-test: false  # long-running
-
 # ---
 #
 # https://laion.ai/blog/laion-400-open-dataset/

--- a/12_datasets/rosettafold.py
+++ b/12_datasets/rosettafold.py
@@ -1,6 +1,5 @@
 # ---
-# deploy: true
-# lambda-test: false
+# lambda-test: false  # long-running
 # ---
 #
 # This script demonstrated how to ingest the https://github.com/RosettaCommons/RoseTTAFold protein-folding

--- a/14_clusters/simple_torch_cluster_script.py
+++ b/14_clusters/simple_torch_cluster_script.py
@@ -1,5 +1,5 @@
 # ---
-# lambda-test: false
+# lambda-test: false  # auxiliary-file
 # pytest: false
 # ---
 import argparse

--- a/misc/hello_shebang.py
+++ b/misc/hello_shebang.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-# ---
-# lambda-test: false
-# ---
-
 # # Syntax for making modal scripts executable
 
 # This example shows how you can add a shebang to a script that is meant to be invoked with `modal run`.

--- a/misc/say_hello_cron.py
+++ b/misc/say_hello_cron.py
@@ -1,7 +1,3 @@
-# ---
-# lambda-test: false
-# ---
-
 # # Deploy a cron job with Modal
 
 # This example shows how you can deploy a cron job with Modal.


### PR DESCRIPTION
Removes or documents all of the monitoring opt-outs. Those I fixed are very old opt-outs from when we couldn't do as much.

I used the following slugs to document reasons in YAML comments:
- `auxiliary-file`: this is an auxiliary Python file that's part of an example but not a monitored unit in its own right, like a script to be run from a Modal Function. This is the only good reason to skip monitoring, but it should still be used sparingly. A self-contained, self-documented application is a beautiful thing!
- `long-running`: this example runs for too long. These are all in `12_datasets`. We should rethink these examples in light of notebooks, cc @thundergolfer.
-  `deprecated`: this example should be removed. They're waiting on the deployment of a PR to `modal` [here](https://github.com/modal-labs/modal/pull/22917)
- `missing-secret`: this example uses a Secret that was deleted. These examples should be resuscitated or removed.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)
