### PR TITLE
Replacing `requests` with `urllib` in comfy and ocr jobs examples

### DIFF
--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -170,9 +170,8 @@ def parse_receipt(image: bytes) -> str:
 
 @app.local_entrypoint()
 def main(receipt_filename: Optional[str] = None):
+    import urllib.request
     from pathlib import Path
-
-    import requests
 
     if receipt_filename is None:
         receipt_filename = Path(__file__).parent / "receipt.png"
@@ -183,9 +182,9 @@ def main(receipt_filename: Optional[str] = None):
         image = receipt_filename.read_bytes()
         print(f"running OCR on {receipt_filename}")
     else:
-        receipt_url = (
-            "https://nwlc.org/wp-content/uploads/2022/01/Brandys-walmart-receipt-8.webp"
-        )
-        image = requests.get(receipt_url).content
+        receipt_url = "https://modal-cdn.com/cdnbot/Brandys-walmart-receipt-8g68_a_hk_f9c25fce.webp"
+        request = urllib.request.Request(receipt_url)
+        with urllib.request.urlopen(request) as response:
+            image = response.read()
         print(f"running OCR on sample from URL {receipt_url}")
     print(parse_receipt.remote(image))


### PR DESCRIPTION
The comfyUI and OCR jobs examples both used `requests` in the local scope. Replacing with `urllib` equivalent to remove `requests` as a third-party dependency.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [x] Example updates (Bug fixes, new features, etc.)
