### PR TITLE
Adds Chatterbox TTS example

### DIFF
--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -15,6 +15,7 @@
 # Import the necessary modules for Modal deployment and TTS functionality.
 
 import io
+
 import modal
 
 # ## Define a container image
@@ -34,7 +35,6 @@ app = modal.App("chatterbox-api-example", image=image)
 with image.imports():
     import torchaudio as ta
     from chatterbox.tts import ChatterboxTTS
-    from fastapi import FastAPI
     from fastapi.responses import StreamingResponse
 
 # ## The TTS model class

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -1,0 +1,87 @@
+# # Create a Chatterbox TTS API on Modal
+
+# This example demonstrates how to deploy a text-to-speech (TTS) API using the Chatterbox TTS model on Modal.
+# The API accepts text prompts and returns generated audio as WAV files through a FastAPI endpoint.
+# We use Modal's class-based approach with GPU acceleration to provide fast, scalable TTS inference.
+
+# ## Setup
+
+# Import the necessary modules for Modal deployment and TTS functionality.
+
+import io
+import modal
+
+# ## Define a container image
+
+# We start with Modal's baseline `debian_slim` image and install the required packages.
+# - `chatterbox-tts`: The TTS model library
+# - `fastapi`: Web framework for creating the API endpoint
+
+image = modal.Image.debian_slim().pip_install("chatterbox-tts==0.1.1", "fastapi[standard]")
+app = modal.App("chatterbox-api-example", image=image)
+
+# Import the required libraries within the image context to ensure they're available
+# when the container runs. This includes audio processing and the TTS model itself.
+
+with image.imports():
+    import torchaudio as ta
+    from chatterbox.tts import ChatterboxTTS
+    from fastapi import FastAPI
+    from fastapi.responses import StreamingResponse
+
+# ## The TTS model class
+
+# The TTS service is implemented using Modal's class syntax with GPU acceleration.
+# We configure the class to use an A10G GPU with additional parameters:
+# #
+# - `scaledown_window=60 * 5`: Keep containers alive for 5 minutes after last request
+# - `enable_memory_snapshot=True`: Enable [memory snapshots](https://modal.com/docs/guide/memory-snapshot) to optimize cold boot times
+# - `@modal.concurrent(max_inputs=10)`: Allow up to 10 concurrent requests per container
+
+@app.cls(gpu="a10g", scaledown_window=60 * 5, enable_memory_snapshot=True)
+@modal.concurrent(max_inputs=10)
+class Chatterbox:
+    @modal.enter()
+    def load(self):
+        self.model = ChatterboxTTS.from_pretrained(device="cuda")
+
+    @modal.fastapi_endpoint(docs=True, method="POST")
+    def generate(self, prompt: str):
+        # Generate audio waveform from the input text
+        wav = self.model.generate(prompt)
+
+        # Create an in-memory buffer to store the WAV file
+        buffer = io.BytesIO()
+
+        # Save the generated audio to the buffer in WAV format
+        # Uses the model's sample rate and WAV format
+        ta.save(buffer, wav, self.model.sr, format="wav")
+
+        # Reset buffer position to the beginning for reading
+        buffer.seek(0)
+
+        # Return the audio as a streaming response with appropriate MIME type.
+        # This allows for browsers to playback audio directly.
+        return StreamingResponse(
+            io.BytesIO(buffer.read()),
+            media_type="audio/wav",
+        )
+
+# Now deploy the Chatterbox API with:
+#
+# ```shell
+# modal deploy chatterbox_tts.py
+# ```
+#
+# And query the endpoint with:
+#
+# ```shell
+# curl -X POST --get "https://modal-labs-luis-dev--chatterbox-api-example-chatterbox-generate.modal.run" \
+#   --data-urlencode "prompt=Chatterbox running on Modal"
+#   --output output.wav
+# ```
+#
+# You'll receive a WAV file named `output.wav` containing the generated audio.
+#
+# This app takes about 30 seconds to cold boot, mostly dominated by loading
+# the Chatterbox model into GPU memory. It takes 2-3s to generate a 5s audio clip.

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -1,6 +1,7 @@
 # ---
 # output-directory: "/tmp/chatterbox-tts"
 # lambda-test: false
+# cmd: ["modal", "serve", "06_gpu_and_ml/test-to-audio/chatterbox_tts.py"]
 # ---
 
 
@@ -87,7 +88,8 @@ class Chatterbox:
 #
 # ```shell
 # mkdir -p /tmp/chatterbox-tts  # create tmp directory
-# curl -X POST --get "https://modal-labs-luis-dev--chatterbox-api-example-chatterbox-generate.modal.run" \
+#
+# curl -X POST --get "<YOUR-ENDPOINT-URL>" \
 #   --data-urlencode "prompt=Chatterbox running on Modal"
 #   --output /tmp/chatterbox-tts/output.wav
 # ```

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -1,5 +1,6 @@
 # ---
 # output-directory: "/tmp/chatterbox-tts"
+# lambda-test: false
 # ---
 
 
@@ -22,7 +23,7 @@ import modal
 # - `chatterbox-tts`: The TTS model library
 # - `fastapi`: Web framework for creating the API endpoint
 
-image = modal.Image.debian_slim().pip_install("chatterbox-tts==0.1.1", "fastapi[standard]")
+image = modal.Image.debian_slim(python_version="3.12").pip_install("chatterbox-tts==0.1.1", "fastapi[standard]")
 app = modal.App("chatterbox-api-example", image=image)
 
 # Import the required libraries within the image context to ensure they're available

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -23,7 +23,9 @@ import modal
 # - `chatterbox-tts`: The TTS model library
 # - `fastapi`: Web framework for creating the API endpoint
 
-image = modal.Image.debian_slim(python_version="3.12").pip_install("chatterbox-tts==0.1.1", "fastapi[standard]")
+image = modal.Image.debian_slim(python_version="3.12").pip_install(
+    "chatterbox-tts==0.1.1", "fastapi[standard]"
+)
 app = modal.App("chatterbox-api-example", image=image)
 
 # Import the required libraries within the image context to ensure they're available
@@ -43,6 +45,7 @@ with image.imports():
 # - `scaledown_window=60 * 5`: Keep containers alive for 5 minutes after last request
 # - `enable_memory_snapshot=True`: Enable [memory snapshots](https://modal.com/docs/guide/memory-snapshot) to optimize cold boot times
 # - `@modal.concurrent(max_inputs=10)`: Allow up to 10 concurrent requests per container
+
 
 @app.cls(gpu="a10g", scaledown_window=60 * 5, enable_memory_snapshot=True)
 @modal.concurrent(max_inputs=10)
@@ -72,6 +75,7 @@ class Chatterbox:
             io.BytesIO(buffer.read()),
             media_type="audio/wav",
         )
+
 
 # Now deploy the Chatterbox API with:
 #

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -87,7 +87,7 @@ class Chatterbox:
 #   --output /tmp/chatterbox-tts/output.wav
 # ```
 #
-# You'll receive a WAV file named `output.wav` containing the generated audio.
+# You'll receive a WAV file named `/tmp/chatterbox-tts/output.wav` containing the generated audio.
 #
 # This app takes about 30 seconds to cold boot, mostly dominated by loading
 # the Chatterbox model into GPU memory. It takes 2-3s to generate a 5s audio clip.

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -1,3 +1,8 @@
+# ---
+# output-directory: "/tmp/chatterbox-tts"
+# ---
+
+
 # # Create a Chatterbox TTS API on Modal
 
 # This example demonstrates how to deploy a text-to-speech (TTS) API using the Chatterbox TTS model on Modal.
@@ -76,9 +81,10 @@ class Chatterbox:
 # And query the endpoint with:
 #
 # ```shell
+# mkdir -p /tmp/chatterbox-tts  # create tmp directory
 # curl -X POST --get "https://modal-labs-luis-dev--chatterbox-api-example-chatterbox-generate.modal.run" \
 #   --data-urlencode "prompt=Chatterbox running on Modal"
-#   --output output.wav
+#   --output /tmp/chatterbox-tts/output.wav
 # ```
 #
 # You'll receive a WAV file named `output.wav` containing the generated audio.


### PR DESCRIPTION
Adds simple web endpoint example for running [Chatterbox TTS](https://github.com/resemble-ai/chatterbox) on Modal. I couldn't find a TTS example and Chatterbox was just released, is small, is fast, and has a simple client interface.

## Type of Change

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


