### PR TITLE
Flash attn

### DIFF
--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -1,22 +1,19 @@
-# ---
-# cmd: ["modal", "run", "02_building_containers/install_flash_attn.py::main"]
-# ---
-
 # # Install Flash Attention on Modal
+
 # FlashAttention is an optimized CUDA library for Transformer
 # scaled-dot-product attention. Dao AI Lab now publishes pre-compiled
 # wheels, which makes installation quick.  This script shows how to
-#
 # 1. Pin an exact wheel that matches CUDA 12 / PyTorch 2.6 / Python 3.13.
 # 2. Build a Modal image that installs torch, numpy, and FlashAttention.
 # 3. Launch a GPU function to confirm the kernel runs on a GPU.
-#
+
 import modal
 
 app = modal.App("example-install-flash-attn")
 
-# Here we specify an exact release wheel. You can find
-# (more on their github)[https://github.com/Dao-AILab/flash-attention/releases].
+# You need to specify an exact release wheel. You can find
+# [more on their github](https://github.com/Dao-AILab/flash-attention/releases).
+
 flash_attn_release = (
     "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/"
     "flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp313-cp313-linux_x86_64.whl"
@@ -28,6 +25,8 @@ image = modal.Image.debian_slim(python_version="3.13").pip_install(
 
 
 # And here is a demo verifying that it works:
+
+
 @app.function(gpu="L40S", image=image)
 def run_flash_attn():
     import torch
@@ -45,8 +44,3 @@ def run_flash_attn():
 
     out = flash_attn_func(q, k, v)
     assert out.shape == (batch_size, seqlen, nheads, headdim)
-
-
-@app.local_entrypoint()
-def main():
-    run_flash_attn.remote()

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -1,8 +1,23 @@
+# ---
+# cmd: ["modal", "run", "02_building_containers/install_flash_attn.py::main"]
+# ---
+
+# # Install Flash Attention on Modal
+# FlashAttention is an optimized CUDA library for Transformer
+# scaled-dot-product attention. Dao AI Lab now publishes pre-compiled
+# wheels, which makes installation quick.  This script shows how to
+#
+# 1. Pin an exact wheel that matches CUDA 12 / PyTorch 2.6 / Python 3.13.
+# 2. Build a Modal image that installs torch, numpy, and FlashAttention.
+# 3. Launch a GPU function to confirm the kernel runs on a GPU.
+#
 import modal
 
 app = modal.App("example-install-flash-attn")
 
-flash_attn_release = (  # find releases at https://github.com/Dao-AILab/flash-attention/releases
+# Here we specify an exact release wheel. You can find
+# (more on their github)[https://github.com/Dao-AILab/flash-attention/releases].
+flash_attn_release = (
     "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/"
     "flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp313-cp313-linux_x86_64.whl"
 )
@@ -12,6 +27,7 @@ image = modal.Image.debian_slim(python_version="3.13").pip_install(
 )
 
 
+# And here is a brief demo proving that it works!
 @app.function(gpu="L40S", image=image)
 def run_flash_attn():
     import torch

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -27,7 +27,7 @@ image = modal.Image.debian_slim(python_version="3.13").pip_install(
 )
 
 
-# And here is a brief demo proving that it works!
+# And here is a demo verifying that it works!
 @app.function(gpu="L40S", image=image)
 def run_flash_attn():
     import torch

--- a/02_building_containers/install_flash_attn.py
+++ b/02_building_containers/install_flash_attn.py
@@ -27,7 +27,7 @@ image = modal.Image.debian_slim(python_version="3.13").pip_install(
 )
 
 
-# And here is a demo verifying that it works!
+# And here is a demo verifying that it works:
 @app.function(gpu="L40S", image=image)
 def run_flash_attn():
     import torch


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
