### PR TITLE
Fix broken link for CI documentation

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -71,7 +71,7 @@ with image.imports():
 
 # ## Implementing SD3.5 Large Turbo inference on Modal
 
-# We wrap inference in a Modal [Cls](https://modal.com/docs/guide/lifecycle-methods)
+# We wrap inference in a Modal [Cls](https://modal.com/docs/guide/lifecycle-functions)
 # that ensures models are loaded and then moved to the GPU once when a new container
 # starts, before the container picks up any work.
 


### PR DESCRIPTION
## Summary
I was following the text-to-image example and noticed a URL was broken. I believe the one I have updated it to is correct since the topic is the same and since method ≈≈ function :~)


## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)
