### PR TITLE
fix: Image2video make slugify an inline function

### DIFF
--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -333,7 +333,3 @@ def ui():
     )
 
     return web_app
-
-
-def slugify(s: str) -> str:
-    return 

--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -171,7 +171,7 @@ class Inference:
             num_inference_steps=num_inference_steps,
         ).frames[0]
 
-        mp4_name = slugify(prompt)
+        mp4_name = f"{seed}_{''.join(c if c.isalnum() else '-' for c in prompt[:100])}.mp4"
         diffusers.utils.export_to_video(
             video, f"{Path(OUTPUT_PATH) / mp4_name}", fps=24
         )
@@ -336,4 +336,4 @@ def ui():
 
 
 def slugify(s: str) -> str:
-    return f"{time.strftime('%Y%m%d_%H%M%S')}_{''.join(c if c.isalnum() else '-' for c in s[:100]).strip('-')}.mp4"
+    return 


### PR DESCRIPTION
Simple inlining of a function that is defined in the last line in the example. Makes the example run when copy pasting chunks in the downward fashion. 
## Type of Change
Non-functional change, purely code semantics 

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
