### PR TITLE
Fix broken 'create secret' link

### DIFF
--- a/05_scheduling/hackernews_alerts.py
+++ b/05_scheduling/hackernews_alerts.py
@@ -27,9 +27,9 @@ slack_sdk_image = modal.Image.debian_slim().pip_install("slack-sdk")
 
 # Our Slack bot will need access to a bot token.
 # We can use Modal's [Secrets](https://modal.com/secrets) interface to accomplish this.
-# To quickly create a Slack bot secret, navigate to the
-# [create secret](https://modal.com/secrets/create) page, select the Slack secret template
-# from the list options, and follow the instructions in the "Where to find the credentials?" panel.
+# To quickly create a Slack bot secret, click the "Create new secret" button.
+# Then, select the Slack secret template from the list options,
+# and follow the instructions in the "Where to find the credentials?" panel.
 # Name your secret `hn-bot-slack.`
 
 # Now, we define the function `post_to_slack`, which simply instantiates the Slack client using our token,


### PR DESCRIPTION
The Hacker News example has a link that leads to a 404. Since the create secret link seems to depend on knowing the account ID, I've replaced it with instructions.

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/1509372f-3607-4f2d-8f72-270a90ac95c0" />


## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)