### PR TITLE
update vllm example

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -1,5 +1,6 @@
 # ---
 # pytest: false
+# cmd: ["modal", "run", "06_gpu_and_ml/llm-serving/vllm_inference.py"]
 # ---
 
 # # Run OpenAI-compatible LLM inference with LLaMA 3.1-8B and vLLM
@@ -14,81 +15,119 @@
 # Our examples repository also includes scripts for running clients and load-testing for OpenAI-compatible APIs
 # [here](https://github.com/modal-labs/modal-examples/tree/main/06_gpu_and_ml/llm-serving/openai_compatible).
 
-# You can find a video walkthrough of this example and the related scripts on the Modal YouTube channel
+# You can find a (somewhat out-of-date) video walkthrough of this example and the related scripts on the Modal YouTube channel
 # [here](https://www.youtube.com/watch?v=QmY_7ePR1hM).
 
 # ## Set up the container image
 
 # Our first order of business is to define the environment our server will run in:
 # the [container `Image`](https://modal.com/docs/guide/custom-container).
-# vLLM can be installed with `pip`.
+# vLLM can be installed with `pip`, since Modal [provides the CUDA drivers](https://modal.com/docs/guide/cuda).
 
+# To take advantage of optimized kernels for CUDA 12.8, we install PyTorch, flashinfer, and their dependencies
+# via an `extra` Python package index.
+
+import json
+from typing import Any
+
+import aiohttp
 import modal
 
 vllm_image = (
     modal.Image.debian_slim(python_version="3.12")
     .pip_install(
-        "vllm==0.7.2",
-        "huggingface_hub[hf_transfer]==0.26.2",
-        "flashinfer-python==0.2.0.post2",  # pinning, very unstable
-        extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5",
+        "vllm==0.9.1",
+        "huggingface_hub[hf_transfer]==0.32.0",
+        "flashinfer-python==0.2.6.post1",
+        extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})  # faster model transfers
 )
 
-# In its 0.7 release, vLLM added a new version of its backend infrastructure,
-# the [V1 Engine](https://blog.vllm.ai/2025/01/27/v1-alpha-release.html).
-# Using this new engine can lead to some [impressive speedups](https://github.com/modal-labs/modal-examples/pull/1064),
-# but as of version 0.7.2 the new engine does not support all inference engine features
-# (including important performance optimizations like
-# [speculative decoding](https://docs.vllm.ai/en/v0.7.2/features/spec_decode.html)).
-
-# The features we use in this demo are supported, so we turn the engine on by setting an environment variable
-# on the Modal Image.
-
-vllm_image = vllm_image.env({"VLLM_USE_V1": "1"})
-
 # ## Download the model weights
 
 # We'll be running a pretrained foundation model -- Meta's LLaMA 3.1 8B
-# in the Instruct variant that's trained to chat and follow instructions,
-# quantized to 4-bit by [Neural Magic](https://neuralmagic.com/) and uploaded to Hugging Face.
+# in the Instruct variant that's trained to chat and follow instructions.
 
-# You can read more about the `w4a16` "Machete" weight layout and kernels
-# [here](https://neuralmagic.com/blog/introducing-machete-a-mixed-input-gemm-kernel-optimized-for-nvidia-hopper-gpus/).
+# Model parameters are often quantized to a lower precision during training
+# than they are run at during inference.
+# We'll use an eight bit floating point quantization from Neural Magic/Red Hat.
+# Native hardware support for FP8 formats in [Tensor Cores](https://modal.com/gpu-glossary/device-hardware/tensor-core)
+# is limited to the latest [Streaming Multiprocessor architectures](https://modal.com/gpu-glossary/device-hardware/streaming-multiprocessor-architecture),
+# like those of Modal's [Hopper H100/H200 and Blackwell B200 GPUs](https://modal.com/blog/announcing-h200-b200).
 
-MODELS_DIR = "/llamas"
-MODEL_NAME = "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
-MODEL_REVISION = "a7c09948d9a632c2c840722f519672cd94af885d"
+# You can swap this model out for another by changing the strings below.
+# A single B200 GPUs has enough VRAM to store a 70,000,000,000 parameter model,
+# like Llama 3.3, in eight bit precision, along with a very large KV cache.
 
-# Although vLLM will download weights on-demand, we want to cache them if possible. We'll use [Modal Volumes](https://modal.com/docs/guide/volumes),
-# which act as a "shared disk" that all Modal Functions can access, for our cache.
+MODEL_NAME = "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8"
+MODEL_REVISION = "12fd6884d2585dd4d020373e7f39f74507b31866"  # avoid nasty surprises when repos update!
+
+# Although vLLM will download weights from Hugging Face on-demand,
+# we want to cache them so we don't do it every time our server starts.
+# We'll use [Modal Volumes](https://modal.com/docs/guide/volumes) for our cache.
+# Modal Volumes are essentially a "shared disk" that all Modal Functions can access like it's a regular disk.
 
 hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
+
+# We'll also cache some of vLLM's JIT compilation artifacts in a Modal Volume.
+
 vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
 
+# ## Configuring vLLM
+
+# ### The V1 engine
+
+# In its 0.7 release, in early 2025, vLLM added a new version of its backend infrastructure,
+# the [V1 Engine](https://blog.vllm.ai/2025/01/27/v1-alpha-release.html).
+# Using this new engine can lead to some [impressive speedups](https://github.com/modal-labs/modal-examples/pull/1064).
+# It was made the default in version 0.8 and is [slated for complete removal by 0.11](https://github.com/vllm-project/vllm/issues/18571),
+# in late summer of 2025.
+
+# A small number of features, described in the RFC above, may still require the V0 engine prior to removal.
+# Until deprecation, you can use it by setting the below environment variable to `0`.
+
+vllm_image = vllm_image.env({"VLLM_USE_V1": "1"})
+
+# ### Trading off fast boots and token generation performance
+
+# vLLM has embraced dynamic and just-in-time compilation to eke out additional performance without having to write too many custom kernels,
+# e.g. via the Torch compiler and CUDA graph capture.
+# These compilation features incur latency at startup in exchange for lowered latency and higher throughput during generation.
+# We make this trade-off controllable with the `FAST_BOOT` variable below.
+
+FAST_BOOT = True
+
+# If you're running an LLM service that frequently scales from 0 (frequent ["cold starts"](https://modal.com/docs/guide/cold-start))
+# then you'll want to set this to `True`.
+
+# If you're running an LLM service that usually has multiple replicas running, then set this to `False` for improved performance.
+
+# See the code below for details on the parameters that `FAST_BOOT` controls.
+
+# For more on the performance you can expect when serving your own LLMs, see
+# [our LLM engine performance benchmarks](https://modal.com/llm-almanac).
 
 # ## Build a vLLM engine and serve it
 
-# The function below spawns a vLLM instance listening at port 8000, serving requests to our model. vLLM will authenticate requests
-# using the API key we provide it.
-
+# The function below spawns a vLLM instance listening at port 8000, serving requests to our model.
 # We wrap it in the [`@modal.web_server` decorator](https://modal.com/docs/guide/webhooks#non-asgi-web-servers)
 # to connect it to the Internet.
 
+# The server runs in an independent process, via `subprocess.Popen`, and only starts accepting requests
+# once the model is spun up and the `serve` function returns.
+
+
 app = modal.App("example-vllm-openai-compatible")
 
-N_GPU = 1  # tip: for best results, first upgrade to more powerful GPUs, and only then increase GPU count
-API_KEY = "super-secret-key"  # api key, for auth. for production use, replace with a modal.Secret
-
+N_GPU = 1
 MINUTES = 60  # seconds
-
 VLLM_PORT = 8000
 
 
 @app.function(
     image=vllm_image,
-    gpu=f"H100:{N_GPU}",
+    gpu=f"B200:{N_GPU}",
     scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
     timeout=10 * MINUTES,  # how long should we wait for container start?
     volumes={
@@ -96,10 +135,10 @@ VLLM_PORT = 8000
         "/root/.cache/vllm": vllm_cache_vol,
     },
 )
-@modal.concurrent(
-    max_inputs=100
-)  # how many requests can one replica handle? tune carefully!
-@modal.web_server(port=VLLM_PORT, startup_timeout=5 * MINUTES)
+@modal.concurrent(  # how many requests can one replica handle? tune carefully!
+    max_inputs=32
+)
+@modal.web_server(port=VLLM_PORT, startup_timeout=10 * MINUTES)
 def serve():
     import subprocess
 
@@ -110,13 +149,23 @@ def serve():
         MODEL_NAME,
         "--revision",
         MODEL_REVISION,
+        "--served-model-name",
+        MODEL_NAME,
+        "llm",
         "--host",
         "0.0.0.0",
         "--port",
         str(VLLM_PORT),
-        "--api-key",
-        API_KEY,
     ]
+
+    # enforce-eager disables both Torch compilation and CUDA graph capture
+    # default is no-enforce-eager. see the --compilation-config flag for tighter control
+    cmd += ["--enforce-eager" if FAST_BOOT else "--no-enforce-eager"]
+
+    # assume multiple GPUs are for splitting up large matrix multiplications
+    cmd += ["--tensor-parallel-size", str(N_GPU)]
+
+    print(cmd)
 
     subprocess.Popen(" ".join(cmd), shell=True)
 
@@ -175,43 +224,61 @@ def serve():
 
 
 @app.local_entrypoint()
-def test(test_timeout=10 * MINUTES):
-    import json
-    import time
-    import urllib
+async def test(test_timeout=10 * MINUTES, content=None, twice=True):
+    url = serve.get_web_url()
 
-    print(f"Running health check for server at {serve.get_web_url()}")
-    up, start, delay = False, time.time(), 10
-    while not up:
-        try:
-            with urllib.request.urlopen(serve.get_web_url() + "/health") as response:
-                if response.getcode() == 200:
-                    up = True
-        except Exception:
-            if time.time() - start > test_timeout:
-                break
-            time.sleep(delay)
-
-    assert up, f"Failed health check for server at {serve.get_web_url()}"
-
-    print(f"Successful health check for server at {serve.get_web_url()}")
-
-    messages = [{"role": "user", "content": "Testing! Is this thing on?"}]
-    print(f"Sending a sample message to {serve.get_web_url()}", *messages, sep="\n")
-
-    headers = {
-        "Authorization": f"Bearer {API_KEY}",
-        "Content-Type": "application/json",
+    system_prompt = {
+        "role": "system",
+        "content": "You are a pirate who can't help but drop sly reminders that he went to Harvard.",
     }
-    payload = json.dumps({"messages": messages, "model": MODEL_NAME})
-    req = urllib.request.Request(
-        serve.get_web_url() + "/v1/chat/completions",
-        data=payload.encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
-    with urllib.request.urlopen(req) as response:
-        print(json.loads(response.read().decode()))
+    if content is None:
+        content = "Explain the singular value decomposition."
+
+    messages = [
+        system_prompt,
+        {"role": "user", "content": content},
+    ]  # OpenAI chat format
+
+    async with aiohttp.ClientSession(base_url=url) as session:
+        print(f"Running health check for server at {url}")
+        async with session.get("/health", timeout=test_timeout - 1 * MINUTES) as resp:
+            up = resp.status == 200
+        assert up, f"Failed health check for server at {url}"
+        print(f"Successful health check for server at {url}")
+
+        print(f"Sending messages to {url}:", *messages, sep="\n\t")
+        await _send_request(session, "llm", messages)
+        if twice:
+            messages[0]["content"] = "You are Jar Jar Binks."
+            print(f"Sending messages to {url}:", *messages, sep="\n\t")
+            await _send_request(session, "llm", messages)
+
+
+async def _send_request(
+    session: aiohttp.ClientSession, model: str, messages: list
+) -> None:
+    # `stream=True` tells an OpenAI-compatible backend to stream chunks.
+    payload: dict[str, Any] = {"messages": messages, "model": model, "stream": True}
+
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+
+    async with session.post(
+        "/v1/chat/completions", json=payload, headers=headers, timeout=1 * MINUTES
+    ) as resp:
+        async for raw in resp.content:
+            resp.raise_for_status()
+            # extract new content and stream it
+            line = raw.decode().strip()
+            if not line or line == "data: [DONE]":
+                continue
+            if line.startswith("data: "):  # SSE prefix
+                line = line[len("data: ") :]
+
+            chunk = json.loads(line)
+            assert (
+                chunk["object"] == "chat.completion.chunk"
+            )  # or something went horribly wrong
+            print(chunk["choices"][0]["delta"]["content"], end="")
 
 
 # We also include a basic example of a load-testing setup using

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -279,6 +279,7 @@ async def _send_request(
                 chunk["object"] == "chat.completion.chunk"
             )  # or something went horribly wrong
             print(chunk["choices"][0]["delta"]["content"], end="")
+    print()
 
 
 # We also include a basic example of a load-testing setup using

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -234,10 +234,10 @@ async def test(test_timeout=10 * MINUTES, content=None, twice=True):
     if content is None:
         content = "Explain the singular value decomposition."
 
-    messages = [
+    messages = [  # OpenAI chat format
         system_prompt,
         {"role": "user", "content": content},
-    ]  # OpenAI chat format
+    ]
 
     async with aiohttp.ClientSession(base_url=url) as session:
         print(f"Running health check for server at {url}")
@@ -257,7 +257,7 @@ async def test(test_timeout=10 * MINUTES, content=None, twice=True):
 async def _send_request(
     session: aiohttp.ClientSession, model: str, messages: list
 ) -> None:
-    # `stream=True` tells an OpenAI-compatible backend to stream chunks.
+    # `stream=True` tells an OpenAI-compatible backend to stream chunks
     payload: dict[str, Any] = {"messages": messages, "model": model, "stream": True}
 
     headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}


### PR DESCRIPTION
### What if the vLLM example was fast?

This PR makes a number of changes to make the vLLM inference example run and feel faster.

It reduces the cold start time from over four minutes to less than one while generating more tokens and getting them to the client faster.

### How does this PR make the vLLM example faster?

- It switches to eager mode by default. vLLM has generally moved in the direction of trading compile time for run time, which is sensible in a large, stable production environment but isn't great for a demo of a serverless platform. Their docs incorrectly say that the default compilation level is `-O0`, but from my experiments it's actually `-O3`. I gave up on tuning the flags more tightly than just `eager`/`no-eager` because I couldn't get them to be respected, and it turns out `--enforce-eager` turns off pretty much everything, which is basically what we want. This PR also documents the choice and makes it more obviously configurable. **This is the biggest change**, cutting ~145s of latency on cold boot.
- It updates vLLM to 0.9, which has a number of perf improvements, including running a newer Torch version.
- It moves to Blackwell, since we have Blackwells and Blackwell is supported in vLLM/Torch and in flashinfer (requires CUDA 12.8). We can even install flashinfer with CUDA 12.8 from a wheel now! This has only a small impact on speed, because it doesn't impact cold start and inference is firmly in the host overhead regime.
- It adds streaming responses, so the first token shows up faster. Latency is perceived, not just measured!
- It adjusts the testing so that more work is done, which paradoxically makes it _feel_ faster -- the boot is amortized over more work. It adjusts the prompt so that more tokens are produced and sets a new default behavior of sending two user messages (with different system prompts).

### Why isn't this even faster?

Well, what are we spending our ~45s of boot time on? Let's look at the sample logs [here](https://modal.com/apps/modal-labs/examples/ap-S50cxoTULd1AkgIZMdl7Gy?start=1749693451.135&end=1749697051.135&live=true&fcId=fc-01JXGZWJH0HRJGF78VMT2SM278&activeTab=functions&functionId=fu-iivcCctNqGyxEiIz4aXlvS&functionSection=calls&limit=100&includeLogContext=false) (internal only, sorry).

- T=0: Container is scheduled. No queueing! Sub-second network+scheduler latency, can ignore, that matters for requests, not for cold starts.
- T=4: We print the command we're going to run. The rest of the time is container boot (1-2s?) and code in the global scope (3-2s?). We don't import `vllm` or `torch` yet.
- T=10: `vllm` logs `Automatically detected platform cuda` from `__init__.py`. So maybe five seconds to `import vllm`?
- T=18: `vllm` logs `server version` from `api_server.py`. So 7-8s to "spin up the web server"?
- T=28: `vllm` logs model/engine config (e.g. `Chunked prefill is enabled`) from `config.py`. So ~10s to read model/engine configuration?
- T=39: Over 9 seconds, `vllm` logs a `NCCL_CUMEM_ENABLE` warning, `Automatically detected platform cuda`again, and then finally `Waiting for init message from front-end` from `core.py`. Not sure what's going on here, more "engine spin-up"?
- T=45: Model is loaded (4.7s), KV cache created, model warmed up, and API server launched. Health check returns 200.

Nothing obvious jumps out to me here. Even if we loaded models via blazingly fast RDMA, we'd never save more than 5s. It would just let us run a more interesting model here, like Mistral Small, LLaMA 70B, etc.

The easiest way to speed all of this up would be to snapshot it (hard to demo in an ephemeral app, but we'd figure something out). But the created state here is going to be tricky to snapshot. Not just because it's GPU memory, but also because it involves network resources like sockets.

I investigated FP4 models, since Blackwell supports FP4 and it would cut size in ~half again. There are some testing-only versions in a neural magic side org on Hugging Face ([eg](https://huggingface.co/nm-testing/Llama-3.1-8B-Instruct-NVFP4)), and those run, but the speedup isn't meaningful and the quality seems worse. I'll keep an eye on FP4 support.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`
