### PR TITLE
Fix links to modal websites

### DIFF
--- a/06_gpu_and_ml/torch_profiling.py
+++ b/06_gpu_and_ml/torch_profiling.py
@@ -21,7 +21,7 @@
 # so by default these files disappear as soon as the Function finishes running.
 
 # We can ensure these files persist by saving them to a
-# [Modal Volume](https://modal.com/docs/guide/volume).
+# [Modal Volume](https://modal.com/docs/guide/volumes).
 # Volumes are a distributed file system: files can be read or written from
 # by many machines across a network, in this case from inside any Modal Function.
 

--- a/07_web_endpoints/webrtc/webrtc_yolo.py
+++ b/07_web_endpoints/webrtc/webrtc_yolo.py
@@ -261,7 +261,7 @@ class ObjDet(ModalWebRtcPeer):
 # The `ModalWebRtcSignalingServer` class is much simpler to implement.
 # The main thing we need to do is implement the `get_modal_peer_class` method which will return our implementation of the `ModalWebRtcPeer` class, `ObjDet`.
 #
-# It also has an `initialize()` method we can optionally override (called at the beginning of the [container lifecycle](https://modal.com/docs/guides/lifecycle-functions))
+# It also has an `initialize()` method we can optionally override (called at the beginning of the [container lifecycle](https://modal.com/docs/guide/lifecycle-functions))
 # as well as a `web_app` property which will be [served by Modal](https://modal.com/docs/guide/webhooks#asgi-apps---fastapi-fasthtml-starlette).
 # We'll use these to add a frontend which uses the WebRTC JavaScript API to stream a peer's webcam from the browser.
 #


### PR DESCRIPTION
Fixes links to modal websites

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`