### PR TITLE
Adding a link to the FLUX blog post in the FLUX example

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -3,6 +3,9 @@
 # args: ["--no-compile"]
 # ---
 
+# Update: To speed up inference by another >2x, check out the additional optimization
+# techniques we tried in [this blog post](https://modal.com/blog/flux-3x-faster).
+
 # # Run Flux fast on H100s with `torch.compile`
 
 # In this guide, we'll run Flux as fast as possible on Modal using open source tools.

--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -3,10 +3,10 @@
 # args: ["--no-compile"]
 # ---
 
-# Update: To speed up inference by another >2x, check out the additional optimization
-# techniques we tried in [this blog post](https://modal.com/blog/flux-3x-faster).
-
 # # Run Flux fast on H100s with `torch.compile`
+
+# _Update: To speed up inference by another >2x, check out the additional optimization
+# techniques we tried in [this blog post](https://modal.com/blog/flux-3x-faster)!_
 
 # In this guide, we'll run Flux as fast as possible on Modal using open source tools.
 # We'll use `torch.compile` and NVIDIA H100 GPUs.


### PR DESCRIPTION
The [FLUX blog post](https://modal.com/blog/flux-3x-faster) extends the FLUX example. Adding an update in the example that points to the blog.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->
- [x] Example updates (Bug fixes, new features, etc.)