### PR TITLE
Add example to run deepseek in fp4 with trtllm on blackwell gpus

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_deepseek.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_deepseek.py
@@ -1,0 +1,426 @@
+# ---
+# deploy: true
+# ---
+
+# # Run state-of-the-art RLMs on Blackwell GPUs with TensorRT-LLM (DeepSeek-R1-0528-FP4)
+
+# In this example, we demonstrate how to use the TensorRT-LLM framework to serve NVIDIA's DeepSeek-R1-0528-FP4 model,
+# a [state-of-the-art reasoning language model](https://lmarena.ai/leaderboard),
+# on Modal's Blackwell GPUs (8 x B200s).
+
+# Because this model is so large, our focus will be on optimizing the cold start and the model's inference latencies.
+# We use [NVIDIA's recommendations](https://huggingface.co/nvidia/DeepSeek-R1-0528-FP4#minimum-latency-server-deployment)
+# for matching expected performance and minimizing inference latency.
+
+# ## Overview
+
+# This guide is intended to document two things:
+# the general process for building TensorRT-LLM on Modal
+# and a specific configuration for serving the DeepSeek-R1-0528-FP4 model.
+
+# ## Installing TensorRT-LLM
+
+# To run TensorRT-LLM, we must first install it. Easier said than done!
+
+# To run code on Modal, we define [container images](https://modal.com/docs/guide/images).
+# All Modal containers have access to GPU drivers via the underlying host environment,
+# but we still need to install the software stack on top of the drivers, from the CUDA runtime up.
+
+# We start from an official `nvidia/cuda` container image,
+# which includes the CUDA runtime & development libraries
+# and the environment configuration necessary to run them.
+
+import os
+import webbrowser  # for opening generated HTML files in browser
+from pathlib import Path
+
+import modal
+
+# To run TensorRT-LLM on Blackwell GPUs (sm_100), we need:
+#   1. PyTorch with CUDA 12.8 support (required for Blackwell)
+#   2. TensorRT-LLM built from PyPI
+
+# We also add some system dependencies of TensorRT-LLM,
+# including OpenMPI for distributed communication, some core software like `git`,
+# and install packages using [uv](https://docs.astral.sh/uv/)
+# to speed up the installation process.
+
+tensorrt_image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.1-devel-ubuntu22.04",
+        add_python="3.12",  # TRT-LLM requires Python 3.12
+    )
+    .entrypoint([])  # silence base-image entrypoint
+    .apt_install(
+        "git",
+        "openmpi-bin",
+        "libopenmpi-dev",
+    )
+    # fast Python dependency installer
+    .pip_install("uv")
+    .run_commands(
+        "uv pip install --system --compile-bytecode torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
+    )
+    .run_commands("uv pip install --system --compile-bytecode mpi4py tensorrt_llm")
+)
+
+# Note that we're doing this by [method-chaining](https://quanticdev.com/articles/method-chaining/)
+# a number of calls to methods on the `modal.Image`. If you're familiar with
+# Dockerfiles, you can think of this as a Pythonic interface to instructions like `RUN` and `CMD`.
+
+# End-to-end, this step takes a few minutes on first run.
+# If you're reading this from top to bottom,
+# you might want to stop here and execute the example
+# with `modal run` so that it runs in the background while you read the rest.
+
+# ## Downloading the model
+
+# Next, we'll set up a few things to download the model to persistent storage and do it quickly.
+# For persistent, distributed storage, we use
+# [Modal Volumes](https://modal.com/docs/guide/volumes), which can be accessed from any container
+# with read speeds in excess of a gigabyte per second.
+
+# We also set the `HF_HOME` environment variable to point to the Volume so that the model
+# is cached there. And we install `hf-transfer` to get maximum download throughput from
+# the Hugging Face Hub, in the hundreds of megabytes per second.
+
+app_name = "example-trtllm-deepseek"
+
+hf_cache_vol = modal.Volume.from_name(f"{app_name}-hf-cache", create_if_missing=True)
+HF_CACHE_PATH = Path("/hf_cache")
+volumes = {HF_CACHE_PATH: hf_cache_vol}
+
+MODEL_NAME = "nvidia/DeepSeek-R1-0528-FP4"
+MODEL_REVISION = "91cfc7c35acd8ecfc769205989310208b8b81c9c"  # in case repo updates!
+MODELS_PATH = HF_CACHE_PATH / "models"
+MODEL_PATH = MODELS_PATH / MODEL_NAME
+
+
+# We use the function below to download the model from the Hugging Face Hub.
+
+
+def download_model():
+    from huggingface_hub import snapshot_download
+
+    print(f"downloading base model to {MODEL_PATH} if necessary")
+    snapshot_download(
+        MODEL_NAME,
+        local_dir=MODEL_PATH,
+        ignore_patterns=["*.pt", "*.bin"],  # using safetensors
+        revision=MODEL_REVISION,
+    )
+
+
+# Just defining that function doesn't actually download the model, though.
+# We can run it by adding it to the image's build process with `run_function`.
+# The download process has its own dependencies, which we add here.
+
+MINUTES = 60  # seconds
+tensorrt_image = (
+    tensorrt_image.run_commands(
+        "uv pip install --system --compile-bytecode hf-transfer==0.1.9 huggingface_hub==0.33.0"
+    )
+    .env(
+        {
+            "HF_HUB_ENABLE_HF_TRANSFER": "1",
+            "HF_HOME": str(MODELS_PATH),
+        }
+    )
+    .run_function(download_model, volumes=volumes, timeout=40 * MINUTES)
+)
+
+with tensorrt_image.imports():
+    import os
+
+    from tensorrt_llm import SamplingParams
+    from tensorrt_llm._torch import LLM
+
+
+# ## Setting up the engine
+
+# ### Configure plugins
+
+# TensorRT-LLM is an LLM inference framework built on top of NVIDIA's TensorRT,
+# which is a generic inference framework for neural networks.
+
+# TensorRT includes a "plugin" extension system that allows you to adjust behavior,
+# like configuring the [CUDA kernels](https://modal.com/gpu-glossary/device-software/kernel)
+# used by the engine.
+# The [General Matrix Multiply (GEMM)](https://docs.nvidia.com/deeplearning/performance/dl-performance-matrix-multiplication/index.html)
+# plugin, for instance, adds heavily-optimized matrix multiplication kernels
+# from NVIDIA's [cuBLAS library of linear algebra routines](https://docs.nvidia.com/cuda/cublas/).
+
+# We'll specify the `paged_kv_cache` plugin which enables a
+# [paged attention algorithm](https://arxiv.org/abs/2309.06180)
+# for the key-value (KV) cache.
+
+
+def get_plugin_config():
+    from tensorrt_llm.plugin.plugin import PluginConfig
+
+    return PluginConfig.from_dict(
+        {
+            "paged_kv_cache": True,
+        }
+    )
+
+
+# ### Configure speculative decoding
+
+# Speculative decoding is a technique for generating multiple tokens per step,
+# avoiding the auto-regressive bottleneck in the Transformer architecture.
+# Generating multiple tokens in parallel exposes more parallelism to the GPU.
+# It works best for text that has predicable patterns, like code,
+# but it's worth testing for any workload where latency is critical.
+
+# Speculative decoding can use any technique to guess tokens, including running another,
+# smaller language model. Here, we'll use a speculative decoding strategy called "MTP Decoding",
+# which uses a small auxiliary model to predict the next few tokens
+# and then verifies these predictions with the main model.
+
+# NOTE: MTP speculative decoding is temporarily disabled due to compatibility issues
+# with TensorRT-LLM 0.20.0 from PyPI. For full MTP support, you may need to build
+# TensorRT-LLM from source using the latest main branch.
+
+
+def get_speculative_config():
+    from tensorrt_llm.llmapi import MTPDecodingConfig
+
+    return MTPDecodingConfig(
+        num_nextn_predict_layers=3,
+        use_relaxed_acceptance_for_thinking=True,
+        relaxed_topk=10,
+        relaxed_delta=0.6,
+    )
+
+
+# ### Set the build config
+
+# Finally, we'll specify the overall build configuration for the engine. This includes
+# more obvious parameters such as the maximum input length, the maximum number of tokens
+# to process at once before queueing occurs, and the maximum number of sequences
+# to process at once before queueing occurs.
+
+# To minimize latency, we set the maximum number of sequences (the "batch size")
+# to 4. We enforce this maximum by setting the number of inputs that the
+# Modal Function is allowed to process at once -- `max_concurrent_inputs`.
+
+MAX_BATCH_SIZE = MAX_CONCURRENT_INPUTS = 4
+
+
+def get_build_config():
+    from tensorrt_llm import BuildConfig
+
+    return BuildConfig(
+        plugin_config=get_plugin_config(),
+        # speculative_decoding_mode="MTP_DECODING",
+        max_input_len=8192,
+        max_num_tokens=16384,
+        max_batch_size=MAX_BATCH_SIZE,
+    )
+
+
+# ## Serving inference
+
+# Now that we have written the code to compile the engine, we can
+# serve it with Modal!
+
+# We start by creating an `App`.
+
+app = modal.App(app_name)
+
+# Thanks to our [custom container runtime system](https://modal.com/blog/jono-containers-talk),
+# even this large container boots in seconds.
+
+# On the first container start, we mount the Volume and build the engine,
+# which takes a few minutes. Subsequent starts will be much faster,
+# as the engine is cached in the Volume and loaded in seconds.
+
+# Container starts are triggered when Modal scales up your Function,
+# like the first time you run this code or the first time a request comes in after a period of inactivity.
+# For details on optimizing container start latency, see
+# [this guide](https://modal.com/docs/guide/cold-start).
+
+# Container lifecycles in Modal are managed via our `Cls` interface, so we define one below
+# to separate out the engine startup (`enter`) and engine execution (`generate`).
+# For details, see [this guide](https://modal.com/docs/guide/lifecycle-functions).
+
+
+@app.cls(
+    image=tensorrt_image,
+    gpu="B200:8",
+    scaledown_window=10 * MINUTES,
+    timeout=20 * MINUTES,
+    volumes=volumes,
+)
+@modal.concurrent(max_inputs=MAX_CONCURRENT_INPUTS)
+class Model:
+    def build_engine(self, engine_path, engine_kwargs) -> None:
+        llm = LLM(model=MODEL_PATH, **engine_kwargs)
+        llm.save(engine_path)
+        return llm
+
+    @modal.enter()
+    def enter(self):
+        import torch
+        from transformers import AutoTokenizer
+
+        self.tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+        engine_kwargs = {
+            "build_config": get_build_config(),
+            # "speculative_config": get_speculative_config(),
+            "tensor_parallel_size": torch.cuda.device_count(),
+            "ep_size": 2,
+            "enable_attention_dp": True,
+            "moe_backend": "TRTLLM",
+            "use_cuda_graph": True,
+            "backend": "pytorch",
+            "max_batch_size": MAX_BATCH_SIZE,
+            "trust_remote_code": True,
+        }
+
+        self.sampling_params = SamplingParams(
+            temperature=0.6,
+            top_p=0.95,
+            max_tokens=32768,  # max generated tokens
+            # lookahead_config=engine_kwargs.get("speculative_config"),
+        )
+
+        engine_path = MODEL_PATH / "trtllm_engine"
+        if not os.path.exists(engine_path):
+            print(f"building new engine at {engine_path}")
+            self.llm = self.build_engine(engine_path, engine_kwargs)
+        else:
+            print(f"loading engine from {engine_path}")
+            self.llm = LLM(model=engine_path, **engine_kwargs)
+
+    @modal.method()
+    async def generate_async(self, prompt):
+        text = self.text_from_prompt(prompt)
+        async for output in self.llm.generate_async(
+            text, self.sampling_params, streaming=True
+        ):
+            yield output.outputs[0].text_diff
+
+    def text_from_prompt(self, prompt):
+        messages = [{"role": "user", "content": prompt}]
+
+        return self.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+
+    @modal.method()
+    def boot(self):
+        pass  # no-op to start up containers
+
+    @modal.exit()
+    def shutdown(self):
+        self.llm.shutdown()
+        del self.llm
+
+
+# ## Calling our inference function
+
+# To run our `Model`'s `.generate` method from Python, we just need to call it --
+# with `.remote` appended to run it on Modal.
+
+# We wrap that logic in a `local_entrypoint` so you can run it from the command line with
+
+# ```bash
+# modal run trtllm_deepseek.py
+# ```
+
+# For simplicity, we ask the model to generate a game of tic-tac-toe in HTML and open it in the browser.
+# But the code in the `local_entrypoint` is just regular Python code
+# that runs on your machine -- we wrap it in a CLI automatically --
+# so feel free to customize it to your liking.
+
+
+@app.local_entrypoint()
+def main():
+    print("🏎️  creating container")
+    model = Model()
+
+    print("🏎️  cold booting container")
+    model.boot.remote()
+
+    prompt = """
+    Create an HTML page implementing a simple game of tic-tac-toe.
+    Only output the HTML in English, no other text or language.
+    """
+
+    print("🏎️ creating game of tic-tac-toe")
+    prompt = [{"role": "user", "content": prompt}]
+    resp = ""
+    for out in model.generate_async.remote_gen(prompt):
+        print(out, end="", flush=True)
+        resp += out
+    print("\n")
+
+    # post-process
+    html_content = (
+        resp.split("</think>")[-1].split("```html")[-1].split("```")[0].strip()
+    )
+
+    html_filename = Path(__file__).parent / "tic_tac_toe.html"
+    with open(html_filename, "w") as f:
+        f.write(html_content)
+
+    file_path = html_filename.absolute()
+    file_url = f"file://{file_path}"
+    print(f"\nHTML saved to: {file_path}")
+    print(f"Opening in browser: {file_url}")
+
+    print("🏎️  opening in browser")
+    webbrowser.open(file_url)
+
+
+# Once deployed with `modal deploy`, this `Model.generate` function
+# can be called from other Python code. It can also be converted to an HTTP endpoint
+# for invocation over the Internet by any client.
+# For details, see [this guide](https://modal.com/docs/guide/trigger-deployed-functions).
+
+# As a quick demo, we've included some sample chat client code in the
+# Python main entrypoint below. To use it, first deploy with
+
+# ```bash
+# modal deploy trtllm_deepseek.py
+# ```
+
+# and then run the client with
+
+# ```python notest
+# python trtllm_deepseek.py
+# ```
+
+
+if __name__ == "__main__":
+    import sys
+
+    try:
+        Model = modal.Cls.from_name(app_name, "Model")
+        print("🏎️  connecting to model")
+        model = Model()
+        model.boot.remote()
+    except modal.exception.NotFoundError as e:
+        raise SystemError("Deploy this app first with modal deploy") from e
+
+    print("🏎️  starting chat. exit with :q, ctrl+C, or ctrl+D")
+    try:
+        prompt = []
+        while (nxt := input("🏎️  > ")) != ":q":
+            prompt.append({"role": "user", "content": nxt})
+            resp = ""
+            for out in model.generate_async.remote_gen(prompt):
+                print(out, end="", flush=True)
+                resp += out
+            print("\n")
+            prompt.append({"role": "assistant", "content": resp})
+    except KeyboardInterrupt:
+        pass
+    except SystemExit:
+        pass
+    finally:
+        print("\n")
+        sys.exit(0)

--- a/06_gpu_and_ml/llm-serving/vllm_deepseek.py
+++ b/06_gpu_and_ml/llm-serving/vllm_deepseek.py
@@ -1,0 +1,411 @@
+# # Run state-of-the-art RLMs on Blackwell GPUs with DeepSeek-R1-0528-FP4 and vLLM
+
+# In this example, we demonstrate how to run NVIDIA's DeepSeek-R1-0528-FP4 model,
+# a [state-of-the-art reasoning language model](https://lmarena.ai/leaderboard),
+# by running a vLLM server in OpenAI-compatible mode on Modal's Blackwell GPUs.
+
+# Our examples repository also includes scripts for running clients and load-testing for OpenAI-compatible APIs
+# [here](https://github.com/modal-labs/modal-examples/tree/main/06_gpu_and_ml/llm-serving/openai_compatible).
+
+# ## Quantization
+
+# The amount of [GPU RAM](https://modal.com/gpu-glossary/device-hardware/gpu-ram)
+# on a single card is a tight constraint for large models:
+# RAM is measured in billions of bytes and large models have billions of parameters,
+# each of which is two to four bytes.
+# The performance cliff if you need to spill to CPU memory is steep,
+# so all of those parameters must fit in the GPU memory,
+# along with other things like the KV cache built up while processing prompts.
+
+# The simplest way to reduce LLM inference's RAM requirements is to make the model's parameters smaller,
+# fitting their values in a smaller number of bits, like four or eight. This is known as _quantization_.
+
+# NVIDIA's [Blackwell chips](https://modal.com/gpu-glossary/device-hardware/streaming-multiprocessor-architecture),
+# like the B200, are capable of native [4bit floating point](https://www.nvidia.com/en-us/data-center/technologies/blackwell-architecture/)
+# calculations in their [Tensor Cores](https://modal.com/gpu-glossary/device-hardware/tensor-core),
+# so we choose that as our quantization format.
+# These GPUs are capable of nearly twice as many floating point operations per second in 4bit as in 8bit --
+# about [9 PFLOP/s](https://modal.com/blog/introducing-b200-h200).
+
+# Quantization buys us two things:
+
+# - faster startup, since less data has to be moved over the network onto CPU and GPU RAM
+
+# - faster inference, since we get twice the FLOP/s and less data has to be moved from GPU RAM into
+# [on-chip memory](https://modal.com/gpu-glossary/device-hardware/l1-data-cache) and
+# [registers](https://modal.com/gpu-glossary/device-hardware/register-file)
+# with each computation
+
+# ## Set up the container image
+
+# To run code on Modal, we define [container images](https://modal.com/docs/guide/images).
+# All Modal containers have access to GPU drivers via the underlying host environment,
+# and vLLM can be installed with `pip`, since Modal [provides the CUDA drivers](https://modal.com/docs/guide/cuda).
+
+# To take advantage of optimized kernels for CUDA 12.8, we install PyTorch, flashinfer, and their dependencies
+# via an `extra` Python package index.
+
+import json
+import os
+import shutil
+import webbrowser
+from pathlib import Path
+
+import aiohttp
+import modal
+
+vllm_image = (
+    modal.Image.from_registry("nvidia/cuda:12.8.1-devel-ubuntu22.04", add_python="3.12")
+    .apt_install("git")
+    .pip_install(
+        "vllm==0.9.1",
+        "huggingface_hub[hf_transfer]==0.32.0",
+        "flashinfer-python==0.2.6.post1",
+        extra_index_url="https://download.pytorch.org/whl/cu128",
+    )
+)
+
+# ## Configuring vLLM
+
+# ### The V1 engine
+
+# In its 0.7 release, in early 2025, vLLM added a new version of its backend infrastructure,
+# the [V1 Engine](https://blog.vllm.ai/2025/01/27/v1-alpha-release.html).
+# Using this new engine can lead to some [impressive speedups](https://github.com/modal-labs/modal-examples/pull/1064).
+# It was made the default in version 0.8 and is [slated for complete removal by 0.11](https://github.com/vllm-project/vllm/issues/18571),
+# in late summer of 2025.
+
+# A small number of features, described in the RFC above, may still require the V0 engine prior to removal.
+# Until deprecation, you can use it by setting the below environment variable to `0`.
+
+vllm_image = vllm_image.env({"VLLM_USE_V1": "0"})
+
+# ### Trading off fast boots and token generation performance
+
+# vLLM has embraced dynamic and just-in-time compilation to eke out additional performance without having to write too many custom kernels,
+# e.g. via the Torch compiler and CUDA graph capture.
+# These compilation features incur latency at startup in exchange for lowered latency and higher throughput during generation.
+# We make this trade-off controllable with the `FAST_BOOT` variable below.
+
+FAST_BOOT = True
+
+# If you're running an LLM service that frequently scales from 0 (frequent ["cold starts"](https://modal.com/docs/guide/cold-start))
+# then you'll want to set this to `True`.
+
+# If you're running an LLM service that usually has multiple replicas running, then set this to `False` for improved performance.
+
+# See the code below for details on the parameters that `FAST_BOOT` controls.
+
+# For more on the performance you can expect when serving your own LLMs, see
+# [our LLM engine performance benchmarks](https://modal.com/llm-almanac).
+
+# ## Download the model weights
+
+# We'll be running a pretrained foundation model -- NVIDIA's DeepSeek-R1-0528-FP4
+
+# Model parameters are often quantized to a lower precision during training
+# than they are run at during inference.
+# We'll use a four bit floating point quantization from NVIDIA.
+# Native hardware support for FP4 formats in [Tensor Cores](https://modal.com/gpu-glossary/device-hardware/tensor-core)
+# is limited to the latest [Streaming Multiprocessor architectures](https://modal.com/gpu-glossary/device-hardware/streaming-multiprocessor-architecture),
+# like those of Modal's [Hopper H100/H200 and Blackwell B200 GPUs](https://modal.com/blog/introducing-b200-h200).
+
+MODEL_NAME = "nvidia/DeepSeek-R1-0528-FP4"  #  "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B"
+MODEL_REVISION = "91cfc7c35acd8ecfc769205989310208b8b81c9c"  # "6e8885a6ff5c1dc5201574c8fd700323f23c25fa"
+
+# Although vLLM will download weights from Hugging Face on-demand,
+# we want to cache them so we don't do it every time our server starts.
+# We'll use [Modal Volumes](https://modal.com/docs/guide/volumes) for our cache.
+# Modal Volumes are essentially a "shared disk" that all Modal Functions can access like it's a regular disk.
+
+app_name = "example-vllm-deepseek"
+
+hf_cache_vol = modal.Volume.from_name(f"{app_name}-hf-cache", create_if_missing=True)
+
+# We'll also cache some of vLLM's JIT compilation artifacts in a Modal Volume.
+
+vllm_cache_vol = modal.Volume.from_name(
+    f"{app_name}-vllm-cache", create_if_missing=True
+)
+
+# We set the `HF_HOME` and `VLLM_CACHE_ROOT` environment variables to point to the Volumes so that the model weights
+# and JIT compilation artifacts are cached there.
+
+HF_CACHE_PATH = Path("/hf_cache")
+VLLM_CACHE_PATH = Path("/vllm_cache")
+
+MODELS_PATH = HF_CACHE_PATH / "models"
+ARTIFACTS_PATH = VLLM_CACHE_PATH / "artifacts"
+
+volumes = {
+    HF_CACHE_PATH: hf_cache_vol,
+    VLLM_CACHE_PATH: vllm_cache_vol,
+}
+
+# Note though that even though we've pre-download the model weights,
+# having all workers (1 per GPU) read the entire checkpoint takes a while.
+# Therefore, we'll [shard the checkpoint](https://docs.vllm.ai/en/stable/examples/offline_inference/save_sharded_state.html)
+# such that each worker loads their model state dict separately.
+
+N_GPUS = 8
+GPU_CONFIG = f"B200:{N_GPUS}"
+MODEL_DIR = MODELS_PATH / MODEL_NAME
+MODEL_SHARD_DIR = MODEL_DIR / "sharded"
+
+
+def download_model_and_shard():
+    from huggingface_hub import snapshot_download
+    from vllm import LLM
+
+    print("downloading base model if necessary")
+    snapshot_download(
+        MODEL_NAME,
+        local_dir=MODEL_DIR,
+        ignore_patterns=["*.pt", "*.bin"],  # using safetensors
+        revision=MODEL_REVISION,
+    )
+
+    print("sharding checkpoint for each GPU")
+    llm = LLM(
+        model=str(MODEL_DIR),
+        tensor_parallel_size=N_GPUS,
+        revision=MODEL_REVISION,
+    )
+
+    Path(MODEL_SHARD_DIR).mkdir(exist_ok=True)
+
+    # Check which engine version is being used
+    is_v1_engine = hasattr(llm.llm_engine, "engine_core")
+
+    if is_v1_engine:
+        # For V1 engine, we need to use engine_core.save_sharded_state
+        print("Using V1 engine save path")
+        llm.llm_engine.engine_core.save_sharded_state(
+            path=str(MODEL_SHARD_DIR),
+        )
+    else:
+        # For V0 engine
+        print("Using V0 engine save path")
+        model_executor = llm.llm_engine.model_executor
+        model_executor.save_sharded_state(
+            path=str(MODEL_SHARD_DIR),
+        )
+
+    # Copy metadata files to output directory
+    for file in os.listdir(MODEL_DIR):
+        if os.path.splitext(file)[1] not in (".bin", ".pt", ".safetensors"):
+            if os.path.isdir(os.path.join(MODEL_DIR, file)):
+                shutil.copytree(
+                    os.path.join(MODEL_DIR, file),
+                    os.path.join(MODEL_SHARD_DIR, file),
+                    dirs_exist_ok=True,
+                )
+            else:
+                shutil.copy(os.path.join(MODEL_DIR, file), MODEL_SHARD_DIR)
+
+
+vllm_image = vllm_image.env(
+    {
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",  # faster model transfers
+        "HF_HOME": str(MODELS_PATH),
+        "VLLM_CACHE_ROOT": str(ARTIFACTS_PATH),
+    }
+).run_function(download_model_and_shard, volumes=volumes, gpu=GPU_CONFIG)
+
+# On the first container start, we mount the Volume, download the model, and build the engine,
+# which takes a few minutes. Subsequent starts will be much faster,
+# as the engine is cached in the Volume and loaded in seconds.
+
+# Container starts are triggered when Modal scales up your Function,
+# like the first time you run this code or the first time a request comes in after a period of inactivity.
+# For details on optimizing container start latency, see
+# [this guide](https://modal.com/docs/guide/cold-start).
+
+# ## Build a vLLM engine and serve it
+
+# The function below spawns a vLLM instance listening at port 8000, serving requests to our model.
+# We wrap it in the [`@modal.web_server` decorator](https://modal.com/docs/guide/webhooks#non-asgi-web-servers)
+# to connect it to the Internet.
+
+# The server runs in an independent process, via `subprocess.Popen`, and only starts accepting requests
+# once the model is spun up and the `serve` function returns.
+
+app = modal.App(app_name)
+
+MINUTES = 60  # seconds
+MAX_BATCH_SIZE = 32  # how many requests can one replica handle? tune carefully!
+VLLM_PORT = 8000
+
+
+@app.function(
+    image=vllm_image,
+    gpu=GPU_CONFIG,
+    scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
+    timeout=10 * MINUTES,  # how long should we wait for container start?
+    volumes=volumes,
+)
+@modal.concurrent(max_inputs=MAX_BATCH_SIZE)
+@modal.web_server(port=VLLM_PORT, startup_timeout=10 * MINUTES)
+def serve():
+    import subprocess
+
+    cmd = [
+        "vllm",
+        "serve",
+        "--uvicorn-log-level=info",
+        str(MODEL_SHARD_DIR),
+        "--revision",
+        MODEL_REVISION,
+        "--served-model-name",
+        MODEL_NAME,
+        "llm",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(VLLM_PORT),
+        "--load-format",
+        "sharded_state",
+    ]
+
+    # enforce-eager disables both Torch compilation and CUDA graph capture
+    # default is no-enforce-eager. see the --compilation-config flag for tighter control
+    cmd += ["--enforce-eager" if FAST_BOOT else "--no-enforce-eager"]
+
+    # assume multiple GPUs are for splitting up large matrix multiplications
+    cmd += ["--tensor-parallel-size", str(N_GPUS)]
+
+    print(cmd)
+
+    subprocess.Popen(" ".join(cmd), shell=True)
+
+
+# ## Deploy the server
+
+# To deploy the API on Modal, just run
+# ```bash
+# modal deploy vllm_deepseek.py
+# ```
+
+# This will create a new app on Modal, build the container image for it if it hasn't been built yet,
+# and deploy the app.
+
+# ## Interact with the server
+
+# Once it is deployed, you'll see a URL appear in the command line,
+# something like `https://your-workspace-name--example-vllm-deepseek-serve.modal.run`.
+
+# You can find [interactive Swagger UI docs](https://swagger.io/tools/swagger-ui/)
+# at the `/docs` route of that URL, i.e. `https://your-workspace-name--example-vllm-openai-compatible-serve.modal.run/docs`.
+# These docs describe each route and indicate the expected input and output
+# and translate requests into `curl` commands.
+
+# For simple routes like `/health`, which checks whether the server is responding,
+# you can even send a request directly from the docs.
+
+# To interact with the API programmatically in Python, we recommend the `openai` library.
+
+# See the `client.py` script in the examples repository
+# [here](https://github.com/modal-labs/modal-examples/tree/main/06_gpu_and_ml/llm-serving/openai_compatible)
+# to take it for a spin:
+
+# ```bash
+# # pip install openai==1.76.0
+# python openai_compatible/client.py
+# ```
+
+# ## Testing the server
+
+# To make it easier to test the server setup, we also include a `local_entrypoint`
+# that does a healthcheck and then hits the server.
+
+# If you execute the command
+
+# ```bash
+# modal run vllm_deepseek.py
+# ```
+
+# a fresh replica of the server will be spun up on Modal while
+# the code below executes on your local machine.
+
+# Think of this like writing simple tests inside of the `if __name__ == "__main__"`
+# block of a Python script, but for cloud deployments!
+
+
+@app.local_entrypoint()
+async def test(test_timeout=10 * MINUTES):
+    url = serve.get_web_url()
+
+    system_prompt = {
+        "role": "system",
+        "content": """
+        You are a helpful assistant that only responds in English and can generate HTML pages, and only responds with the HTML.
+        """,
+    }
+
+    prompt = """
+    Create an HTML page implementing a simple game of tic-tac-toe.
+    Only output the HTML, no other text.
+    """
+
+    messages = [  # OpenAI chat format
+        system_prompt,
+        {"role": "user", "content": prompt},
+    ]
+
+    async with aiohttp.ClientSession(base_url=url) as session:
+        print(f"Running health check for server at {url}")
+        async with session.get("/health", timeout=test_timeout - 1 * MINUTES) as resp:
+            up = resp.status == 200
+        assert up, f"Failed health check for server at {url}"
+        print(f"Successful health check for server at {url}")
+
+        print(f"Sending messages to {url}:", *messages, sep="\n\t")
+        output = await _send_request(session, "llm", messages)
+
+    # post-process
+    html_content = (
+        output.split("</think>")[-1].split("```html")[-1].split("```")[0].strip()
+    )
+
+    html_filename = Path(__file__).parent / "tic_tac_toe.html"
+    with open(html_filename, "w") as f:
+        f.write(html_content)
+
+    file_path = os.path.abspath(html_filename)
+    file_url = f"file://{file_path}"
+    print(f"\nHTML saved to: {file_path}")
+    print(f"Opening in browser: {file_url}")
+    webbrowser.open(file_url)
+
+
+async def _send_request(
+    session: aiohttp.ClientSession, model: str, messages: list
+) -> str:
+    # `stream=True` tells an OpenAI-compatible backend to stream chunks
+    payload: dict[str, object] = {"messages": messages, "model": model, "stream": True}
+
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+
+    output = ""
+    async with session.post(
+        "/v1/chat/completions", json=payload, headers=headers, timeout=1 * MINUTES
+    ) as resp:
+        async for raw in resp.content:
+            resp.raise_for_status()
+            # extract new content and stream it
+            line = raw.decode().strip()
+            if not line or line == "data: [DONE]":
+                continue
+            if line.startswith("data: "):  # SSE prefix
+                line = line[len("data: ") :]
+
+            chunk = json.loads(line)
+            assert (
+                chunk["object"] == "chat.completion.chunk"
+            )  # or something went horribly wrong
+            content = chunk["choices"][0]["delta"]["content"]
+            if content:
+                output += content
+                print(content, end="")
+    print()
+    return output


### PR DESCRIPTION
This is an example to run NVIDIA's Deepseek-R1-0528-FP4 with TensorRT-LLM on 8 B200 GPUs.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [☑️] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [☑️] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [☑️] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [☑️] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [☑️] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [☑️] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [☑️] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [☑️] Example pins all dependencies in container images
    - [☑️] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [☑️] Example specifies a `python_version` for the base image, if it is used 
    - [☑️] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [☑️] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
