### PR TITLE
[DO NOT MERGE] Smolagent example with Modal Executor

### DIFF
--- a/misc/smolagent_modal/modal_executor.py
+++ b/misc/smolagent_modal/modal_executor.py
@@ -60,7 +60,7 @@ def get_executor_cls():
             super().__init__(additional_imports, logger)
 
             sandbox_image = (
-                modal.Image.debian_slim().pip_install(*additional_imports).add_local_python_source("sql_engine")
+                modal.Image.debian_slim().pip_install(*additional_imports)
             )
             self.additional_imports = additional_imports
 

--- a/misc/smolagent_modal/modal_executor.py
+++ b/misc/smolagent_modal/modal_executor.py
@@ -1,0 +1,137 @@
+from textwrap import dedent
+import json
+import pickle
+import base64
+from typing import Any
+import inspect
+import modal
+
+
+def driver_program():
+    import json
+    import sys
+    from contextlib import redirect_stderr, redirect_stdout
+    from io import StringIO
+
+    globals: dict[str, Any] = {}
+    while True:
+        command = json.loads(input())  # read a line of JSON from stdin
+        code = command.get("code")
+        if code is None:
+            print(json.dumps({"error": "No code to execute"}))
+            continue
+
+        # Capture the executed code's outputs
+        stdout_io, stderr_io = StringIO(), StringIO()
+        with redirect_stdout(stdout_io), redirect_stderr(stderr_io):
+            try:
+                exec(code, globals)
+            except Exception as e:
+                print(f"Execution Error: {e}", file=sys.stderr)
+
+        print(
+            json.dumps(
+                {
+                    "stdout": stdout_io.getvalue(),
+                    "stderr": stderr_io.getvalue(),
+                }
+            ),
+            flush=True,
+        )
+
+
+def run_code(p: modal.container_process.ContainerProcess, code: str):
+    p.stdin.write(json.dumps({"code": code}))
+    p.stdin.write("\n")
+    p.stdin.drain()
+    next_line = next(iter(p.stdout))
+    result = json.loads(next_line)
+    return result["stdout"], result["stderr"]
+
+
+def get_executor_cls():
+    from smolagents.remote_executors import RemotePythonExecutor
+    from smolagents.monitoring import LogLevel
+    from smolagents.utils import AgentError
+    from smolagents.tools import get_tools_definition_code
+
+    class ModalExecutor(RemotePythonExecutor):
+        def __init__(self, additional_imports: list[str], logger, app, **kwargs):
+            super().__init__(additional_imports, logger)
+
+            sandbox_image = (
+                modal.Image.debian_slim().pip_install(*additional_imports).add_local_python_source("sql_engine")
+            )
+            self.additional_imports = additional_imports
+
+            self.sandbox = modal.Sandbox.create(app=app, image=sandbox_image)
+
+            self.logger.log("ModalExecutor is running", level=LogLevel.INFO)
+
+            driver_program_text = inspect.getsource(driver_program)
+            driver_program_command = f"""{driver_program_text}\n\ndriver_program()"""
+            self.p = self.sandbox.exec("python", "-c", driver_program_command)
+
+        def send_variables(self, variables: dict):
+            if not variables:
+                return
+            return super().send_variables(variables)
+
+        def send_tools(self, tools):
+            # Install tool packages
+            print("tools", tools)
+            packages_to_install = {
+                pkg
+                for tool in tools.values()
+                for pkg in tool.to_dict()["requirements"]
+                if pkg not in self.installed_packages + ["smolagents"]
+            }
+            if packages_to_install:
+                self.installed_packages += self.install_packages(list(packages_to_install))
+            # Get tool definitions
+            code = get_tools_definition_code(tools)
+            if code:
+                execution = self.run_code_raise_errors(code)
+                self.logger.log(execution[1])
+
+        def run_code_raise_errors(self, code_action, return_final_answer=False):
+            PICKLE_PREFIX = "RESULT_PICKLE:"
+            wrapped_code = code_action
+            if return_final_answer:
+                match = self.final_answer_pattern.search(code_action)
+                if match:
+                    pre_final_answer_code = self.final_answer_pattern.sub("", code_action)
+                    result_expr = match.group(1)
+                    wrapped_code = pre_final_answer_code + dedent(f"""
+                        import pickle, base64
+                        _result = {result_expr}
+                        print("{PICKLE_PREFIX}" + base64.b64encode(pickle.dumps(_result)).decode())
+                        """)
+
+            stdout, stderr = run_code(self.p, wrapped_code)
+            result = None
+
+            if stderr:
+                logs = f"Executing code yielded an error: {stderr}"
+                raise AgentError(logs, self.logger)
+
+            if return_final_answer:
+                if not stdout:
+                    raise AgentError("No result returned by executor!", self.logger)
+
+                if stdout.startswith("RESULT_PICKLE:"):
+                    pickle_data = stdout[len(PICKLE_PREFIX) :].strip()
+                    result = pickle.loads(base64.b64decode(pickle_data))
+
+            return result, stdout
+
+        def install_packages(self, additional_imports):
+            if additional_imports:
+                out = self.sandbox.exec("python", "-m", "pip", "install", *additional_imports)
+                self.logger.log(out.stdout.read())
+            return additional_imports
+
+        def cleanup(self):
+            self.sandbox.terminate()
+
+    return ModalExecutor

--- a/misc/smolagent_modal/simple.py
+++ b/misc/smolagent_modal/simple.py
@@ -40,7 +40,7 @@ class MyAgent:
         ModelExecutor = get_executor_cls()
 
         # If we upstream a modal exeuctor, then we can write:
-        # agent = CodeAgent(tools=[], model=model, executor_type="modal")
+        # agent = CodeAgent(tools=[], model=model, executor_type="modal", executor_kwargs={"app": app})
         agent = CodeAgent(tools=[], model=model)
         agent.python_executor = ModelExecutor([], agent.logger, app=app)
 

--- a/misc/smolagent_modal/simple.py
+++ b/misc/smolagent_modal/simple.py
@@ -13,7 +13,7 @@ image = (
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
     .add_local_python_source("modal_executor")
 )
-app = modal.App("smolagent-text-to-sql")
+app = modal.App("smolagent-simple")
 
 hf_cache_vol = modal.Volume.from_name("smol-agent-huggingface-cache", create_if_missing=True)
 vllm_cache_vol = modal.Volume.from_name("smol-agent-vllm-cache", create_if_missing=True)
@@ -36,7 +36,7 @@ class MyAgent:
         from smolagents import VLLMModel, CodeAgent
         from modal_executor import get_executor_cls
 
-        model = VLLMModel(model_id="Qwen/Qwen2.5-Coder-7B-Instruct")
+        model = VLLMModel(model_id="Qwen/Qwen2.5-Coder-7B-Instruct", model_kwargs={"enforce_eager": False})
         ModelExecutor = get_executor_cls()
 
         # If we upstream a modal exeuctor, then we can write:

--- a/misc/smolagent_modal/simple.py
+++ b/misc/smolagent_modal/simple.py
@@ -1,0 +1,53 @@
+import modal
+
+image = (
+    modal.Image.debian_slim()
+    .pip_install(
+        "smolagents==1.18.0",
+        "vllm",
+        "torch",
+        "huggingface-hub[hf_transfer]==0.31.2",
+        "hf_xet==1.1.1",
+        "sqlalchemy",
+    )
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
+    .add_local_python_source("modal_executor")
+)
+app = modal.App("smolagent-text-to-sql")
+
+hf_cache_vol = modal.Volume.from_name("smol-agent-huggingface-cache", create_if_missing=True)
+vllm_cache_vol = modal.Volume.from_name("smol-agent-vllm-cache", create_if_missing=True)
+
+
+@app.cls(
+    cpu=4,
+    memory=8192,
+    gpu="A10G",
+    timeout=10 * 60,
+    volumes={
+        "/root/.cache/huggingface": hf_cache_vol,
+        "/root/.cache/vllm": vllm_cache_vol,
+    },
+    image=image,
+)
+class MyAgent:
+    @modal.enter()
+    def create_agent(self):
+        from smolagents import VLLMModel, CodeAgent
+        from modal_executor import get_executor_cls
+
+        model = VLLMModel(model_id="Qwen/Qwen2.5-Coder-7B-Instruct")
+        ModelExecutor = get_executor_cls()
+
+        # If we upstream a modal exeuctor, then we can write:
+        # agent = CodeAgent(tools=[], model=model, executor_type="modal")
+        agent = CodeAgent(tools=[], model=model)
+        agent.python_executor = ModelExecutor([], agent.logger, app=app)
+
+        self.agent = agent
+
+    @modal.method()
+    def run_agent(self):
+        result = self.agent.run("Can you give me the 100th Fibonacci number?")
+        print(result)
+        return result


### PR DESCRIPTION
Quick POC for creating a Modal Executor that works with Huggingface's `smolagent`

My example has a custom ModalExeuctor that works with smolagent. If we were to upstream it, I can see user code to looking like:

```python
from smolagents import CodeAgent

app = modal.App("smolagent")
agent = CodeAgent(..., executor_type="modal", executor_kwargs={"app": app})
```

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
