### PR TITLE
Update example to reflect no longer api

### DIFF
--- a/06_gpu_and_ml/audio-editing/playdiffusion-model.py
+++ b/06_gpu_and_ml/audio-editing/playdiffusion-model.py
@@ -1,14 +1,14 @@
 # ---
 # output-directory: "/tmp/playdiffusion"
-# cmd: ["modal", "run", "06_gpu_and_ml/audio-editing/playdiffusion-api.py"]
+# cmd: ["modal", "run", "06_gpu_and_ml/audio-editing/playdiffusion-model.py"]
 # args: ["--audio-url", "https://modal-public-assets.s3.us-east-1.amazonaws.com/mono_44100_127389__acclivity__thetimehascome.wav", "--output-text", "November, '9 PM. I'm standing in alley. After waiting several hours, the time has come. A man with long dark hair approaches. I have to act and fast before he realizes what has happened. I must find out.", "--output-path", "/tmp/playdiffusion/output.wav"]
 # ---
 
 
-# # Create a PlayDiffusion API on Modal
+# # Run PlayDiffusion on Modal
 
-# This example demonstrates how to deploy a PlayDiffusion audio editing API using the PlayDiffusion model on Modal.
-# The API accepts text prompts and input audio as WAV files and returns generated audio as WAV files through a FastAPI endpoint.
+# This example demonstrates how to run the PlayDiffusion audio editing model on Modal.
+# The function accepts text prompts and input audio as WAV files and returns generated audio as WAV files.
 # We use Modal's class-based approach with GPU acceleration to provide fast, scalable inference.
 
 # ## Setup
@@ -26,7 +26,6 @@ import modal
 # ## Define a container image
 
 # We start with Modal's baseline `debian_slim` image and install the required packages.
-# - `fastapi`: Web framework for creating the API endpoint
 # - `openai`: PlayDiffusion requires a transcript as input. You can either provide the transcript yourself as input, or use a transcription model to transcribe the audio on the fly. In this case we use openai's whisper api, but you can use any model of your choice.
 AUDIO_URL: str = "https://github.com/voxserv/audio_quality_testing_samples/raw/refs/heads/master/mono_44100/156550__acclivity__a-dream-within-a-dream.wav"
 
@@ -34,12 +33,12 @@ AUDIO_URL: str = "https://github.com/voxserv/audio_quality_testing_samples/raw/r
 image: modal.Image = (
     modal.Image.debian_slim(python_version="3.11")
     .apt_install("git")
-    .pip_install("fastapi[standard]==0.115.13", "openai==1.91.0")
+    .pip_install("openai==1.91.0")
     .run_commands(
         "pip install git+https://github.com/playht/PlayDiffusion.git@d3995b9e2cd8a80b88be6aeeb4e35fd282b2d255"
     )
 )
-app: modal.App = modal.App("playdiffusion-api-example", image=image)
+app: modal.App = modal.App("playdiffusion-model-example", image=image)
 
 # Import the required libraries within the image context to ensure they're available
 # when the container runs. This includes audio processing and the TTS model itself.
@@ -147,7 +146,7 @@ def main(audio_url: str, output_text: str, output_path: str) -> None:
 
 
 # Example command line invocation:
-# `modal run playdiffusion-api.py --audio-url "https://modal-public-assets.s3.us-east-1.amazonaws.com/mono_44100_127389__acclivity__thetimehascome.wav" --output-text "November, '9 PM. I'm standing in alley. After waiting several hours, the time has come. A man with long dark hair approaches. I have to act and fast before he realizes what has happened. I must find out." --output-path "/tmp/playdiffusion/output.wav"`
+# `modal run playdiffusion-model.py --audio-url "https://modal-public-assets.s3.us-east-1.amazonaws.com/mono_44100_127389__acclivity__thetimehascome.wav" --output-text "November, '9 PM. I'm standing in alley. After waiting several hours, the time has come. A man with long dark hair approaches. I have to act and fast before he realizes what has happened. I must find out." --output-path "/tmp/playdiffusion/output.wav"`
 
 
 # Some utility functions


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
