### PR TITLE
Update sdxl turbo img-to-img eg to use flux kontext

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -10,9 +10,9 @@
 # For example, the model transformed the image on the left into the image on the right based on the prompt
 # _dog wizard, gandalf, lord of the rings, detailed, fantasy, cute, adorable, Pixar, Disney, 8k_.
 
-# ![](https://modal-cdn.com/cdnbot/sd-im2im-dog-8sanham3_915c7d4c.webp)
+# ![](https://modal-cdn.com/cdnbot/outputkyaht0zg_6c034cc6.webp)
 
-# The model is from Black Forest Labs' [FLUX.1-Kontext-dev](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev).
+# The model is Black Forest Labs' [FLUX.1-Kontext-dev](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev).
 # Learn more about the model [here](https://bfl.ai/announcements/flux-1-kontext-dev).
 
 # ## Define a container image

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -8,7 +8,7 @@
 # the model takes in a prompt and an image and transforms the image to better match the prompt.
 
 # For example, the model transformed the image on the left into the image on the right based on the prompt
-# _dog wizard, gandalf, lord of the rings, detailed, fantasy, cute, adorable, Pixar, Disney, 8k_.
+# _dog wizard, gandalf, lord of the rings, detailed, fantasy, cute, Studio Ghibli.
 
 # ![](https://modal-cdn.com/cdnbot/outputkyaht0zg_6c034cc6.webp)
 

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -2,9 +2,9 @@
 # output-directory: "/tmp/stable-diffusion"
 # ---
 
-# # Transform images with SDXL Turbo
+# # Transform images with Flux Kontext
 
-# In this example, we run the SDXL Turbo model in _image-to-image_ mode:
+# In this example, we run the Flux Kontext model in _image-to-image_ mode:
 # the model takes in a prompt and an image and transforms the image to better match the prompt.
 
 # For example, the model transformed the image on the left into the image on the right based on the prompt
@@ -12,8 +12,8 @@
 
 # ![](https://modal-cdn.com/cdnbot/sd-im2im-dog-8sanham3_915c7d4c.webp)
 
-# SDXL Turbo is a distilled model designed for fast, interactive image synthesis.
-# Learn more about it [here](https://stability.ai/news/stability-ai-sdxl-turbo).
+# The model is from Black Forest Labs' [FLUX.1-Kontext-dev](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev).
+# Learn more about the model [here](https://bfl.ai/announcements/flux-1-kontext-dev).
 
 # ## Define a container image
 
@@ -25,41 +25,51 @@ from pathlib import Path
 
 import modal
 
-CACHE_DIR = "/cache"
+diffusers_commit_sha = "00f95b9755718aabb65456e791b8408526ae6e76"
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git")
     .pip_install(
-        "accelerate~=0.25.0",  # Allows `device_map="auto"``, for computation of optimized device_map
-        "diffusers~=0.24.0",  # Provides model libraries
-        "huggingface-hub[hf-transfer]~=0.25.2",  # Lets us download models from Hugging Face's Hub
-        "Pillow~=10.1.0",  # Image manipulation in Python
-        "safetensors~=0.4.1",  # Enables safetensor format as opposed to using unsafe pickle format
-        "transformers~=4.35.2",  # This is needed for `import torch`
-    )
-    .env(
-        {
-            "HF_HUB_ENABLE_HF_TRANSFER": "1",  # Allows faster model downloads
-            "HF_HUB_CACHE": CACHE_DIR,  # Points the Hugging Face cache to a Volume
-        }
+        "accelerate~=1.8.1",  # Allows `device_map="balanced"``, for computation of optimized device_map
+        f"git+https://github.com/huggingface/diffusers.git@{diffusers_commit_sha}",  # Provides model libraries
+        "huggingface-hub[hf-transfer]~=0.33.1",  # Lets us download models from Hugging Face's Hub
+        "Pillow~=11.0.0",  # Image manipulation in Python
+        "safetensors~=0.5.3",  # Enables safetensor format as opposed to using unsafe pickle format
+        "transformers~=4.53.0",
+        "sentencepiece~=0.2.0",
     )
 )
 
-cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
+MODEL_NAME = "black-forest-labs/FLUX.1-Kontext-dev"
 
-app = modal.App("image-to-image", image=image, volumes={CACHE_DIR: cache_volume})
+CACHE_DIR = Path("/cache")
+cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
+volumes = {CACHE_DIR: cache_volume}
+
+secrets = [modal.Secret.from_name("huggingface-secret")]
+
+
+image = image.env(
+    {
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",  # Allows faster model downloads
+        "HF_HOME": str(CACHE_DIR),  # Points the Hugging Face cache to a Volume
+    }
+)
+
+
+app = modal.App("image-to-image")
 
 with image.imports():
     import torch
-    from diffusers import AutoPipelineForImage2Image
+    from diffusers import FluxKontextPipeline
     from diffusers.utils import load_image
-    from huggingface_hub import snapshot_download
     from PIL import Image
 
 
-# ## Downloading, setting up, and running SDXL Turbo
+# ## Setting up and running Flux Kontext
 
-# The Modal `Cls` defined below contains all the logic to download, set up, and run SDXL Turbo.
+# The Modal `Cls` defined below contains all the logic to set up and run Flux Kontext.
 
 # The [container lifecycle](https://modal.com/docs/guide/lifecycle-functions#container-lifecycle-beta) decorator
 # (`@modal.enter()`) ensures that the model is loaded into memory when a container starts, before it picks up any inputs.
@@ -70,50 +80,33 @@ with image.imports():
 # To avoid excessive cold-starts, we set the `scaledown_window` to 240 seconds, meaning once a GPU has loaded the model it will stay
 # online for 4 minutes before spinning down.
 
-# We also provide a function that will download the model weights to the cache Volume ahead of time.
-# You can run this function directly with `modal run`. Otherwise, the weights will be cached after the
-# first container cold start.
 
-
-@app.function()
-def download_models():
-    # Ignore files that we don't need to speed up download time.
-    ignore = [
-        "*.bin",
-        "*.onnx_data",
-        "*/diffusion_pytorch_model.safetensors",
-    ]
-
-    snapshot_download("stabilityai/sdxl-turbo", ignore_patterns=ignore)
-
-
-@app.cls(gpu="A10G", scaledown_window=240)
+@app.cls(
+    image=image, gpu="H100", volumes=volumes, secrets=secrets, scaledown_window=240
+)
 class Model:
     @modal.enter()
     def enter(self):
-        self.pipe = AutoPipelineForImage2Image.from_pretrained(
-            "stabilityai/sdxl-turbo",
-            torch_dtype=torch.float16,
-            variant="fp16",
-            device_map="auto",
+        print(f"Downloading {MODEL_NAME} if necessary...")
+        self.pipe = FluxKontextPipeline.from_pretrained(
+            MODEL_NAME,
+            revision="f9fdd1a95e0dfd7653cb0966cda2486745122695",
+            torch_dtype=torch.bfloat16,
+            device_map="balanced",
+            cache_dir=CACHE_DIR,
         )
 
     @modal.method()
     def inference(
-        self, image_bytes: bytes, prompt: str, strength: float = 0.9
+        self, image_bytes: bytes, prompt: str, guidance_scale: float = 2.5
     ) -> bytes:
         init_image = load_image(Image.open(BytesIO(image_bytes))).resize((512, 512))
-        num_inference_steps = 4
-        # "When using SDXL-Turbo for image-to-image generation, make sure that num_inference_steps * strength is larger or equal to 1"
-        # See: https://huggingface.co/stabilityai/sdxl-turbo
-        assert num_inference_steps * strength >= 1
 
         image = self.pipe(
-            prompt,
             image=init_image,
-            num_inference_steps=num_inference_steps,
-            strength=strength,
-            guidance_scale=0.0,
+            prompt=prompt,
+            guidance_scale=guidance_scale,
+            generator=torch.Generator().manual_seed(42),
         ).images[0]
 
         byte_stream = BytesIO()


### PR DESCRIPTION
Update the SDXL Turbo image to image example to use Flux Kontext.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
