### PR TITLE
Add example for maintaining a pool of warm sandboxes

### DIFF
--- a/13_sandboxes/sandbox_pool.py
+++ b/13_sandboxes/sandbox_pool.py
@@ -1,0 +1,123 @@
+# ---
+# cmd: ["python", "13_sandboxes/sandbox_pool.py"]
+# pytest: false
+# ---
+
+# # Build a pool of warm sandboxes that are healthy and ready to serve requests
+
+
+import time
+
+import modal
+
+app = modal.App("sandbox-pool")
+
+pool_queue = modal.Queue.from_name("sandbox-pool-buffer", create_if_missing=True)
+
+server_image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "fastapi[standard]",
+    "requests",
+)
+sandbox_image = modal.Image.debian_slim()
+
+
+SERVER_PORT = 8080
+HEALTH_CHECK_TIMEOUT_SECONDS = 10
+SANDBOX_TIMEOUT_SECONDS = 60 * 60
+SANDBOX_USE_DURATION_SECONDS = 5 * 60
+DEFAULT_POOL_SIZE = 2
+
+
+def health_check_sandbox(daemon_url):
+    import requests
+
+    start_time = time.time()
+    while time.time() - start_time < HEALTH_CHECK_TIMEOUT_SECONDS:
+        try:
+            response = requests.get(daemon_url, timeout=HEALTH_CHECK_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            return
+        except requests.RequestException:
+            if time.time() - start_time >= HEALTH_CHECK_TIMEOUT_SECONDS:
+                raise
+            time.sleep(0.1)
+
+    raise requests.RequestException("Health check failed")
+
+
+@app.function(image=server_image)
+@modal.concurrent(max_inputs=100)
+def add_sandbox_to_queue():
+    # This is done so we don't create sandboxes in the ephemeral app
+    deployed_app = modal.App.lookup("sandbox-pool", create_if_missing=True)
+
+    server_command = ["python", "-m", "http.server", f"{SERVER_PORT}"]
+    sb = modal.Sandbox.create(
+        *server_command,
+        app=deployed_app,
+        image=sandbox_image,
+        encrypted_ports=[SERVER_PORT],
+        timeout=SANDBOX_TIMEOUT_SECONDS,
+    )
+    expiration_time = int(time.time()) + SANDBOX_TIMEOUT_SECONDS
+    url = sb.tunnels()[SERVER_PORT].url
+
+    health_check_sandbox(url)
+
+    pool_queue.put((sb.object_id, url, expiration_time))
+
+
+@app.function(image=server_image)
+@modal.fastapi_endpoint()
+@modal.concurrent(max_inputs=100)
+def get_sandbox() -> str:
+    while res := pool_queue.get(block=True):
+        sb_id, url, expiration_time = res
+
+        # backfill + ensures the queue will have at least one sandbox
+        add_sandbox_to_queue.spawn()
+
+        if expiration_time < time.time() + SANDBOX_USE_DURATION_SECONDS:
+            print(f"Sandbox {sb_id} does not have enough time left - removing it")
+            sb = modal.Sandbox.from_id(sb_id)
+            sb.terminate()
+            continue
+
+        return url
+
+    raise RuntimeError("No sandbox with enough time left")
+
+
+@app.local_entrypoint()
+def resize_pool(target: int = DEFAULT_POOL_SIZE):
+    if target < 0:
+        raise ValueError("Target pool size must be non-negative")
+
+    current_size = pool_queue.len()
+    diff = target - current_size
+
+    if diff > 0:
+        for _ in add_sandbox_to_queue.starmap(() for _ in range(diff)):
+            pass
+    elif diff < 0:
+        for _ in range(-diff):
+            if res := pool_queue.get(block=False):
+                sb_id, _, _ = res
+                sb = modal.Sandbox.from_id(sb_id)
+                sb.terminate()
+            else:
+                break
+
+    print(f"Changed pool size by {diff:+d}, now at {pool_queue.len()} sandboxes.")
+
+
+@app.local_entrypoint()
+def check_pool(verbose: bool = False):
+    print(f"Number of sandboxes in the pool: {pool_queue.len()}")
+    if verbose:
+        for sb_id, url, expiration_time in pool_queue.iterate():
+            seconds_left = expiration_time - time.time()
+            print(
+                f"Sandbox '{sb_id}' is at {url} and expires at {expiration_time} "
+                f"({seconds_left} seconds left)"
+            )


### PR DESCRIPTION
[**NB:** I know documentation and comments are missing, and I'd need to adapt it to the repo guidelines, so this is not intended for full review yet, just to get early feedback on the overall functionality and flow. I'm also not sure this is a good fit for this repo at all or if you should rather put it somewhere else.]

This is currently what it looks like:

```sh
> modal deploy 13_sandboxes/sandbox_pool.py
...
└── 🔨 Created web function get_sandbox => https://modal-labs-eric-hansander-dev--sandbox-pool-get-sandbox.modal.run

> modal run 13_sandboxes/sandbox_pool.py::check_pool --verbose
...
Number of sandboxes in the pool: 0

> modal run 13_sandboxes/sandbox_pool.py::resize_pool --target 2
...
Changed pool size by +2, now at 2 sandboxes.

# Claim one sandbox from the pool (note: curling the deployed app here!)
> curl https://modal-labs-eric-hansander-dev--sandbox-pool-get-sandbox.modal.run
"https://p7w3b4twc0t9f6.r404.modal.host"

# Ping the web server in the sandbox
> curl https://p7w3b4twc0t9f6.r404.modal.host
<!DOCTYPE HTML>
<html lang="en">
...

# The pool is maintained at (at least) the same level
> modal run 13_sandboxes/sandbox_pool.py::check_pool --verbose
Number of sandboxes in the pool: 2
Sandbox 'sb-qu1zrx6JPiwo5sSuovn30J' is at https://moys8nnkvqyao4.r403.modal.host and expires at 1751037590 (268.2722198963165 seconds left)
Sandbox 'sb-QL7Atj224qMEKE42JWpqaP' is at https://rjguyhfj60wjf0.r401.modal.host and expires at 1751037589 (267.0822160243988 seconds left)

> modal run 13_sandboxes/sandbox_pool.py::resize_pool --target 0
...
Changed pool size by -2, now at 0 sandboxes.

> modal run 13_sandboxes/sandbox_pool.py::check_pool --verbose
...
Number of sandboxes in the pool: 0
```


<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
