### PR TITLE
remove empty headers

### DIFF
--- a/06_gpu_and_ml/audio-editing/playdiffusion-model.py
+++ b/06_gpu_and_ml/audio-editing/playdiffusion-model.py
@@ -58,7 +58,8 @@ with image.imports():
 
 # The service is implemented using Modal's class syntax with GPU acceleration.
 # We configure the class to use an A10G GPU with additional parameters:
-# #
+
+
 # - `scaledown_window=60 * 5`: Keep containers alive for 5 minutes after last request
 # - `@modal.concurrent(max_inputs=10)`: Allow up to 10 concurrent requests per containerå
 @app.cls(gpu="a10g", scaledown_window=60 * 5)

--- a/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
+++ b/06_gpu_and_ml/text-to-audio/chatterbox_tts.py
@@ -42,7 +42,7 @@ with image.imports():
 
 # The TTS service is implemented using Modal's class syntax with GPU acceleration.
 # We configure the class to use an A10G GPU with additional parameters:
-# #
+
 # - `scaledown_window=60 * 5`: Keep containers alive for 5 minutes after last request
 # - `enable_memory_snapshot=True`: Enable [memory snapshots](https://modal.com/docs/guide/memory-snapshot) to optimize cold boot times
 # - `@modal.concurrent(max_inputs=10)`: Allow up to 10 concurrent requests per container


### PR DESCRIPTION
These two examples had lines like
`# #`

which produce an empty h1 tag that 1) was likely unintended and 2) triggers an a11y warning from the Svelte compiler (below).

The preferred style for representing whitespace in the examples is actually just a blank line -- they are ignored during frontend rendering but create a similar visual separation in the raw code files.

![Screenshot 2025-06-27 at 2 11 32 PM](https://github.com/user-attachments/assets/7f620a3c-e9a3-4c66-8efe-bf3339053dbd)