### PR TITLE
aria label for links around videos

### DIFF
--- a/06_gpu_and_ml/llm-serving/llama_cpp.py
+++ b/06_gpu_and_ml/llm-serving/llama_cpp.py
@@ -14,7 +14,7 @@
 # our jobs are still safe, for now.
 
 # <center>
-# <a href="https://gist.github.com/charlesfrye/a3788c61019c32cb7947f4f5b1c04818"> <video controls autoplay loop muted> <source src="https://modal-cdn.com/example-flap-py.mp4" type="video/mp4"> </video> </a>
+# <a href="https://gist.github.com/charlesfrye/a3788c61019c32cb7947f4f5b1c04818" aria-label="View the generated code"> <video controls autoplay loop muted aria-hidden="true"> <source src="https://modal-cdn.com/example-flap-py.mp4" type="video/mp4"> </video> </a>
 # </center>
 
 from pathlib import Path

--- a/06_gpu_and_ml/llm-serving/llama_cpp.py
+++ b/06_gpu_and_ml/llm-serving/llama_cpp.py
@@ -14,7 +14,7 @@
 # our jobs are still safe, for now.
 
 # <center>
-# <a href="https://gist.github.com/charlesfrye/a3788c61019c32cb7947f4f5b1c04818" aria-label="View the generated code"> <video controls autoplay loop muted aria-hidden="true"> <source src="https://modal-cdn.com/example-flap-py.mp4" type="video/mp4"> </video> </a>
+# <a href="https://gist.github.com/charlesfrye/a3788c61019c32cb7947f4f5b1c04818" aria-label="View the generated code"> <video controls autoplay loop muted> <source src="https://modal-cdn.com/example-flap-py.mp4" type="video/mp4"> </video> </a>
 # </center>
 
 from pathlib import Path

--- a/06_gpu_and_ml/protein-folding/chai1.py
+++ b/06_gpu_and_ml/protein-folding/chai1.py
@@ -19,7 +19,7 @@
 # To experience the full power of Modal, try scaling inference up and running on hundreds or thousands of structures!
 
 # <center>
-# <a href="https://molstar.org/viewer" aria-label="Open the Mol* viewer"> <video controls autoplay loop muted aria-hidden="true"> <source src="https://modal-cdn.com/example-chai1-folding.mp4" type="video/mp4"> </video> </a>
+# <a href="https://molstar.org/viewer" aria-label="Open the Mol* viewer"> <video controls autoplay loop muted> <source src="https://modal-cdn.com/example-chai1-folding.mp4" type="video/mp4"> </video> </a>
 # </center>
 
 # ## Setup

--- a/06_gpu_and_ml/protein-folding/chai1.py
+++ b/06_gpu_and_ml/protein-folding/chai1.py
@@ -19,7 +19,7 @@
 # To experience the full power of Modal, try scaling inference up and running on hundreds or thousands of structures!
 
 # <center>
-# <a href="https://molstar.org/viewer"> <video controls autoplay loop muted> <source src="https://modal-cdn.com/example-chai1-folding.mp4" type="video/mp4"> </video> </a>
+# <a href="https://molstar.org/viewer" aria-label="Open the Mol* viewer"> <video controls autoplay loop muted aria-hidden="true"> <source src="https://modal-cdn.com/example-chai1-folding.mp4" type="video/mp4"> </video> </a>
 # </center>
 
 # ## Setup


### PR DESCRIPTION
Screen readers use link text when announcing links, but in a few places we use a video as the link content, so screen readers don't know what to announce (at least until video understanding models are a few hundred times faster).

This PR adds the appropriate [ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) attributes, which resolves a warning from the Svelte Compiler.