### PR TITLE
update css in img-to-img

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -20,7 +20,7 @@
 # <style>
 # @media (min-width: 768px) {
 #  #image-pair {
-#    flex-direction: row !important;
+#    flex-direction: row;
 #  }
 # }
 # </style>

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -10,18 +10,21 @@
 # For example, the model transformed the image on the left into the image on the right based on the prompt
 # "_A cute dog wizard inspired by Gandalf from Lord of the Rings, featuring detailed fantasy elements in Studio Ghibli style_".
 
-# <div style="display: flex; justify-content: center; align-items: center; gap: 10px; flex-direction: column;">
-# <img src="https://modal-cdn.com/cdnbot/dog878j0n1o_3179e00c.webp" alt="Before image transformation" width="200" height="200"/>
-# <img src="https://modal-cdn.com/cdnbot/contentn1z57lt1_4a3da38f.webp" alt="After image transformation" width="200" height="200"/>
+# <div style="display: flex; justify-content: center; align-items: center; gap: 10px; flex-direction: column;" id="image-pair">
+#  <img src="https://modal-cdn.com/cdnbot/dog878j0n1o_3179e00c.webp" alt="Before image transformation"
+#       style="width: 200px; height: 200px; object-fit: cover;" />
+#  <img src="https://modal-cdn.com/cdnbot/contentn1z57lt1_4a3da38f.webp" alt="After image transformation"
+#       style="width: 200px; height: 200px; object-fit: cover;" />
 # </div>
 #
 # <style>
 # @media (min-width: 768px) {
-#   div {
-#     flex-direction: row !important;
-#   }
+#  #image-pair {
+#    flex-direction: row !important;
+#  }
 # }
 # </style>
+
 
 # The model is Black Forest Labs' [FLUX.1-Kontext-dev](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev).
 # Learn more about the model [here](https://bfl.ai/announcements/flux-1-kontext-dev).

--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -7,24 +7,10 @@
 # In this example, we run the Flux Kontext model in _image-to-image_ mode:
 # the model takes in a prompt and an image and transforms the image to better match the prompt.
 
-# For example, the model transformed the image on the left into the image on the right based on the prompt
+# For example, the model transformed the first image into the second based on the prompt
 # "_A cute dog wizard inspired by Gandalf from Lord of the Rings, featuring detailed fantasy elements in Studio Ghibli style_".
 
-# <div style="display: flex; justify-content: center; align-items: center; gap: 10px; flex-direction: column;" id="image-pair">
-#  <img src="https://modal-cdn.com/cdnbot/dog878j0n1o_3179e00c.webp" alt="Before image transformation"
-#       style="width: 200px; height: 200px; object-fit: cover;" />
-#  <img src="https://modal-cdn.com/cdnbot/contentn1z57lt1_4a3da38f.webp" alt="After image transformation"
-#       style="width: 200px; height: 200px; object-fit: cover;" />
-# </div>
-#
-# <style>
-# @media (min-width: 768px) {
-#  #image-pair {
-#    flex-direction: row;
-#  }
-# }
-# </style>
-
+#  <img src="https://modal-cdn.com/dog-wizard-ghibli-flux-kontext.jpg" alt="A photo of a dog transformed into a cartoon of a cute dog wizard" />
 
 # The model is Black Forest Labs' [FLUX.1-Kontext-dev](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev).
 # Learn more about the model [here](https://bfl.ai/announcements/flux-1-kontext-dev).


### PR DESCRIPTION
adds `object-fit` so that the image covers the whole 200x200 block and uses an ID to target in place of all divs