### PR TITLE
Update Tailscale example to not use Dockerfile commands

### DIFF
--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -22,10 +22,8 @@ image = (
     .run_commands("curl -fsSL https://tailscale.com/install.sh | sh")
     .pip_install("requests==2.32.3", "PySocks==1.7.1")
     .add_local_file("./entrypoint.sh", "/root/entrypoint.sh", copy=True)
-    .dockerfile_commands(
-        "RUN chmod a+x /root/entrypoint.sh",
-        'ENTRYPOINT ["/root/entrypoint.sh"]',
-    )
+    .run_commands("chmod a+x /root/entrypoint.sh")
+    .entrypoint(["/root/entrypoint.sh"])
 )
 app = modal.App(image=image)
 


### PR DESCRIPTION
Substitutes manual Dockerfile commands with `run_commands` and `entrypoint`. 