### PR TITLE
Update Tailscale example to use `modal.is_local()`

### DIFF
--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -27,12 +27,15 @@ image = (
 )
 app = modal.App(image=image)
 
-# Configure Python to use the SOCKS5 proxy globally.
+# Packages might not be installed locally. This catches import errors and
+# only attemps imports in the container. 
 with image.imports():
     import socket
 
     import socks
 
+# Configure Python to use the SOCKS5 proxy globally.
+if not modal.is_local():
     socks.set_default_proxy(socks.SOCKS5, "0.0.0.0", 1080)
     socket.socket = socks.socksocket
 

--- a/10_integrations/tailscale/modal_tailscale.py
+++ b/10_integrations/tailscale/modal_tailscale.py
@@ -28,7 +28,7 @@ image = (
 app = modal.App(image=image)
 
 # Packages might not be installed locally. This catches import errors and
-# only attemps imports in the container. 
+# only attempts imports in the container.
 with image.imports():
     import socket
 


### PR DESCRIPTION
This guarantees that a configuration expected to happen only inside the container instead of applying them with `image.imports()`. This is better because imports might work locally, leading to the application of container-bound configurations locally.