### PR TITLE
pins flashinfer version to one that installs properly

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -88,6 +88,7 @@ tensorrt_image = tensorrt_image.apt_install(
 ).pip_install(
     "tensorrt-llm==0.18.0",
     "pynvml<12",  # avoid breaking change to pynvml version API
+    "flashinfer-python==0.2.5",
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )


### PR DESCRIPTION
More recent versions of flashinfer-python fail to install in this example. This PR pins to the most recent working version.

Didn't root cause this one -- the install is looking for the CUDA runtime, which should be present (though the CUDA drivers are not, which might be the issue).

Error message below, for posterity.
```
× Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [24 lines of output]
      No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
      /tmp/pip-build-env-vak8231l/overlay/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
      !!
      
              ********************************************************************************
              Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
      
              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        corresp(dist, value, root_dir)
      0 AOT ops found in /tmp/pip-install-42enva2j/flashinfer-python_6dc2acd3b3a04939828325398e65fc19/aot-ops
      running dist_info
      creating /tmp/pip-modern-metadata-felo182i/flashinfer_python.egg-info
      writing /tmp/pip-modern-metadata-felo182i/flashinfer_python.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-modern-metadata-felo182i/flashinfer_python.egg-info/dependency_links.txt
      writing requirements to /tmp/pip-modern-metadata-felo182i/flashinfer_python.egg-info/requires.txt
      writing top-level names to /tmp/pip-modern-metadata-felo182i/flashinfer_python.egg-info/top_level.txt
      writing manifest file '/tmp/pip-modern-metadata-felo182i/flashinfer_python.egg-info/SOURCES.txt'
      error: package directory '3rdparty/spdlog' does not exist
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Terminating task due to error: failed to run builder command "python -m pip install 'pynvml<12' tensorrt-llm==0.18.0 --extra-index-url https://pypi.nvidia.com/ --pre": container exit status: 1
Runner failed with exit code: -1
```