### PR TITLE
TRTLLM throughput version pin

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -86,8 +86,8 @@ tensorrt_image = modal.Image.from_registry(
 tensorrt_image = tensorrt_image.apt_install(
     "openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget"
 ).pip_install(
-    "tensorrt-llm==0.18.0",
-    "pynvml<12",  # avoid breaking change to pynvml version API
+    "tensorrt-llm==0.20.0",
+    "pynvml>=12.0.0",  # avoid breaking change to pynvml version API
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )

--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -87,7 +87,6 @@ tensorrt_image = tensorrt_image.apt_install(
     "openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget"
 ).pip_install(
     "tensorrt-llm==0.20.0",
-    "pynvml>=12.0.0",  # avoid breaking change to pynvml version API
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )

--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -86,7 +86,8 @@ tensorrt_image = modal.Image.from_registry(
 tensorrt_image = tensorrt_image.apt_install(
     "openmpi-bin", "libopenmpi-dev", "git", "git-lfs", "wget"
 ).pip_install(
-    "tensorrt-llm==0.20.0",
+    "tensorrt-llm==0.18.0",
+    "pynvml<12",  # avoid breaking change to pynvml version API
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -120,7 +120,7 @@ tensorrt_image = (  # update the image by downloading the model we're using
     tensorrt_image.pip_install(  # add utilities for downloading the model
         "hf-transfer==0.1.8",
         "huggingface_hub==0.26.2",
-        "requests>=2.32.2",
+        "requests~=2.32.2",
     )
     .env(  # hf-transfer for faster downloads
         {"HF_HUB_ENABLE_HF_TRANSFER": "1"}

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -120,7 +120,7 @@ tensorrt_image = (  # update the image by downloading the model we're using
     tensorrt_image.pip_install(  # add utilities for downloading the model
         "hf-transfer==0.1.8",
         "huggingface_hub==0.26.2",
-        "requests~=2.31.0",
+        "requests>=2.32.2",
     )
     .env(  # hf-transfer for faster downloads
         {"HF_HUB_ENABLE_HF_TRANSFER": "1"}


### PR DESCRIPTION
This PR pins requests to the most recent working version compatible with the example. Root cause was figured out by looking at failing action logs.

```
Context:
=== Failed run 15853340643 ===
4T14:41:43.9000601Z   Attempting uninstall: huggingface_hub
2025-06-24T14:41:43.9001301Z     Found existing installation: huggingface-hub 0.33.0
2025-06-24T14:41:43.9454242Z     Uninstalling huggingface-hub-0.33.0:
2025-06-24T14:41:44.2624425Z       Successfully uninstalled huggingface-hub-0.33.0
2025-06-24T14:41:44.5025387Z 
2025-06-24T14:41:44.5307393Z Successfully installed hf-transfer-0.1.8 huggingface_hub-0.26.2 requests-2.31.0
2025-06-24T14:41:44.5310232Z ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
2025-06-24T14:41:44.5311250Z datasets 3.6.0 requires requests>=2.32.2, but you have requests 2.31.0 which is incompatible.
```

Fix is based on this error messaged.

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
