### PR TITLE
fix: use line-buffering in code interpreter to handle large outputs

### DIFF
--- a/13_sandboxes/simple_code_interpreter.py
+++ b/13_sandboxes/simple_code_interpreter.py
@@ -89,7 +89,7 @@ driver_program_command = f"""{driver_program_text}\n\ndriver_program()"""
 
 app = modal.App.lookup("code-interpreter", create_if_missing=True)
 sb = modal.Sandbox.create(app=app)
-p = sb.exec("python", "-c", driver_program_command)
+p = sb.exec("python", "-c", driver_program_command, bufsize=1)
 
 # ## Running code in a Modal Sandbox
 


### PR DESCRIPTION

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

