### PR TITLE
WhisperX (Simple) Example

### DIFF
--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -37,9 +37,9 @@ image = (
     .apt_install("libcudnn8-dev")  # cuDNN headers (needed by torch wheels)
     # ── Python deps ─────────────────────────────────────────────────────────────
     .pip_install(
-        "whisperx",  # our ASR library
-        "numpy",
-        "scipy",
+        "whisperx==3.4.0",  # our ASR library
+        "numpy==2.0.2",
+        "scipy==1.15.0",
     )
     # Tell HF & Torch to cache inside our Volume
     .env({"HF_HUB_CACHE": MODEL_CACHE_DIR})
@@ -73,7 +73,6 @@ class WhisperX:
 
         print("🔄 Loading WhisperX model …")
         import whisperx
-        import torch
 
         self.model = whisperx.load_model(
             "large-v2",

--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -58,8 +58,8 @@ class ChunkResult:
     volumes={MODEL_CACHE_DIR: models_volume},
     timeout=1800,
     min_containers=0,
-    max_containers=30,
-    scaledown_window=60,
+    max_containers=60,
+    scaledown_window=30,
 )
 class WhisperX:
     device: str = modal.parameter(default="cuda")
@@ -295,6 +295,7 @@ def main(
         return
     
     transcriber = WhisperX()
+    time_taken = 0
     
     if stream:
         start_time = time.time()    
@@ -307,7 +308,7 @@ def main(
         
         results.sort(key=lambda r: r.chunk_index)
         
-        print(f"Time taken: {time.time() - start_time:.2f} seconds")
+        time_taken = time.time() - start_time
         
         all_segments = []
         language = "en"
@@ -349,14 +350,7 @@ def main(
         
         print(f"\nLanguage: {result['language']}")
         print(f"Duration: {result['duration']:.2f} seconds")
-        print("\nTranscription:")
-        print("-" * 40)
-        
-        for segment in result['segments']:
-            start = segment.get('start', 0)
-            end = segment.get('end', 0)
-            text = segment.get('text', '').strip()
-            print(f"[{start:.2f}-{end:.2f}] {text}")
+        print(f"Time taken: {time_taken:.2f} seconds")
         
         import json
         with open("transcription.json", "w") as f:

--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -61,7 +61,7 @@ class ChunkResult:
     max_containers=30,
     scaledown_window=60,
 )
-class SimpleWhisperX:
+class WhisperX:
     device: str = modal.parameter(default="cuda")
         
     @modal.enter()
@@ -294,7 +294,7 @@ def main(
         print("Error: Provide --audio-file")
         return
     
-    transcriber = SimpleWhisperX()
+    transcriber = WhisperX()
     
     if stream:
         start_time = time.time()    

--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -4,17 +4,14 @@
 # # WhisperX transcription with word-level timestamps
 #
 # This example shows how to run [WhisperX](https://github.com/m-bain/whisperX) on
-# **Modal** for accurate, word-level timestamped transcription.
+# Modal for accurate, word-level timestamped transcription.
 #
-# Cold-start → first transcription of a ~3 min file on an H100 takes
-# ≈ 40 s (model download + load + inference).
-#
-# We’ll walk through
+# We’ll walk through the following steps:
 #
 # 1. Defining the container image with CUDA 12.8, cuDNN 8, FFmpeg and Python deps.
 # 2. Persisting model weights to a [Modal Volume](https://modal.com/docs/reference/modal.Volume).
 # 3. A [Modal Cls](https://modal.com/docs/reference/modal.App#cls) that loads WhisperX once per GPU instance.
-# 4. A [local CLI entrypoint](https://modal.com/docs/reference/modal.App#local_entrypoint) that uploads an audio file to the service.
+# 4. A [local entrypoint](https://modal.com/docs/reference/modal.App#local_entrypoint) that uploads an audio file to the service.
 #
 # ## Defining image
 #

--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -1,354 +1,170 @@
-"""
-WhisperX transcription with word-level timestamps.
-
-Usage:
-    modal run whisperx_transcribe.py --audio-file "audio.wav"
-    modal run whisperx_transcribe.py --audio-file "audio.wav" --stream
-"""
+# ---
+# lambda-test: false  # requires audio file
+# ---
+# # WhisperX transcription with word-level timestamps
+#
+# This example shows how to run [WhisperX](https://github.com/m-bain/whisperX) on
+# **Modal** for accurate, word-level timestamped transcription.
+#
+# Cold-start → first transcription of a ~3 min file on an H100 takes
+# ≈ 40 s (model download + load + inference).
+#
+# We’ll walk through
+#
+# 1. Defining the container image with CUDA 12.8, cuDNN 8, FFmpeg and Python deps.
+# 2. Persisting model weights to a [Modal Volume](https://modal.com/docs/reference/modal.Volume).
+# 3. A [Modal Cls](https://modal.com/docs/reference/modal.App#cls) that loads WhisperX once per GPU instance.
+# 4. A [local CLI entrypoint](https://modal.com/docs/reference/modal.App#local_entrypoint) that uploads an audio file to the service.
+#
+# ## Defining image
+#
+# We start from NVIDIA’s official CUDA 12.8 devel image, add cuDNN, FFmpeg, and
+# install the WhisperX Python package plus its numerical deps.
+#
 
 import os
-from typing import Dict, List
-from dataclasses import dataclass
+from typing import Dict
 
 import modal
 
 MODEL_CACHE_DIR = "/whisperx-cache"
 
 image = (
-     modal.Image.from_registry(
-        "nvidia/cuda:12.8.0-cudnn-devel-ubuntu22.04", add_python="3.12"
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.0-cudnn-devel-ubuntu22.04",
+        add_python="3.12",
     )
-    .apt_install("ffmpeg")
-    .apt_install("libcudnn8")
-    .apt_install("libcudnn8-dev")
+    # ── System deps ─────────────────────────────────────────────────────────────
+    .apt_install("ffmpeg")  # audio decoding / resampling
+    .apt_install("libcudnn8")  # cuDNN runtime
+    .apt_install("libcudnn8-dev")  # cuDNN headers (needed by torch wheels)
+    # ── Python deps ─────────────────────────────────────────────────────────────
     .pip_install(
-        "whisperx",
+        "whisperx",  # our ASR library
         "numpy",
         "scipy",
     )
+    # Tell HF & Torch to cache inside our Volume
     .env({"HF_HUB_CACHE": MODEL_CACHE_DIR})
 )
 
-
+# ## Defining the app
+#
+# Downloaded weights live in a [Modal Volume](https://modal.com/docs/reference/modal.Volume) so subsequent runs reuse them.
 app = modal.App("whisperx-example", image=image)
 models_volume = modal.Volume.from_name("whisperx-models", create_if_missing=True)
 
 
-@dataclass
-class ChunkInput:
-    chunk_bytes: bytes
-    chunk_index: int
-    start_time: float
-    end_time: float
-    sample_rate: int
-
-
-@dataclass
-class ChunkResult:
-    chunk_index: int
-    segments: List[Dict]
-    language: str
-    start_time: float
-    end_time: float
-
-
+# ## Defining the inference service
+#
+# We wrap WhisperX inference in a Modal Cls.
+# A single GPU container can serve multiple concurrent requests.
 @app.cls(
-    gpu="A100",
+    gpu="H100",
     image=image,
     volumes={MODEL_CACHE_DIR: models_volume},
-    timeout=1800,
-    min_containers=0,
-    max_containers=60,
-    scaledown_window=30,
+    timeout=30 * 60,
 )
 class WhisperX:
+    """Serverless WhisperX service running on a single GPU."""
+
     device: str = modal.parameter(default="cuda")
-        
+
     @modal.enter()
     def setup(self):
-        import os
         os.environ["TORCH_HOME"] = MODEL_CACHE_DIR
-        
+
+        print("🔄 Loading WhisperX model …")
         import whisperx
         import torch
-        
-        self.model = None
-        
-        if torch.cuda.is_available():
-            print(f"CUDA available: {torch.cuda.get_device_name(0)}")
-        else:
-            print("Using CPU")
-            self.device = "cpu"
-            
-        print("Loading WhisperX model...")
+
         self.model = whisperx.load_model(
-            "large-v2", 
+            "large-v2",
             device=self.device,
             compute_type="float16" if self.device == "cuda" else "int8",
-            download_root=MODEL_CACHE_DIR
+            download_root=MODEL_CACHE_DIR,
         )
-        print("Model loaded!")
-    
+        print("✅ Model ready!")
+
     @modal.method()
     def transcribe(self, audio_data: bytes) -> Dict:
+        """
+        Transcribe an audio file passed in as raw bytes.
+        Returns language, per-word segments, and total duration.
+        """
         import whisperx
         import tempfile
-        
+
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_audio:
             temp_audio.write(audio_data)
             temp_audio_path = temp_audio.name
-        
-        try:
-            audio = whisperx.load_audio(temp_audio_path)
-            result = self.model.transcribe(audio, batch_size=16, language="en")
-            
-            language = result.get("language", "en")
-            if len(result["segments"]) > 0:
-                try:
-                    align_model, metadata = whisperx.load_align_model(
-                        language_code=language, 
-                        device=self.device,
-                        model_dir=MODEL_CACHE_DIR
-                    )
-                    result = whisperx.align(result["segments"], align_model, metadata, audio, self.device)
-                except:
-                    print("Alignment failed, using segment-level timestamps")
-            
-            return {
-                "language": language,
-                "segments": result["segments"],
-                "duration": len(audio) / 16000,
-            }
-            
-        finally:
-            if os.path.exists(temp_audio_path):
-                os.unlink(temp_audio_path)
 
-    @modal.method()
-    def process_chunk(self, chunk_input: ChunkInput) -> ChunkResult:
-        import whisperx
-        import tempfile
-        import scipy.io.wavfile as wav
-        import io
-        
-        with io.BytesIO(chunk_input.chunk_bytes) as bio:
-            _, chunk_audio = wav.read(bio)
-        
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_audio:
-            wav.write(temp_audio.name, chunk_input.sample_rate, chunk_audio)
-            temp_audio_path = temp_audio.name
-        
         try:
             audio = whisperx.load_audio(temp_audio_path)
             result = self.model.transcribe(audio, batch_size=16, language="en")
-            
+
             language = result.get("language", "en")
-            if len(result.get("segments", [])) > 0:
+
+            if result["segments"]:
                 try:
                     align_model, metadata = whisperx.load_align_model(
                         language_code=language,
                         device=self.device,
-                        model_dir=MODEL_CACHE_DIR
+                        model_dir=MODEL_CACHE_DIR,
                     )
-                    result = whisperx.align(result["segments"], align_model, metadata, audio, self.device)
-                except:
-                    pass
-            
-            adjusted_segments = []
-            for segment in result.get("segments", []):
-                adjusted_segment = segment.copy()
-                adjusted_segment["start"] = segment.get("start", 0) + chunk_input.start_time
-                adjusted_segment["end"] = segment.get("end", 0) + chunk_input.start_time
-                adjusted_segments.append(adjusted_segment)
-            
-            return ChunkResult(
-                chunk_index=chunk_input.chunk_index,
-                segments=adjusted_segments,
-                language=language,
-                start_time=chunk_input.start_time,
-                end_time=chunk_input.end_time
-            )
-            
+                    result = whisperx.align(
+                        result["segments"], align_model, metadata, audio, self.device
+                    )
+                except Exception as e:
+                    print(f"⚠️ Alignment failed: {e} — falling back to segment-level")
+
+            return {
+                "language": language,
+                "segments": result["segments"],
+                "duration": len(audio) / 16_000,  # audio is 16 kHz
+            }
+
         finally:
             if os.path.exists(temp_audio_path):
                 os.unlink(temp_audio_path)
 
 
-def chunk_generator(audio_file: str, chunk_seconds: float):
-    import scipy.io.wavfile as wav
-    import io
-    import warnings
-    
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore')
-        sample_rate, audio_data = wav.read(audio_file)
-    
-    if len(audio_data.shape) > 1:
-        audio_data = audio_data.mean(axis=1).astype(audio_data.dtype)
-    
-    total_samples = len(audio_data)
-    chunk_samples = int(chunk_seconds * sample_rate)
-    
-    chunk_index = 0
-    position = 0
-    
-    while position < total_samples:
-        chunk_end = min(position + chunk_samples, total_samples)
-        chunk_audio = audio_data[position:chunk_end]
-        
-        bio = io.BytesIO()
-        wav.write(bio, sample_rate, chunk_audio)
-        chunk_bytes = bio.getvalue()
-        
-        start_time = position / sample_rate
-        end_time = chunk_end / sample_rate
-        
-        yield ChunkInput(
-            chunk_bytes=chunk_bytes,
-            chunk_index=chunk_index,
-            start_time=start_time,
-            end_time=end_time,
-            sample_rate=sample_rate
-        )
-        
-        position = chunk_end
-        chunk_index += 1
-
-
-def aggregate_and_display_stats(transcription_data: Dict, base_filename: str = "transcript"):
-    segments = transcription_data.get('segments', [])
-    
-    if not segments:
-        print("No segments found in transcription")
-        return
-    
-    full_text = []
-    for segment in segments:
-        text = segment.get('text', '').strip()
-        if text:
-            full_text.append(text)
-    
-    aggregated_text = ' '.join(full_text)
-    
-    plain_file = f"{base_filename}.txt"
-    with open(plain_file, 'w', encoding='utf-8') as f:
-        f.write(aggregated_text)
-    
-    formatted_file = f"{base_filename}_with_timestamps.txt"
-    with open(formatted_file, 'w', encoding='utf-8') as f:
-        f.write(f"Transcription\n")
-        f.write(f"Language: {transcription_data.get('language', 'unknown')}\n")
-        if 'duration' in transcription_data:
-            f.write(f"Duration: {transcription_data['duration']:.2f} seconds\n")
-        f.write("=" * 50 + "\n\n")
-        
-        for segment in segments:
-            start = segment.get('start', 0)
-            end = segment.get('end', 0)
-            text = segment.get('text', '').strip()
-            if text:
-                f.write(f"[{start:.2f}s - {end:.2f}s] {text}\n")
-    
-    word_count = len(aggregated_text.split())
-    char_count = len(aggregated_text)
-    
-    total_speaking_time = 0
-    for segment in segments:
-        if segment.get('text', '').strip():
-            duration = segment.get('end', 0) - segment.get('start', 0)
-            total_speaking_time += duration
-    
-    print("\n" + "=" * 50)
-    print("📊 TRANSCRIPTION STATISTICS")
-    print("=" * 50)
-    print(f"📝 Files created:")
-    print(f"   - Plain text: {plain_file}")
-    print(f"   - With timestamps: {formatted_file}")
-    print(f"\n📈 Content stats:")
-    print(f"   - Total segments: {len(segments)}")
-    print(f"   - Total words: {word_count:,}")
-    print(f"   - Total characters: {char_count:,}")
-    print(f"   - Speaking time: {total_speaking_time:.1f}s ({total_speaking_time/60:.1f} minutes)")
-    
-    if total_speaking_time > 0:
-        words_per_minute = (word_count / total_speaking_time) * 60
-        print(f"   - Speaking rate: {words_per_minute:.0f} words/minute")
-    
-    print("=" * 50 + "\n")
-
-
-"""
-Usage:
-    modal run example.py --audio-file "audio.wav" # if you want to transcribe a single file
-    modal run example.py --audio-file "audio.wav" --stream # if you want to stream the audio in chunks and process them in parallel
-
-"""
+# ## Command-line usage
+#
+# We expose a [local entrypoint](https://modal.com/docs/reference/modal.App#local_entrypoint)
+# so you can run:
+#
+# ```bash
+# modal run whisperx_transcribe.py --audio-file audio.wav
+# ```
+#
 @app.local_entrypoint()
 def main(
     audio_file: str = None,
-    stream: bool = False,
 ):
     import time
-    
+    import json
+
     if not audio_file:
-        print("Error: Provide --audio-file")
+        print("❌ Error: provide --audio-file")
         return
-    
+
+    print(f"🔊 Reading {audio_file} …")
+    with open(audio_file, "rb") as f:
+        audio_data = f.read()
+
     transcriber = WhisperX()
-    time_taken = 0
-    
-    if stream:
-        start_time = time.time()    
-        print("Streaming mode: Processing audio in parallel chunks...")
-        
-        chunk_seconds = 120.0
-        
-        chunk_gen = chunk_generator(audio_file, chunk_seconds)
-        results = list(transcriber.process_chunk.map(chunk_gen))
-        
-        results.sort(key=lambda r: r.chunk_index)
-        
-        time_taken = time.time() - start_time
-        
-        all_segments = []
-        language = "en"
-        
-        for result in results:
-            all_segments.extend(result.segments)
-            if result.language:
-                language = result.language
-        
-        print(f"\nLanguage: {language}")
-        print(f"Duration: {len(all_segments) / 16000:.2f} seconds")
-        print(f"Time taken: {time_taken:.2f} seconds")
-        
-        transcription_data = {
-            "language": language,
-            "segments": all_segments
-        }
-        
-        import json
-        with open("transcription.json", "w") as f:
-            json.dump(transcription_data, f, indent=2)
-        print(f"\nSaved to: transcription.json")
-        
-        aggregate_and_display_stats(transcription_data)
-        
-    else:
-        print(f"Full-file mode: Reading {audio_file}")
-        with open(audio_file, "rb") as f:
-            audio_data = f.read()
-        
-        print("Transcribing...")
-        result = transcriber.transcribe.remote(audio_data)
-        
-        print(f"\nLanguage: {result['language']}")
-        print(f"Duration: {result['duration']:.2f} seconds")
-        print(f"Time taken: {time_taken:.2f} seconds")
-        
-        import json
-        with open("transcription.json", "w") as f:
-            json.dump(result, f, indent=2)
-        print(f"\nSaved to: transcription.json")
-        
-        aggregate_and_display_stats(result)
+
+    print("📝 Transcribing …")
+    start = time.time()
+    result = transcriber.transcribe.remote(audio_data)
+    duration = time.time() - start
+
+    print(f"\n🌐 Detected language: {result['language']}")
+    print(f"⏱️  Audio duration:   {result['duration']:.2f} s")
+    print(f"🚀 Time taken:        {duration:.2f} s")
+
+    with open("transcription.json", "w") as f:
+        json.dump(result, f, indent=2)
+
+    print("\n💾 Saved transcription → transcription.json")

--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -319,14 +319,8 @@ def main(
                 language = result.language
         
         print(f"\nLanguage: {language}")
-        print("\nTranscription:")
-        print("-" * 40)
-        
-        for segment in all_segments:
-            start = segment.get('start', 0)
-            end = segment.get('end', 0)
-            text = segment.get('text', '').strip()
-            print(f"[{start:.2f}-{end:.2f}] {text}")
+        print(f"Duration: {len(all_segments) / 16000:.2f} seconds")
+        print(f"Time taken: {time_taken:.2f} seconds")
         
         transcription_data = {
             "language": language,

--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -1,0 +1,366 @@
+"""
+WhisperX transcription with word-level timestamps.
+
+Usage:
+    modal run whisperx_transcribe.py --audio-file "audio.wav"
+    modal run whisperx_transcribe.py --audio-file "audio.wav" --stream
+"""
+
+import os
+from typing import Dict, List
+from dataclasses import dataclass
+
+import modal
+
+MODEL_CACHE_DIR = "/whisperx-cache"
+
+image = (
+     modal.Image.from_registry(
+        "nvidia/cuda:12.8.0-cudnn-devel-ubuntu22.04", add_python="3.12"
+    )
+    .apt_install("ffmpeg")
+    .apt_install("libcudnn8")
+    .apt_install("libcudnn8-dev")
+    .pip_install(
+        "whisperx",
+        "numpy",
+        "scipy",
+    )
+    .env({"HF_HUB_CACHE": MODEL_CACHE_DIR})
+)
+
+
+app = modal.App("whisperx-example", image=image)
+models_volume = modal.Volume.from_name("whisperx-models", create_if_missing=True)
+
+
+@dataclass
+class ChunkInput:
+    chunk_bytes: bytes
+    chunk_index: int
+    start_time: float
+    end_time: float
+    sample_rate: int
+
+
+@dataclass
+class ChunkResult:
+    chunk_index: int
+    segments: List[Dict]
+    language: str
+    start_time: float
+    end_time: float
+
+
+@app.cls(
+    gpu="A100",
+    image=image,
+    volumes={MODEL_CACHE_DIR: models_volume},
+    timeout=1800,
+    min_containers=0,
+    max_containers=30,
+    scaledown_window=60,
+)
+class SimpleWhisperX:
+    device: str = modal.parameter(default="cuda")
+        
+    @modal.enter()
+    def setup(self):
+        import os
+        os.environ["TORCH_HOME"] = MODEL_CACHE_DIR
+        
+        import whisperx
+        import torch
+        
+        self.model = None
+        
+        if torch.cuda.is_available():
+            print(f"CUDA available: {torch.cuda.get_device_name(0)}")
+        else:
+            print("Using CPU")
+            self.device = "cpu"
+            
+        print("Loading WhisperX model...")
+        self.model = whisperx.load_model(
+            "large-v2", 
+            device=self.device,
+            compute_type="float16" if self.device == "cuda" else "int8",
+            download_root=MODEL_CACHE_DIR
+        )
+        print("Model loaded!")
+    
+    @modal.method()
+    def transcribe(self, audio_data: bytes) -> Dict:
+        import whisperx
+        import tempfile
+        
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_audio:
+            temp_audio.write(audio_data)
+            temp_audio_path = temp_audio.name
+        
+        try:
+            audio = whisperx.load_audio(temp_audio_path)
+            result = self.model.transcribe(audio, batch_size=16, language="en")
+            
+            language = result.get("language", "en")
+            if len(result["segments"]) > 0:
+                try:
+                    align_model, metadata = whisperx.load_align_model(
+                        language_code=language, 
+                        device=self.device,
+                        model_dir=MODEL_CACHE_DIR
+                    )
+                    result = whisperx.align(result["segments"], align_model, metadata, audio, self.device)
+                except:
+                    print("Alignment failed, using segment-level timestamps")
+            
+            return {
+                "language": language,
+                "segments": result["segments"],
+                "duration": len(audio) / 16000,
+            }
+            
+        finally:
+            if os.path.exists(temp_audio_path):
+                os.unlink(temp_audio_path)
+
+    @modal.method()
+    def process_chunk(self, chunk_input: ChunkInput) -> ChunkResult:
+        import whisperx
+        import tempfile
+        import scipy.io.wavfile as wav
+        import io
+        
+        with io.BytesIO(chunk_input.chunk_bytes) as bio:
+            _, chunk_audio = wav.read(bio)
+        
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_audio:
+            wav.write(temp_audio.name, chunk_input.sample_rate, chunk_audio)
+            temp_audio_path = temp_audio.name
+        
+        try:
+            audio = whisperx.load_audio(temp_audio_path)
+            result = self.model.transcribe(audio, batch_size=16, language="en")
+            
+            language = result.get("language", "en")
+            if len(result.get("segments", [])) > 0:
+                try:
+                    align_model, metadata = whisperx.load_align_model(
+                        language_code=language,
+                        device=self.device,
+                        model_dir=MODEL_CACHE_DIR
+                    )
+                    result = whisperx.align(result["segments"], align_model, metadata, audio, self.device)
+                except:
+                    pass
+            
+            adjusted_segments = []
+            for segment in result.get("segments", []):
+                adjusted_segment = segment.copy()
+                adjusted_segment["start"] = segment.get("start", 0) + chunk_input.start_time
+                adjusted_segment["end"] = segment.get("end", 0) + chunk_input.start_time
+                adjusted_segments.append(adjusted_segment)
+            
+            return ChunkResult(
+                chunk_index=chunk_input.chunk_index,
+                segments=adjusted_segments,
+                language=language,
+                start_time=chunk_input.start_time,
+                end_time=chunk_input.end_time
+            )
+            
+        finally:
+            if os.path.exists(temp_audio_path):
+                os.unlink(temp_audio_path)
+
+
+def chunk_generator(audio_file: str, chunk_seconds: float):
+    import scipy.io.wavfile as wav
+    import io
+    import warnings
+    
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore')
+        sample_rate, audio_data = wav.read(audio_file)
+    
+    if len(audio_data.shape) > 1:
+        audio_data = audio_data.mean(axis=1).astype(audio_data.dtype)
+    
+    total_samples = len(audio_data)
+    chunk_samples = int(chunk_seconds * sample_rate)
+    
+    chunk_index = 0
+    position = 0
+    
+    while position < total_samples:
+        chunk_end = min(position + chunk_samples, total_samples)
+        chunk_audio = audio_data[position:chunk_end]
+        
+        bio = io.BytesIO()
+        wav.write(bio, sample_rate, chunk_audio)
+        chunk_bytes = bio.getvalue()
+        
+        start_time = position / sample_rate
+        end_time = chunk_end / sample_rate
+        
+        yield ChunkInput(
+            chunk_bytes=chunk_bytes,
+            chunk_index=chunk_index,
+            start_time=start_time,
+            end_time=end_time,
+            sample_rate=sample_rate
+        )
+        
+        position = chunk_end
+        chunk_index += 1
+
+
+def aggregate_and_display_stats(transcription_data: Dict, base_filename: str = "transcript"):
+    segments = transcription_data.get('segments', [])
+    
+    if not segments:
+        print("No segments found in transcription")
+        return
+    
+    full_text = []
+    for segment in segments:
+        text = segment.get('text', '').strip()
+        if text:
+            full_text.append(text)
+    
+    aggregated_text = ' '.join(full_text)
+    
+    plain_file = f"{base_filename}.txt"
+    with open(plain_file, 'w', encoding='utf-8') as f:
+        f.write(aggregated_text)
+    
+    formatted_file = f"{base_filename}_with_timestamps.txt"
+    with open(formatted_file, 'w', encoding='utf-8') as f:
+        f.write(f"Transcription\n")
+        f.write(f"Language: {transcription_data.get('language', 'unknown')}\n")
+        if 'duration' in transcription_data:
+            f.write(f"Duration: {transcription_data['duration']:.2f} seconds\n")
+        f.write("=" * 50 + "\n\n")
+        
+        for segment in segments:
+            start = segment.get('start', 0)
+            end = segment.get('end', 0)
+            text = segment.get('text', '').strip()
+            if text:
+                f.write(f"[{start:.2f}s - {end:.2f}s] {text}\n")
+    
+    word_count = len(aggregated_text.split())
+    char_count = len(aggregated_text)
+    
+    total_speaking_time = 0
+    for segment in segments:
+        if segment.get('text', '').strip():
+            duration = segment.get('end', 0) - segment.get('start', 0)
+            total_speaking_time += duration
+    
+    print("\n" + "=" * 50)
+    print("📊 TRANSCRIPTION STATISTICS")
+    print("=" * 50)
+    print(f"📝 Files created:")
+    print(f"   - Plain text: {plain_file}")
+    print(f"   - With timestamps: {formatted_file}")
+    print(f"\n📈 Content stats:")
+    print(f"   - Total segments: {len(segments)}")
+    print(f"   - Total words: {word_count:,}")
+    print(f"   - Total characters: {char_count:,}")
+    print(f"   - Speaking time: {total_speaking_time:.1f}s ({total_speaking_time/60:.1f} minutes)")
+    
+    if total_speaking_time > 0:
+        words_per_minute = (word_count / total_speaking_time) * 60
+        print(f"   - Speaking rate: {words_per_minute:.0f} words/minute")
+    
+    print("=" * 50 + "\n")
+
+
+"""
+Usage:
+    modal run example.py --audio-file "audio.wav" # if you want to transcribe a single file
+    modal run example.py --audio-file "audio.wav" --stream # if you want to stream the audio in chunks and process them in parallel
+
+"""
+@app.local_entrypoint()
+def main(
+    audio_file: str = None,
+    stream: bool = False,
+):
+    import time
+    
+    if not audio_file:
+        print("Error: Provide --audio-file")
+        return
+    
+    transcriber = SimpleWhisperX()
+    
+    if stream:
+        start_time = time.time()    
+        print("Streaming mode: Processing audio in parallel chunks...")
+        
+        chunk_seconds = 120.0
+        
+        chunk_gen = chunk_generator(audio_file, chunk_seconds)
+        results = list(transcriber.process_chunk.map(chunk_gen))
+        
+        results.sort(key=lambda r: r.chunk_index)
+        
+        print(f"Time taken: {time.time() - start_time:.2f} seconds")
+        
+        all_segments = []
+        language = "en"
+        
+        for result in results:
+            all_segments.extend(result.segments)
+            if result.language:
+                language = result.language
+        
+        print(f"\nLanguage: {language}")
+        print("\nTranscription:")
+        print("-" * 40)
+        
+        for segment in all_segments:
+            start = segment.get('start', 0)
+            end = segment.get('end', 0)
+            text = segment.get('text', '').strip()
+            print(f"[{start:.2f}-{end:.2f}] {text}")
+        
+        transcription_data = {
+            "language": language,
+            "segments": all_segments
+        }
+        
+        import json
+        with open("transcription.json", "w") as f:
+            json.dump(transcription_data, f, indent=2)
+        print(f"\nSaved to: transcription.json")
+        
+        aggregate_and_display_stats(transcription_data)
+        
+    else:
+        print(f"Full-file mode: Reading {audio_file}")
+        with open(audio_file, "rb") as f:
+            audio_data = f.read()
+        
+        print("Transcribing...")
+        result = transcriber.transcribe.remote(audio_data)
+        
+        print(f"\nLanguage: {result['language']}")
+        print(f"Duration: {result['duration']:.2f} seconds")
+        print("\nTranscription:")
+        print("-" * 40)
+        
+        for segment in result['segments']:
+            start = segment.get('start', 0)
+            end = segment.get('end', 0)
+            text = segment.get('text', '').strip()
+            print(f"[{start:.2f}-{end:.2f}] {text}")
+        
+        import json
+        with open("transcription.json", "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"\nSaved to: transcription.json")
+        
+        aggregate_and_display_stats(result)


### PR DESCRIPTION
Adds **`whisperx_transcribe.py`** (≈140 LOC):

- **GPU image**: CUDA 12.8 + cuDNN 8 + FFmpeg + WhisperX deps.  
- **Model cache**: mounts a Modal Volume at `/whisperx-cache` → weights download once.  
- **`WhisperX` Cls**  
  - Runs on 1× H100, loads `large-v2` once.  
  - `transcribe(audio_bytes) → {language, segments[], duration}` with optional word-level alignment.  
- **CLI**:  
  ```bash
  modal run whisperx_transcribe.py --audio-file my.wav

Prints stats and writes transcription.json.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
