### PR TITLE
APE-28 Update the SGLang example to latest version

### DIFF
--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -80,19 +80,18 @@ tag = f"{cuda_version}-{flavor}-{operating_sys}"
 
 vlm_image = (
     modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.11")
+    .apt_install("libnuma-dev")  # Add NUMA library for sgl_kernel
     .pip_install(  # add sglang and some Python dependencies
-        "transformers==4.47.1",
+        "transformers==4.52.3",
         "numpy<2",
         "fastapi[standard]==0.115.4",
         "pydantic==2.9.2",
         "requests==2.32.3",
         "starlette==0.41.2",
-        "torch==2.4.0",
-        "sglang[all]==0.4.1",
-        "sgl-kernel==0.1.0",
+        "torch==2.7.1",
+        "sglang[all]==0.4.8",
+        "sgl-kernel==0.1.9;",
         "hf-xet==1.1.5",
-        # as per sglang website: https://sgl-project.github.io/start/install.html
-        extra_options="--find-links https://flashinfer.ai/whl/cu124/torch2.4/flashinfer/",
     )
     .env(
         {

--- a/06_gpu_and_ml/llm-serving/sgl_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sgl_vlm.py
@@ -80,6 +80,7 @@ tag = f"{cuda_version}-{flavor}-{operating_sys}"
 
 vlm_image = (
     modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.11")
+    .entrypoint([])  # removes chatty prints on entry
     .apt_install("libnuma-dev")  # Add NUMA library for sgl_kernel
     .pip_install(  # add sglang and some Python dependencies
         "transformers==4.52.3",
@@ -90,7 +91,7 @@ vlm_image = (
         "starlette==0.41.2",
         "torch==2.7.1",
         "sglang[all]==0.4.8",
-        "sgl-kernel==0.1.9;",
+        "sgl-kernel==0.1.9",
         "hf-xet==1.1.5",
     )
     .env(


### PR DESCRIPTION
Updating the SGLang example to the latest version and updating the pinned dependencies. 

## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)


### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
