### PR TITLE
Fix: example-checkbox crashlooping

### DIFF
--- a/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
+++ b/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
@@ -35,7 +35,7 @@ css_path_remote = "/assets/styles.css"
 
 @app.function(
     image=modal.Image.debian_slim(python_version="3.12")
-    .pip_install("python-fasthtml==0.6.9", "inflect~=7.4.0")
+    .pip_install("python-fasthtml==0.12.21", "inflect~=7.4.0")
     .add_local_file(css_path_local, remote_path=css_path_remote),
     max_containers=1,  # we currently maintain state in memory, so we restrict the server to one worker
 )


### PR DESCRIPTION
Dependency issue causing a crash loop in our deployment:
<img width="1085" height="165" alt="Screenshot 2025-07-17 at 5 50 56 PM" src="https://github.com/user-attachments/assets/2c8e1f96-6c62-456c-b04c-1b3a2d247040" />

Error log:
```text
  File "/usr/local/lib/python3.12/site-packages/fasthtml/common.py", line 7, in <module>
    from sqlite_minutils import Database
ModuleNotFoundError: No module named 'sqlite_minutils'
```

Updated the fasthtml version to the latest one to fix it. Redeployed and tested.

## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
