### PR TITLE
[CI] Fix support for workflow dispatch, for running changed example

### DIFF
--- a/.github/workflows/build-and-run-example.yml
+++ b/.github/workflows/build-and-run-example.yml
@@ -1,4 +1,4 @@
-name: Build and run example
+name: Build and run random example
 
 on:
   workflow_dispatch:

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,4 +1,4 @@
-name: Run
+name: Run changed examples
 
 on:
   pull_request:
@@ -44,8 +44,7 @@ jobs:
   run-changed:
     name: Run changed example
     needs: [diff-matrix]
-    if:
-      ${{ needs.diff-matrix.outputs.matrix != '[]' &&
+    if: ${{ needs.diff-matrix.outputs.matrix != '[]' &&
       needs.diff-matrix.outputs.matrix != '' }}
     runs-on: ubuntu-24.04
     strategy:

--- a/internal/generate_diff_matrix.py
+++ b/internal/generate_diff_matrix.py
@@ -28,6 +28,24 @@ def determine_diff_range(event, event_name):
     elif event_name == "push":
         base = event.get("before")
         head = event.get("after")
+
+    elif event_name == "workflow_dispatch":
+        try:
+            subprocess.run(["git", "fetch", "origin", "main"], check=True)
+
+            base = (
+                subprocess.check_output(["git", "rev-parse", "origin/main"])
+                .decode()
+                .strip()
+            )
+
+            head = (
+                subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Git error while determining diff range: {e}", file=sys.stderr)
+            sys.exit(1)
+
     else:
         print(f"Unsupported event type: {event_name}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->
[Before](https://github.com/modal-labs/modal-examples/actions/runs/16451074809) - Action is workflow dispatch-able, but the diff matrix is not enabled.
[After](https://github.com/modal-labs/modal-examples/actions/runs/16451745289) - Action is workflow dispatch-able!

Also couple of light changes to the Action names so they're a bit clearer.

💡 Idea: In the spirit of increasing workflow dispatches, it would be nice to have a "driver" GH action that can be dispatchable outside of a PR.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [x] Other (Changes to the codebase, but not to examples)
