### PR TITLE
bump pytorch to 2.7.1 (required by trtllm 1.0.0rc0)

### DIFF
--- a/misc/trtllm_deepseek.py
+++ b/misc/trtllm_deepseek.py
@@ -58,7 +58,7 @@ tensorrt_image = (
         "uv pip install --system --compile-bytecode mpi4py tensorrt_llm==1.0.0rc0"
     )
     .run_commands(
-        "uv pip install --system --compile-bytecode torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
+        "uv pip install --system --compile-bytecode torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
     )
 )
 


### PR DESCRIPTION
## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)

## Summary
Update PyTorch version from 2.7.0 to 2.7.1 to meet TensorRT-LLM 1.0.0rc0 requirements.

TensorRT-LLM 1.0.0rc0 requires PyTorch 2.7.1, so this change updates the PyTorch installation command to use the correct version for compatibility.