### PR TITLE
install pytorch with cuda before trtllm to avoid cpu-only version

### DIFF
--- a/misc/trtllm_deepseek.py
+++ b/misc/trtllm_deepseek.py
@@ -55,10 +55,10 @@ tensorrt_image = (
     )
     .pip_install("uv")
     .run_commands(
-        "uv pip install --system --compile-bytecode mpi4py tensorrt_llm==1.0.0rc0"
+        "uv pip install --system --compile-bytecode torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
     )
     .run_commands(
-        "uv pip install --system --compile-bytecode torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
+        "uv pip install --system --compile-bytecode mpi4py tensorrt_llm==1.0.0rc0"
     )
 )
 


### PR DESCRIPTION
## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)

## Summary
Reorder pip install commands to install PyTorch with CUDA before TensorRT-LLM to prevent CPU-only PyTorch installation.

When TensorRT-LLM is installed first, it pulls in PyTorch (2.7.1) as a dependency but defaults to the CPU-only version. By installing PyTorch with CUDA support first, we ensure the correct CUDA-enabled version is used instead of falling back to the CPU variant.