### PR TITLE
Update RL example names

### DIFF
--- a/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
@@ -1,8 +1,8 @@
 # ---
-# cmd: ["modal", "run", "06_gpu_and_ml/reinforcement-learning/trl-grpo.py::train"]
+# cmd: ["modal", "run", "06_gpu_and_ml/reinforcement-learning/grpo_trl.py::train"]
 # ---
 
-# # Run GRPO on Modal using TRL
+# # Train a model to solve coding problems using GRPO and TRL
 
 # This example demonstrates how to run [GRPO](https://arxiv.org/pdf/2402.03300) on Modal using the TRL [GRPO trainer](https://huggingface.co/docs/trl/main/en/grpo_trainer)
 # GRPO is a reinforcement learning algorithm introduced by DeepSeek, and was used to train DeepSeek R1.
@@ -145,7 +145,7 @@ def train() -> None:
     start_grpo_trainer()
 
 
-# To run: `modal run --detach trl-grpo.py::train``
+# To run: `modal run --detach grpo_trl.py::train``
 
 # ## Speeding up training with vLLM
 
@@ -174,7 +174,7 @@ def train_vllm_server_mode() -> None:
     start_grpo_trainer(use_vllm=True, vllm_mode="server")
 
 
-# You can execute this using `modal run --detach trl-grpo.py::train_vllm_server_mode`
+# You can execute this using `modal run --detach grpo_trl.py::train_vllm_server_mode`
 
 # In colocate mode, vLLM runs inside the trainer process and shares GPU memory with the training model.
 # This avoids launching a separate server and can improve GPU utilization, but may lead to memory contention on the training GPUs.
@@ -202,7 +202,7 @@ def train_vllm_colocate_mode() -> None:
     start_grpo_trainer(use_vllm=True, vllm_mode="colocate")
 
 
-# You can execute this using `modal run --detach trl-grpo.py::train_vllm_colocate_mode`
+# You can execute this using `modal run --detach grpo_trl.py::train_vllm_colocate_mode`
 
 # ## Performing inference on the trained model
 
@@ -270,7 +270,7 @@ def serve():
     subprocess.Popen(" ".join(cmd), shell=True)
 
 
-# You can then deploy the server using `modal deploy trl-grpo.py`, which gives you a custom url. You can then query it using the following curl command:
+# You can then deploy the server using `modal deploy grpo_trl.py`, which gives you a custom url. You can then query it using the following curl command:
 
 # ```bash
 # curl -X POST <url>/v1/chat/completions \

--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -121,7 +121,7 @@ def compute_reward(
 
 
 # We then define constants to pass into verl during the training run.
-PATH_TO_REWARD_FUNCTION: Path = Path("/root/grpo-verl.py")
+PATH_TO_REWARD_FUNCTION: Path = Path("/root/grpo_verl.py")
 REWARD_FUNCTION_NAME: str = "compute_reward"
 
 # ## Kicking off a training run

--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -1,8 +1,8 @@
 # ---
-# cmd: ["modal", "run", "06_gpu_and_ml/reinforcement-learning/grpo-verl.py::train"]
+# cmd: ["modal", "run", "06_gpu_and_ml/reinforcement-learning/grpo_verl.py::train"]
 # ---
 
-# # Run GRPO on Modal using verl
+# # Train a model to solve math problems using GRPO and verl
 
 # This example demonstrates how to train with [GRPO](https://arxiv.org/pdf/2402.03300) on Modal using the [verl](https://github.com/volcengine/verl) framework.
 # GRPO is a reinforcement learning algorithm introduced by DeepSeek, and was used to train DeepSeek R1.
@@ -281,7 +281,7 @@ def serve():
     subprocess.Popen(" ".join(cmd), shell=True)
 
 
-# You can then deploy the server using `modal deploy grpo-verl.py`, which gives you a custom url. You can then query it using the following curl command:
+# You can then deploy the server using `modal deploy grpo_verl.py`, which gives you a custom url. You can then query it using the following curl command:
 
 # ```bash
 # curl -X POST <url>/v1/chat/completions \


### PR DESCRIPTION
Based on https://github.com/modal-labs/modal/pull/25104#issuecomment-3134080951

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
