### PR TITLE
Adding `huggingface-secret` to flux example (FLUX.1-schnell is now gated)

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/flux.py
+++ b/06_gpu_and_ml/stable_diffusion/flux.py
@@ -95,8 +95,16 @@ with flux_image.imports():
 
 # 2. We run the actual inference in methods decorated with `@modal.method()`.
 
+# *Note: Access to the Flux.1-schnell model on Hugging Face is
+# [gated by a license agreement](https://huggingface.co/docs/hub/en/models-gated)
+# which you must agree to
+# [here](https://huggingface.co/black-forest-labs/FLUX.1-schnell).
+# After you have accepted the license,
+# [create a Modal Secret](https://modal.com/secrets)
+# with the name `huggingface-secret` following the instructions in the template.*
+
 MINUTES = 60  # seconds
-VARIANT = "schnell"  # or "dev", but note [dev] requires you to accept terms and conditions on HF
+VARIANT = "schnell"  # or "dev"
 NUM_INFERENCE_STEPS = 4  # use ~50 for [dev], smaller for [schnell]
 
 
@@ -112,6 +120,7 @@ NUM_INFERENCE_STEPS = 4  # use ~50 for [dev], smaller for [schnell]
             "inductor-cache", create_if_missing=True
         ),
     },
+    secrets=[modal.Secret.from_name("huggingface-secret")],
 )
 class Model:
     compile: bool = (  # see section on torch.compile below for details


### PR DESCRIPTION
- FLUX.1-schnell is gated now. Adding a `huggingface-secret` and mentioning it in the example's copy. 
- Fixed a typo

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)