### PR TITLE
fix: remove unused and unformatted Python comment

### DIFF
--- a/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
+++ b/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
@@ -106,10 +106,9 @@ HYDRAGEN_MIN_GROUP_SIZE = 129  # sic
 # All values are derived from
 # [this version of the official benchmarking script](https://github.com/ScalingIntelligence/tokasaurus/blob/a0155181f09c0cf40783e01a625b041985667a92/tokasaurus/benchmarks/standalone_monkeys_gsm8k.py),
 # except the `KV_CACHE_NUM_TOKENS`, which we increase to the maximum the GPU can handle.
-# The value in the script is set to the maximum that the other engines can handle, not just Tokasaurus.
+# The value in the script is set to (1024 + 512) * 1024 which is the maximum that the other engines can handle, not just Tokasaurus.
 
 KV_CACHE_NUM_TOKENS = (1024 + 768) * 1024  # tuned for H100, 80 GB RAM
-# KV_CACHE_NUM_TOKENS = (1024 + 512) * 1024  # value in benchmark script
 MAX_TOKENS_PER_FORWARD = 32768
 MAX_SEQS_PER_FORWARD = 8192
 PAGE_SIZE = 16

--- a/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
+++ b/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
@@ -106,7 +106,7 @@ HYDRAGEN_MIN_GROUP_SIZE = 129  # sic
 # All values are derived from
 # [this version of the official benchmarking script](https://github.com/ScalingIntelligence/tokasaurus/blob/a0155181f09c0cf40783e01a625b041985667a92/tokasaurus/benchmarks/standalone_monkeys_gsm8k.py),
 # except the `KV_CACHE_NUM_TOKENS`, which we increase to the maximum the GPU can handle.
-# The value in the script is set to (1024 + 512) * 1024 which is the maximum that the other engines can handle, not just Tokasaurus.
+# The value in the script is set to `(1024 + 512) * 1024`, which is the maximum that the other engines can handle, lower than that of Tokasaurus.
 
 KV_CACHE_NUM_TOKENS = (1024 + 768) * 1024  # tuned for H100, 80 GB RAM
 MAX_TOKENS_PER_FORWARD = 32768


### PR DESCRIPTION
Incorporate the comment's information into the prose.

Right now on https://modal.com/docs/examples/tokasaurus_throughput#configure-tokasaurus-for-maximum-throughput-on-this-workload, the comment looks like 

<img width="713" height="395" alt="image" src="https://github.com/user-attachments/assets/092d48a7-2a08-4701-a52f-0201dffc8e73" />

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)