### PR TITLE
Fix punctuation and some links for RL examples

### DIFF
--- a/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
@@ -32,7 +32,7 @@ with image.imports():
     from datasets import Dataset, load_dataset
     from trl import GRPOConfig, GRPOTrainer
 
-# We also a define a [Modal Volume](https://modal.com/docs/guide/volumes#volumes) for storing model checkpoints.
+# We also define a [Modal Volume](https://modal.com/docs/guide/volumes#volumes) for storing model checkpoints.
 MODELS_DIR = Path("/models")
 checkpoints_volume: modal.Volume = modal.Volume.from_name(
     "grpo-trl-example-checkpoints", create_if_missing=True
@@ -103,7 +103,7 @@ def reward_helper_function(
 
 
 # Preprocess the data, preparing the columns that `GRPOTrainer` expects.
-# We use the OpenCoder-LLM educational instruct dataset, which has (instruction, code, test case) triples valudated through a Python compiler.
+# We use the OpenCoder-LLM educational instruct dataset, which has (instruction, code, test case) triples validated through a Python compiler.
 # More details [here](https://huggingface.co/datasets/OpenCoder-LLM/opc-sft-stage2).
 def start_grpo_trainer(use_vllm=False, vllm_mode=None):
     dataset: Dataset = load_dataset(

--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -11,8 +11,8 @@
 # The training process works as follows:
 # - Each example in the dataset corresponds to a math problem.
 # - In each training step, the model attempts to solve the math problems showing its steps.
-# - We then compute a reward for the the model's solution using the reward function defined below.
-# - That reward value is then used to update the model's paramaters according to the GRPO training algorithm.
+# - We then compute a reward for the model's solution using the reward function defined below.
+# - That reward value is then used to update the model's parameters according to the GRPO training algorithm.
 
 # ## Setup
 
@@ -64,13 +64,13 @@ def prep_dataset() -> None:
     )
 
 
-# You can kickoff the dataset download with
+# You can kick off the dataset download with
 # `modal run <filename.py>::prep_dataset`
 
 # ## Defining a reward function
 
 # In reinforcement learning, we define a reward function for the model.
-# We can define this in a separate file, or in the same file in as in this case that we then pass as an argument to verl.
+# We can define this in a separate file, or in the same file as in this case that we then pass as an argument to verl.
 # We use a `default` reward function for GSM8K from the [verl repo](https://github.com/volcengine/verl/blob/v0.1/verl/utils/reward_score/gsm8k.py), modified to return 1.0 if it's a correct answer and 0 otherwise.
 
 
@@ -131,7 +131,7 @@ MODELS_PATH: Path = Path("/models")
 MINUTES: int = 60
 
 
-# We also a define a Volume for storing model checkpoints.
+# We also define a Volume for storing model checkpoints.
 checkpoints_volume: modal.Volume = modal.Volume.from_name(
     "grpo-verl-example-checkpoints", create_if_missing=True
 )
@@ -215,7 +215,7 @@ def train(*arglist) -> None:
     subprocess.run(cmd, check=True)
 
 
-# You can now run the training using `modal run --detach grpo-verl.py::train`, or pass in any [additional args from the CLI](https://modal.com/docs/guide/apps#argument-parsing) like this `modal run --detach grpo.py::train -- trainer.total_epochs=20 actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=16`.
+# You can now run the training using `modal run --detach grpo_verl.py::train`, or pass in any [additional args from the CLI](https://modal.com/docs/guide/apps#argument-parsing) like this `modal run --detach grpo.py::train -- trainer.total_epochs=20 actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=16`.
 
 # ## Performing inference on the trained model
 
@@ -225,7 +225,7 @@ VLLM_PORT: int = 8000
 
 
 # Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM.
-# The weights path is as follows: `global_step_n/actor/huggingface` where n is the checkpoint you want (eg `global_step_5/actor/huggingface`).
+# The weights path is as follows: `global_step_n/actor/huggingface` where n is the checkpoint you want (e.g. `global_step_5/actor/huggingface`).
 # The `latest_checkpointed_iteration.txt` file stores the most recent checkpoint index.
 def get_latest_checkpoint_file_path():
     with open(MODELS_PATH / "latest_checkpointed_iteration.txt") as f:
@@ -259,7 +259,7 @@ vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
 )
 @modal.concurrent(
     max_inputs=32
-)  # How many requests can one replica handle? tune carefully!
+)  # How many requests can one replica handle? Tune carefully!
 @modal.web_server(port=VLLM_PORT, startup_timeout=10 * MINUTES)
 def serve():
     import subprocess
@@ -281,7 +281,7 @@ def serve():
     subprocess.Popen(" ".join(cmd), shell=True)
 
 
-# You can then deploy the server using `modal deploy grpo_verl.py`, which gives you a custom url. You can then query it using the following curl command:
+# You can then deploy the server using `modal deploy grpo_verl.py`, which gives you a custom URL. You can then query it using the following curl command:
 
 # ```bash
 # curl -X POST <url>/v1/chat/completions \


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
