### PR TITLE
refactor: improve `image_to_image.py` entrypoint arguments

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -141,17 +141,19 @@ class Model:
 @app.local_entrypoint()
 def main(
     image_path=Path(__file__).parent / "demo_images/dog.png",
-    prompt="A cute dog wizard inspired by Gandalf from Lord of the Rings, featuring detailed fantasy elements in Studio Ghibli style",
-    strength=0.9,  # increase to favor the prompt over the baseline image
+    output_path=Path("/tmp/stable-diffusion/output.png"),
+    prompt: str = "A cute dog wizard inspired by Gandalf from Lord of the Rings, featuring detailed fantasy elements in Studio Ghibli style",
 ):
     print(f"🎨 reading input image from {image_path}")
     input_image_bytes = Path(image_path).read_bytes()
-    print(f"🎨 editing image with prompt {prompt}")
+    print(f"🎨 editing image with prompt '{prompt}'")
     output_image_bytes = Model().inference.remote(input_image_bytes, prompt)
 
-    dir = Path("/tmp/stable-diffusion")
+    if isinstance(output_path, str):
+        output_path = Path(output_path)
+
+    dir = output_path.parent
     dir.mkdir(exist_ok=True, parents=True)
 
-    output_path = dir / "output.png"
     print(f"🎨 saving output image to {output_path}")
     output_path.write_bytes(output_image_bytes)


### PR DESCRIPTION
Remove unused `--strength` argument. [FluxKontextPipeline] doesn't seem to
accept a `strength` parameter.

Add `--output-path` argument.

## example command

```
modal run 06_gpu_and_ml/stable_diffusion/image_to_image.py \
  --image-path 06_gpu_and_ml/stable_diffusion/demo_images/my-example.jpg \
  --output-path /tmp/foo/bar.jpg \
  --prompt 'Keep everything the same but change to be in the style of Frida Kahlo'
```

[FluxKontextPipeline]: https://github.com/huggingface/diffusers/blob/9d313fc718c8ace9a35f07dad9d5ce8018f8d216/docs/source/en/api/pipelines/flux.md#kontext

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)