### PR TITLE
Add guide for storing weights in places where we use volumes for model weights

### DIFF
--- a/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
+++ b/06_gpu_and_ml/audio-to-text/whisperx_transcribe.py
@@ -50,6 +50,8 @@ image = (
 # ## Defining the app
 #
 # Downloaded weights live in a [Modal Volume](https://modal.com/docs/reference/modal.Volume) so subsequent runs reuse them.
+# For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 app = modal.App("whisperx-example", image=image)
 models_volume = modal.Volume.from_name("whisperx-models", create_if_missing=True)
 

--- a/06_gpu_and_ml/comfyui/comfyapp.py
+++ b/06_gpu_and_ml/comfyui/comfyapp.py
@@ -78,6 +78,8 @@ image = (
 # 2. Mounting the cache directory to a [Volume](https://modal.com/docs/guide/volumes)
 
 # By persisting the cache to a Volume, you avoid re-downloading the models every time you rebuild your image.
+# For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 
 def hf_download():

--- a/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
+++ b/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
@@ -119,7 +119,7 @@ class SharedConfig:
 # A persisted [`modal.Volume`](https://modal.com/docs/guide/volumes) can store and share data across Modal Apps and Functions.
 
 # We'll use one to store both the original and fine-tuned weights we create during training
-# and then load them back in for inference. # For more on storing model weights on Modal, see
+# and then load them back in for inference. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 volume = modal.Volume.from_name(

--- a/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
+++ b/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
@@ -119,7 +119,8 @@ class SharedConfig:
 # A persisted [`modal.Volume`](https://modal.com/docs/guide/volumes) can store and share data across Modal Apps and Functions.
 
 # We'll use one to store both the original and fine-tuned weights we create during training
-# and then load them back in for inference.
+# and then load them back in for inference. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 volume = modal.Volume.from_name(
     "dreambooth-finetuning-volume-flux", create_if_missing=True

--- a/06_gpu_and_ml/embeddings/image_embeddings_infinity.py
+++ b/06_gpu_and_ml/embeddings/image_embeddings_infinity.py
@@ -78,7 +78,9 @@ model_input_shape = (224, 224)
 
 # We will use a high-performance [Modal Volume](https://modal.com/docs/guide/volumes#volumes "Modal.Volume")
 # both to cache model weights and to store images we want to encode. The details of
-# setting this volume up are below. Here, we just need to name it so that we can instantiate
+# setting this volume up are below. For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+# Here, we just need to name it so that we can instantiate
 # the Modal application.
 # You may need to [set up a secret](https://modal.com/secrets/) to access HuggingFace datasets
 hf_secret = modal.Secret.from_name("huggingface-secret")

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -70,7 +70,7 @@ gpu = "A10G"
 
 # Since we'll be coordinating training across multiple machines we'll use a
 # distributed [Volume](https://modal.com/docs/guide/volumes)
-# to store the data, checkpointed models, and TensorBoard logs. 
+# to store the data, checkpointed models, and TensorBoard logs.
 
 volume = modal.Volume.from_name("example-hp-sweep-gpt-volume", create_if_missing=True)
 volume_path = PosixPath("/vol/data")

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -70,7 +70,7 @@ gpu = "A10G"
 
 # Since we'll be coordinating training across multiple machines we'll use a
 # distributed [Volume](https://modal.com/docs/guide/volumes)
-# to store the data, checkpointed models, and TensorBoard logs.
+# to store the data, checkpointed models, and TensorBoard logs. 
 
 volume = modal.Volume.from_name("example-hp-sweep-gpt-volume", create_if_missing=True)
 volume_path = PosixPath("/vol/data")

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -70,7 +70,7 @@ gpu = "A10G"
 
 # Since we'll be coordinating training across multiple machines we'll use a
 # distributed [Volume](https://modal.com/docs/guide/volumes)
-# to store the data, checkpointed models, and TensorBoard logs.
+# to store the data, checkpointed models, and TensorBoard logs. 
 
 volume = modal.Volume.from_name("example-hp-sweep-gpt-volume", create_if_missing=True)
 volume_path = PosixPath("/vol/data")
@@ -421,7 +421,9 @@ def monitor_training():
 
 # Because our weights are stored in a distributed Volume,
 # we can deploy an inference endpoint based off of them without any extra work --
-# and we can even check in on models while we're still training them!
+# and we can even check in on models while we're still training them! # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+
 
 # ### Remote inference with Modal `Cls`es
 

--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -77,7 +77,9 @@ MODEL_REVISION_ID = "a6d59ee37c13c58261aa79027d3e41cd41960925"
 # which means the weights would get re-downloaded every time we spin up a new instance.
 
 # We can fix this -- without any modifications to Hugging Face's model loading code! --
-# by pointing the Hugging Face cache at a [Modal Volume](https://modal.com/docs/guide/volumes).
+# by pointing the Hugging Face cache at a [Modal Volume](https://modal.com/docs/guide/volumes). # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+
 
 model_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 

--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -77,7 +77,7 @@ MODEL_REVISION_ID = "a6d59ee37c13c58261aa79027d3e41cd41960925"
 # which means the weights would get re-downloaded every time we spin up a new instance.
 
 # We can fix this -- without any modifications to Hugging Face's model loading code! --
-# by pointing the Hugging Face cache at a [Modal Volume](https://modal.com/docs/guide/volumes). # For more on storing model weights on Modal, see
+# by pointing the Hugging Face cache at a [Modal Volume](https://modal.com/docs/guide/volumes). For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -130,7 +130,6 @@ cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 
-
 @app.function(
     image=model_image, volumes={CACHE_DIR: cache_volume}, timeout=20 * MINUTES
 )

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -126,7 +126,7 @@ cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 
 
 # Running this function will download the model weights to the cache volume.
-# Otherwise, the model weights will be downloaded on the first query. # For more on storing model weights on Modal, see
+# Otherwise, the model weights will be downloaded on the first query. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -126,7 +126,9 @@ cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 
 
 # Running this function will download the model weights to the cache volume.
-# Otherwise, the model weights will be downloaded on the first query.
+# Otherwise, the model weights will be downloaded on the first query. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+
 
 
 @app.function(

--- a/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
+++ b/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
@@ -79,7 +79,9 @@ MODEL_REVISION = "4e20de362430cd3b72f300e6b0f18e50e7166e08"  # avoid nasty surpr
 
 # Although Tokasaurus will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.
-# We'll use a [Modal Volume](https://modal.com/docs/guide/volumes) for our cache.
+# We'll use a [Modal Volume](https://modal.com/docs/guide/volumes) for our cache. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+
 
 app_name = "example-tokasaurus-throughput"
 hf_cache_vol = modal.Volume.from_name(f"{app_name}-hf-cache", create_if_missing=True)

--- a/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
+++ b/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
@@ -77,7 +77,7 @@ MODEL_REVISION = "4e20de362430cd3b72f300e6b0f18e50e7166e08"  # avoid nasty surpr
 
 # Although Tokasaurus will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.
-# We'll use a [Modal Volume](https://modal.com/docs/guide/volumes) for our cache. # For more on storing model weights on Modal, see
+# We'll use a [Modal Volume](https://modal.com/docs/guide/volumes) for our cache. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -65,7 +65,7 @@ MODEL_REVISION = "12fd6884d2585dd4d020373e7f39f74507b31866"  # avoid nasty surpr
 # Although vLLM will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.
 # We'll use [Modal Volumes](https://modal.com/docs/guide/volumes) for our cache.
-# Modal Volumes are essentially a "shared disk" that all Modal Functions can access like it's a regular disk. # For more on storing model weights on Modal, see
+# Modal Volumes are essentially a "shared disk" that all Modal Functions can access like it's a regular disk. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -65,7 +65,9 @@ MODEL_REVISION = "12fd6884d2585dd4d020373e7f39f74507b31866"  # avoid nasty surpr
 # Although vLLM will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.
 # We'll use [Modal Volumes](https://modal.com/docs/guide/volumes) for our cache.
-# Modal Volumes are essentially a "shared disk" that all Modal Functions can access like it's a regular disk.
+# Modal Volumes are essentially a "shared disk" that all Modal Functions can access like it's a regular disk. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+
 
 hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
 

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -88,7 +88,7 @@ with image.imports():
 # We'll store the model weights in a Volume and provide a function that you can
 # `modal run` against to download the model weights prior to deploying the App.
 # Otherwise, the model weights will be downloaded for the first inference
-# and cached to the Volume when the first container exits. # For more on storing model weights on Modal, see
+# and cached to the Volume when the first container exits. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/obj_detection_webcam/webcam.py
+++ b/06_gpu_and_ml/obj_detection_webcam/webcam.py
@@ -88,7 +88,9 @@ with image.imports():
 # We'll store the model weights in a Volume and provide a function that you can
 # `modal run` against to download the model weights prior to deploying the App.
 # Otherwise, the model weights will be downloaded for the first inference
-# and cached to the Volume when the first container exits.
+# and cached to the Volume when the first container exits. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
+
 
 cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -46,7 +46,7 @@ DATA_PATH = VOLUME_PATH / "data"
 # The container image for structure inference is based on Modal's default slim Debian
 # Linux image with `esm` for loading and running the model, `gemmi` for
 # managing protein structure file conversions, and `hf_transfer`
-# for faster downloading of the model weights from Hugging Face.
+# for faster downloading of the model weights from Hugging Face. 
 
 esm3_image = (
     modal.Image.debian_slim(python_version="3.11")

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -46,7 +46,7 @@ DATA_PATH = VOLUME_PATH / "data"
 # The container image for structure inference is based on Modal's default slim Debian
 # Linux image with `esm` for loading and running the model, `gemmi` for
 # managing protein structure file conversions, and `hf_transfer`
-# for faster downloading of the model weights from Hugging Face. 
+# for faster downloading of the model weights from Hugging Face.
 
 esm3_image = (
     modal.Image.debian_slim(python_version="3.11")

--- a/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
@@ -209,7 +209,8 @@ def train_vllm_colocate_mode() -> None:
 VLLM_PORT: int = 8000
 
 
-# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM.
+# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 # The weights path is as follows: `global_step_n/actor/huggingface` where n is the checkpoint you want (eg `global_step_5/actor/huggingface`).
 # The `latest_checkpointed_iteration.txt` file stores the most recent checkpoint index.
 def get_latest_checkpoint_file_path():

--- a/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
@@ -209,7 +209,7 @@ def train_vllm_colocate_mode() -> None:
 VLLM_PORT: int = 8000
 
 
-# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM. # For more on storing model weights on Modal, see
+# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 # The weights path is as follows: `global_step_n/actor/huggingface` where n is the checkpoint you want (eg `global_step_5/actor/huggingface`).
 # The `latest_checkpointed_iteration.txt` file stores the most recent checkpoint index.

--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -224,7 +224,8 @@ def train(*arglist) -> None:
 VLLM_PORT: int = 8000
 
 
-# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM.
+# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 # The weights path is as follows: `global_step_n/actor/huggingface` where n is the checkpoint you want (e.g. `global_step_5/actor/huggingface`).
 # The `latest_checkpointed_iteration.txt` file stores the most recent checkpoint index.
 def get_latest_checkpoint_file_path():

--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -224,7 +224,7 @@ def train(*arglist) -> None:
 VLLM_PORT: int = 8000
 
 
-# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM. # For more on storing model weights on Modal, see
+# Once you have the model checkpoints in your Modal Volume, you can load the weights and perform inference using vLLM. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 # The weights path is as follows: `global_step_n/actor/huggingface` where n is the checkpoint you want (e.g. `global_step_5/actor/huggingface`).
 # The `latest_checkpointed_iteration.txt` file stores the most recent checkpoint index.

--- a/06_gpu_and_ml/reinforcement-learning/learn_math.py
+++ b/06_gpu_and_ml/reinforcement-learning/learn_math.py
@@ -52,11 +52,13 @@ image = (
     )
 )
 
-# ## Caching HuggingFace, vLLM, and storing model weights
+# ## Caching HuggingFace, vLLM, and storing model weights. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 # We create Modal Volumes to persist:
 # - HuggingFace downloads
 # - vLLM cache
 # - Model weights
+
 
 # We define the model name and a tool that the model can use to execute Python code that it generates.
 # See this [this training script](/docs/examples/trainer_script_grpo) for more details.

--- a/06_gpu_and_ml/reinforcement-learning/learn_math.py
+++ b/06_gpu_and_ml/reinforcement-learning/learn_math.py
@@ -52,7 +52,7 @@ image = (
     )
 )
 
-# ## Caching HuggingFace, vLLM, and storing model weights. # For more on storing model weights on Modal, see
+# ## Caching HuggingFace, vLLM, and storing model weights. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 # We create Modal Volumes to persist:
 # - HuggingFace downloads

--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -59,7 +59,7 @@ app = modal.App("sam2-app", image=image)
 # We use the `@modal.enter()` decorators here for optimization: it makes sure the initialization
 # method runs only once, when a new container starts, instead of in the path of every call.
 # We'll also use a modal Volume to cache the model weights so that they don't need to be downloaded
-# repeatedly when we start new containers. # For more on storing model weights on Modal, see
+# repeatedly when we start new containers. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/sam/segment_anything.py
+++ b/06_gpu_and_ml/sam/segment_anything.py
@@ -59,7 +59,8 @@ app = modal.App("sam2-app", image=image)
 # We use the `@modal.enter()` decorators here for optimization: it makes sure the initialization
 # method runs only once, when a new container starts, instead of in the path of every call.
 # We'll also use a modal Volume to cache the model weights so that they don't need to be downloaded
-# repeatedly when we start new containers.
+# repeatedly when we start new containers. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 
 video_vol = modal.Volume.from_name("sam2-inputs", create_if_missing=True)

--- a/06_gpu_and_ml/speech-to-text/batched_whisper.py
+++ b/06_gpu_and_ml/speech-to-text/batched_whisper.py
@@ -75,7 +75,8 @@ def download_model():
 
 # We define a `@modal.enter` method to load the model when the container starts, before it picks up any inputs.
 # The weights will be loaded from the Hugging Face cache volume so that we don't need to download them when
-# we start a new container.
+# we start a new container. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 # We also define a `transcribe` method that uses the `@modal.batched` decorator to enable dynamic batching.
 # This allows us to invoke the function with individual audio samples, and the function will automatically batch them

--- a/06_gpu_and_ml/speech-to-text/batched_whisper.py
+++ b/06_gpu_and_ml/speech-to-text/batched_whisper.py
@@ -75,7 +75,7 @@ def download_model():
 
 # We define a `@modal.enter` method to load the model when the container starts, before it picks up any inputs.
 # The weights will be loaded from the Hugging Face cache volume so that we don't need to download them when
-# we start a new container. # For more on storing model weights on Modal, see
+# we start a new container. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 # We also define a `transcribe` method that uses the `@modal.batched` decorator to enable dynamic batching.

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -62,7 +62,7 @@ def load_model(and_return=False):
 # we need to store the weights somewhere besides our local filesystem.
 
 # So we add a Modal [Volume](https://modal.com/docs/guide/volumes)
-# to store the weights in the cloud. # For more on storing model weights on Modal, see
+# to store the weights in the cloud. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 cache_dir = "/cache"

--- a/06_gpu_and_ml/text-to-audio/musicgen.py
+++ b/06_gpu_and_ml/text-to-audio/musicgen.py
@@ -62,7 +62,8 @@ def load_model(and_return=False):
 # we need to store the weights somewhere besides our local filesystem.
 
 # So we add a Modal [Volume](https://modal.com/docs/guide/volumes)
-# to store the weights in the cloud.
+# to store the weights in the cloud. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 cache_dir = "/cache"
 model_cache = modal.Volume.from_name("audiocraft-model-cache", create_if_missing=True)

--- a/06_gpu_and_ml/text-to-video/ltx.py
+++ b/06_gpu_and_ml/text-to-video/ltx.py
@@ -77,7 +77,7 @@ model = modal.Volume.from_name(MODEL_VOLUME_NAME, create_if_missing=True)
 MODEL_PATH = Path("/models")
 image = image.env({"HF_HOME": str(MODEL_PATH)})
 
-# For more on storing Modal weights on Modal, see
+# For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 

--- a/06_gpu_and_ml/text-to-video/mochi.py
+++ b/06_gpu_and_ml/text-to-video/mochi.py
@@ -80,7 +80,7 @@ HOURS = 60 * MINUTES
 
 # ## Downloading the model
 
-# We download the model weights into Volume cache to speed up cold starts. # For more on storing model weights on Modal, see
+# We download the model weights into Volume cache to speed up cold starts. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 # This download takes five minutes or more, depending on traffic

--- a/06_gpu_and_ml/text-to-video/mochi.py
+++ b/06_gpu_and_ml/text-to-video/mochi.py
@@ -80,7 +80,8 @@ HOURS = 60 * MINUTES
 
 # ## Downloading the model
 
-# We download the model weights into Volume cache to speed up cold starts.
+# We download the model weights into Volume cache to speed up cold starts. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 # This download takes five minutes or more, depending on traffic
 # and network speed.

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -46,7 +46,7 @@ image = (
     )
 )
 
-# We also create a persistent [Volume](https://modal.com/docs/guide/volumes) for storing datasets, trained weights, and inference outputs. # For more on storing model weights on Modal, see
+# We also create a persistent [Volume](https://modal.com/docs/guide/volumes) for storing datasets, trained weights, and inference outputs. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 volume = modal.Volume.from_name("yolo-finetune", create_if_missing=True)

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -46,7 +46,8 @@ image = (
     )
 )
 
-# We also create a persistent [Volume](https://modal.com/docs/guide/volumes) for storing datasets, trained weights, and inference outputs.
+# We also create a persistent [Volume](https://modal.com/docs/guide/volumes) for storing datasets, trained weights, and inference outputs. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 volume = modal.Volume.from_name("yolo-finetune", create_if_missing=True)
 volume_path = (  # the path to the volume from within the container

--- a/07_web_endpoints/webrtc/webrtc_yolo.py
+++ b/07_web_endpoints/webrtc/webrtc_yolo.py
@@ -144,7 +144,7 @@ video_processing_image = (
 
 # We also need to create a Modal [Volume](https://modal.com/docs/guide/volumes) to store things we need across replicas --
 # primarily the model weights and ONNX inference graph, but also a few other artifacts like a video file where
-# we'll write out the processed video stream for testing. # For more on storing model weights on Modal, see
+# we'll write out the processed video stream for testing. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 # The very first time we run the app, downloading the model and building the ONNX inference graph will take a few minutes.

--- a/07_web_endpoints/webrtc/webrtc_yolo.py
+++ b/07_web_endpoints/webrtc/webrtc_yolo.py
@@ -144,7 +144,8 @@ video_processing_image = (
 
 # We also need to create a Modal [Volume](https://modal.com/docs/guide/volumes) to store things we need across replicas --
 # primarily the model weights and ONNX inference graph, but also a few other artifacts like a video file where
-# we'll write out the processed video stream for testing.
+# we'll write out the processed video stream for testing. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 # The very first time we run the app, downloading the model and building the ONNX inference graph will take a few minutes.
 # After that, we can load the cached weights and graph from the Volume, which reduces the startup time to about 15 seconds per container.

--- a/misc/deepseek_openai_server.py
+++ b/misc/deepseek_openai_server.py
@@ -140,7 +140,7 @@ vllm_image = (
 # Modal is serverless, so disks are by default ephemeral.
 # To make sure our weights don't disappear between runs
 # and require a long download step, we store them in a
-# Modal [Volume](https://modal.com/docs/guide/volumes). 
+# Modal [Volume](https://modal.com/docs/guide/volumes).
 model_cache = modal.Volume.from_name("deepseek", create_if_missing=True)
 cache_dir = "/root/.cache/deepseek"
 

--- a/misc/deepseek_openai_server.py
+++ b/misc/deepseek_openai_server.py
@@ -140,7 +140,7 @@ vllm_image = (
 # Modal is serverless, so disks are by default ephemeral.
 # To make sure our weights don't disappear between runs
 # and require a long download step, we store them in a
-# Modal [Volume](https://modal.com/docs/guide/volumes).
+# Modal [Volume](https://modal.com/docs/guide/volumes). 
 model_cache = modal.Volume.from_name("deepseek", create_if_missing=True)
 cache_dir = "/root/.cache/deepseek"
 

--- a/misc/flux_endpoint.py
+++ b/misc/flux_endpoint.py
@@ -15,7 +15,7 @@
 
 # We start by importing the necessary libraries and defining our storage paths.
 # We use Modal Volumes for caching model artifacts and Modal CloudBucketMounts for
-# storing generated images. # For more on storing model weights on Modal, see
+# storing generated images. For more on storing model weights on Modal, see
 # [this guide](https://modal.com/docs/guide/model-weights).
 
 from __future__ import annotations

--- a/misc/flux_endpoint.py
+++ b/misc/flux_endpoint.py
@@ -15,7 +15,8 @@
 
 # We start by importing the necessary libraries and defining our storage paths.
 # We use Modal Volumes for caching model artifacts and Modal CloudBucketMounts for
-# storing generated images.
+# storing generated images. # For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 
 from __future__ import annotations
 

--- a/misc/ollama_deployment.py
+++ b/misc/ollama_deployment.py
@@ -49,7 +49,8 @@ image = (
     )
 )
 
-# Create a persistent volume to store model weights
+# Create a persistent volume to store model weights. For more on storing model weights on Modal, see
+# [this guide](https://modal.com/docs/guide/model-weights).
 volume = modal.Volume.from_name("ollama-model-weights", create_if_missing=True)
 
 # Create the Modal application


### PR DESCRIPTION
Adding a reference to our model weights on Modal guide in places we use it.
Also, fixed some "Modal weights" typos. Changed them to "model weights".
Checked the preview links for the changes to make sure no weight newline/formatting business.

## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`
