### PR TITLE
Fix AttributeError in ColQwen2 Chat with PDF Vision Example

### DIFF
--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -36,7 +36,9 @@ model_image = (
     .apt_install("git")
     .pip_install(
         [
-            "git+https://github.com/illuin-tech/colpali.git@782edcd50108d1842d154730ad3ce72476a2d17d",  # we pin the commit id
+            "colpali-engine==0.3.5",  # Use the stable PyPI version instead of git
+            "transformers>=4.45.0",   # Ensure compatible transformers version
+            "torch>=2.0.0",          # Ensure compatible torch version
             "hf_transfer==0.1.8",
             "qwen-vl-utils==0.0.8",
             "torchvision==0.19.1",


### PR DESCRIPTION
## Summary
• Fixed AttributeError: 'ColQwen2' object has no attribute 'get_rope_index' in chat_with_pdf_vision.py
• Replaced pinned git dependency with stable colpali-engine==0.3.5 from PyPI
• Added version constraints for transformers>=4.45.0 and torch>=2.0.0 for compatibility

See error here: https://gist.github.com/nuxe/1683099ece074b22db7677f63ff0ac3f

## Changes Made
• Replaced `git+https://github.com/illuin-tech/colpali.git@782edcd50108d1842d154730ad3ce72476a2d17d` with `colpali-engine==0.3.5`
• Added `transformers>=4.45.0` (ensures compatibility with ColQwen2)
• Added `torch>=2.0.0` (ensures modern torch compatibility)

## Testing
• ✅ Gradio web interface & PDF RAG runs correctly

<img width="1538" height="437" alt="Screenshot 2025-08-03 at 3 36 39 PM" src="https://github.com/user-attachments/assets/087659e5-dd4c-4e8b-a9d6-6792d033cdfd" />

🤖 Generated with [Claude Code](https://claude.ai/code)