### PR TITLE
Update webscraper

### DIFF
--- a/10_integrations/webscraper.py
+++ b/10_integrations/webscraper.py
@@ -1,3 +1,7 @@
+# ---
+# cmd: ["modal", "deploy", "10/integrations/webscraper.py"]
+# ---
+
 # # Web Scraping on Modal
 #
 # In this guide we'll introduce you to Modal by writing a simple web scraper.

--- a/10_integrations/webscraper.py
+++ b/10_integrations/webscraper.py
@@ -129,7 +129,7 @@ playwright_image = modal.Image.debian_slim(python_version="3.10").run_commands(
 
 
 @app.function(image=playwright_image)
-async def get_links(cur_url: str) -> set[str]:
+async def get_links(cur_url: str) -> list[str]:
     from playwright.async_api import async_playwright
 
     async with async_playwright() as p:

--- a/10_integrations/webscraper.py
+++ b/10_integrations/webscraper.py
@@ -1,25 +1,25 @@
 # ---
-# cmd: ["modal", "deploy", "10/integrations/webscraper.py"]
+# deploy: true
 # ---
 
-# # Web Scraping on Modal
-#
+# # A simple web scraper
+
 # In this guide we'll introduce you to Modal by writing a simple web scraper.
 # We'll explain the foundations of a Modal application step by step.
-#
+
 # ## Set up your first Modal app
-#
-# Modal apps are orchestrated as Python scripts, but can theoretically run
+
+# Modal Apps are orchestrated as Python scripts, but can theoretically run
 # anything you can run in a container. To get you started, make sure to install
-# the latest Modal Python package and set up an API token (the first two steps of
-# the [Getting started](/home) page).
-#
+# the latest `modal` Python package and set up an API token (the first two steps of
+# the [Getting started](https://modal.com/docs/guide) page).
+
 # ## Finding links
-#
-# First, we create an empty Python file `scrape.py`. This file will contain our
-# application code. Lets write some basic Python code to fetch the contents of a
-# web page and print the links (href attributes) it finds in the document:
-#
+
+# First, we create an empty Python file `webscraper.py`. This file will contain our
+# application code. Let's write some basic Python code to fetch the contents of a
+# web page and print the links (`href` attributes) it finds in the document:
+
 # ```python
 # import re
 # import sys
@@ -39,38 +39,43 @@
 #     links = get_links(sys.argv[1])
 #     print(links)
 # ```
-#
+
 # Now obviously this is just pure standard library Python code, and you can run it
 # on your machine:
-#
+
 # ```
-# $ python scrape.py http://example.com
+# $ python webscraper.py http://example.com
 # ['https://www.iana.org/domains/example']
 # ```
-#
+
 # ## Running it in Modal
-#
-# To make the `get_links` function run in Modal instead of your local machine, all
+
+# To make the `get_links` function run on Modal instead of your local machine, all
 # you need to do is
-#
+
 # - Import `modal`
 # - Create a [`modal.App`](/docs/reference/modal.App) instance
-# - Add a `@app.function()` annotation to your function
+# - Add an `@app.function()` annotation to your function
 # - Replace the `if __name__ == "__main__":` block with a function decorated with
 #   [`@app.local_entrypoint()`](/docs/reference/modal.App#local_entrypoint)
 # - Call `get_links` using `get_links.remote`
-#
+
 # ```python
 # import re
 # import urllib.request
 # import modal
 #
-# app = modal.App(name="link-scraper")
+# app = modal.App(name="example-webscraper")
 #
 #
 # @app.function()
 # def get_links(url):
-#     ...
+#     response = urllib.request.urlopen(url)
+#     html = response.read().decode("utf8")
+#     links = []
+#     for match in re.finditer('href="(.*?)"', html):
+#         links.append(match.group(1))
+#     return links
 #
 #
 # @app.local_entrypoint()
@@ -78,37 +83,36 @@
 #     links = get_links.remote(url)
 #     print(links)
 # ```
-#
+
 # You can now run this with the Modal CLI, using `modal run` instead of `python`.
 # This time, you'll see additional progress indicators while the script is
-# running:
-#
+# running, something like:
+
 # ```
-# $ modal run scrape.py --url http://example.com
+# $ modal run webscraper.py --url http://example.com
 # ✓ Initialized.
 # ✓ Created objects.
 # ['https://www.iana.org/domains/example']
 # ✓ App completed.
 # ```
-#
+
 # ## Custom containers
-#
+
 # In the code above we make use of the Python standard library `urllib` library.
 # This works great for static web pages, but many pages these days use javascript
 # to dynamically load content, which wouldn't appear in the loaded html file.
 # Let's use the [Playwright](https://playwright.dev/python/docs/intro) package to
 # instead launch a headless Chromium browser which can interpret any javascript
 # that might be on the page.
-#
-# We can pass custom container images (defined using
-# [`modal.Image`](/docs/reference/modal.Image)) to the `@app.function()`
-# decorator. We'll make use of the `modal.Image.debian_slim` pre-bundled image add
-# the shell commands to install Playwright and its dependencies:
 
+# We can pass [custom container images](/docs/guide/images) (defined using
+# [`modal.Image`](/docs/reference/modal.Image)) to the `@app.function()`
+# decorator. We'll make use of the `modal.Image.debian_slim` pre-bundled Image add
+# the shell commands to install Playwright and its dependencies:
 
 import modal
 
-app = modal.App("link-scraper")
+app = modal.App("example-webscraper")
 playwright_image = modal.Image.debian_slim(python_version="3.10").run_commands(
     "apt-get update",
     "apt-get install -y software-properties-common",
@@ -119,11 +123,9 @@ playwright_image = modal.Image.debian_slim(python_version="3.10").run_commands(
     "playwright install chromium",
 )
 
-
 # Note that we don't have to install Playwright or Chromium on our development
 # machine since this will all run in Modal. We can now modify our `get_links`
 # function to make use of the new tools.
-# We also limit the numbers of links scraped to 10 to avoid rate limits.
 
 
 @app.function(image=playwright_image)
@@ -134,36 +136,37 @@ async def get_links(cur_url: str) -> set[str]:
         browser = await p.chromium.launch()
         page = await browser.new_page()
         await page.goto(cur_url)
-        links = await page.eval_on_selector_all("a[href]", "elements => elements.map(element => element.href)")
+        links = await page.eval_on_selector_all(
+            "a[href]", "elements => elements.map(element => element.href)"
+        )
         await browser.close()
 
-    limited_links = links[:10]
-    print("Links", limited_links)
-    return set(limited_links)
+    print("Links", links)
+    return list(set(links))
 
 
 # Since Playwright has a nice async interface, we'll redeclare our `get_links`
 # function as async (Modal works with both sync and async functions).
-#
+
 # The first time you run the function after making this change, you'll notice that
-# the output first shows the progress of building the custom image you specified,
+# the output first shows the progress of building the image you specified,
 # after which your function runs like before. This image is then cached so that on
 # subsequent runs of the function it will not be rebuilt as long as the image
 # definition is the same.
-#
+
 # ## Scaling out
-#
+
 # So far, our script only fetches the links for a single page. What if we want to
 # scrape a large list of links in parallel?
-#
+
 # We can do this easily with Modal, because of some magic: the function we wrapped
 # with the `@app.function()` decorator is no longer an ordinary function, but a
 # Modal [Function](https://modal.com/docs/reference/modal.Function) object. This
 # means it comes with a `map` property built in, that lets us run this function
 # for all inputs in parallel, scaling up to as many workers as needed.
-#
+
 # Let's change our code to scrape all urls we feed to it in parallel:
-#
+
 # ```python
 # @app.local_entrypoint()
 # def main():
@@ -172,16 +175,16 @@ async def get_links(cur_url: str) -> set[str]:
 #         for link in links:
 #             print(link)
 # ```
-#
+
 # ## Schedules and deployments
-#
+
 # Let's say we want to log the scraped links daily. We move the print loop into
 # its own Modal function and annotate it with a `modal.Period(days=1)` schedule -
 # indicating we want to run it once per day. Since the scheduled function will not
 # run from our command line, we also add a hard-coded list of links to crawl for
 # now. In a more realistic setting we could read this from a database or other
 # accessible data source.
-#
+
 # ```python
 # @app.function(schedule=modal.Period(days=1))
 # def daily_scrape():
@@ -190,47 +193,53 @@ async def get_links(cur_url: str) -> set[str]:
 #         for link in links:
 #             print(link)
 # ```
-#
-# To deploy this as a permanent app, run the command
-#
+
+# To deploy App permanently, run the command
+
 # ```
-# modal deploy scrape.py
+# modal deploy webscraper.py
 # ```
-#
+
 # Running this command deploys this function and then closes immediately. We can
 # see the deployment and all of its runs, including the printed links, on the
 # Modal [Apps page](https://modal.com/apps). Rerunning the script will redeploy
 # the code with any changes you have made - overwriting an existing deploy with
-# the same name ("link-scraper" in this case).
-#
+# the same name ("example-webscraper" in this case).
+
 # ## Integrations and Secrets
-#
+
 # Instead of looking at the links in the run logs of our deployments, let's say we
-# wanted to post them to our `#scraped-links` Slack channel. To do this, we can
+# wanted to post them to a `#scraped-links` Slack channel. To do this, we can
 # make use of the [Slack API](https://api.slack.com/) and the `slack-sdk`
 # [PyPI package](https://pypi.org/project/slack-sdk/).
-# We also limit the number of links posted to 50 to avoid rate limits.
-#
+
 # The Slack SDK WebClient requires an API token to get access to our Slack
 # Workspace, and since it's bad practice to hardcode credentials into application
 # code we make use of Modal's **Secrets**. Secrets are snippets of data that will
 # be injected as environment variables in the containers running your functions.
-#
+
 # The easiest way to create Secrets is to go to the
 # [Secrets section of modal.com](https://modal.com/secrets). You can both create a
 # free-form secret with any environment variables, or make use of presets for
 # common services. We'll use the Slack preset and after filling in the necessary
 # information we are presented with a snippet of code that can be used to post to
-# Slack using our credentials:
-#
+# Slack using our credentials, which looks something like:
+
 import os
 
-slack_sdk_image = modal.Image.debian_slim(python_version="3.10").pip_install("slack-sdk")
+slack_sdk_image = modal.Image.debian_slim(python_version="3.10").pip_install(
+    "slack-sdk"
+)
 
 
 @app.function(
     image=slack_sdk_image,
-    secrets=[modal.Secret.from_name("scraper-slack-secret", required_keys=["SLACK_BOT_TOKEN"])],
+    secrets=[
+        modal.Secret.from_name(
+            "scraper-slack-secret", required_keys=["SLACK_BOT_TOKEN"]
+        )
+    ],
+    retries=3,
 )
 def bot_token_msg(channel, message):
     import slack_sdk
@@ -240,42 +249,57 @@ def bot_token_msg(channel, message):
     client.chat_postMessage(channel=channel, text=message)
 
 
-# Copy that code as-is, then amend the `daily_scrape` function to call
-# `bot_token_msg`.
-#
+# Notice the `retries` in the `@app.function` decorator.
+# That parameter adds automatic retries when Function calls fail
+# due to temporary issues, like rate limits. Read more [here](https://modal.com/docs/guide/retries)
 
-
-@app.function()
-def scrape():
-    urls = ["http://modal.com", "http://github.com"]
-
-    for links in get_links.map(urls):
-        for link in links:
-            bot_token_msg.remote("scraped-links", link)
+# Copy that code, then amend the `daily_scrape` function to call
+# `bot_token_msg`. We also add a per-URL `limit` for good measure.
 
 
 @app.function(schedule=modal.Period(days=1))
-def daily_scrape():
+def daily_scrape(limit: int = 50):
     urls = ["http://modal.com", "http://github.com"]
 
     for links in get_links.map(urls):
-        for link in links:
+        for link in links[:limit]:
             bot_token_msg.remote("scraped-links", link)
 
 
 @app.local_entrypoint()
-def run():
-    scrape.remote()
+def main():
+    urls = ["http://modal.com", "http://github.com"]
+    for links in get_links.map(urls):
+        for link in links:
+            print(link)
 
 
 # Note that we are freely making function calls across completely different
-# container images, as if they were regular Python functions in the same program.
-#
-# We rerun the script which overwrites the old deploy with our updated code, and
-# now we get a daily feed of our scraped links in our Slack channel 🎉
-#
+# container images, as if they were regular Python functions in the same program!
+
+# We keep the `local_entrypoint` the same so that we can still `modal run`
+# this script to test the scraping behavior without posting to Slack.
+
+# ```bash
+# modal run webscraper.py  # runs get_links.map via the local_entrypoint
+# ```
+
+# If we want to test the `daily_scrape` or `bot_token_msg` Functions themselves, we can do that too!
+# We just add the name of the Function to the end of our `modal run` command:
+
+# ```bash
+# modal run webscraper.py::daily_scrape --limit 1  # quick test
+# ```
+
+# Now redeploy the script to overwrite the old deploy with our updated code, and
+# you'll get a daily feed of scraped links in your Slack channel 🎉
+
+# ```bash
+# modal deploy webscraper.py
+# ```
+
 # ## Summary
-#
+
 # We have shown how you can use Modal to develop distributed Python data
 # applications using custom containers. Through simple constructs we were able to
 # add parallel execution. With the change of a single line of code were were able

--- a/10_integrations/webscraper.py
+++ b/10_integrations/webscraper.py
@@ -9,12 +9,12 @@
 
 # ## Set up your first Modal app
 
-# Modal Apps are orchestrated as Python scripts, but can theoretically run
+# Modal Apps are orchestrated as Python scripts but can theoretically run
 # anything you can run in a container. To get you started, make sure to install
-# the latest `modal` Python package and set up an API token (the first two steps of
-# the [Getting started](https://modal.com/docs/guide) page).
+# the latest `modal` Python package and set up an API token (the first two steps
+# [here](https://modal.com/docs/guide)).
 
-# ## Finding links
+# ## Scrape links locally
 
 # First, we create an empty Python file `webscraper.py`. This file will contain our
 # application code. Let's write some basic Python code to fetch the contents of a
@@ -43,12 +43,12 @@
 # Now obviously this is just pure standard library Python code, and you can run it
 # on your machine:
 
-# ```
+# ```bash
 # $ python webscraper.py http://example.com
 # ['https://www.iana.org/domains/example']
 # ```
 
-# ## Running it in Modal
+# ## Run it on Modal
 
 # To make the `get_links` function run on Modal instead of your local machine, all
 # you need to do is
@@ -88,7 +88,7 @@
 # This time, you'll see additional progress indicators while the script is
 # running, something like:
 
-# ```
+# ```bash
 # $ modal run webscraper.py --url http://example.com
 # ✓ Initialized.
 # ✓ Created objects.
@@ -96,7 +96,7 @@
 # ✓ App completed.
 # ```
 
-# ## Custom containers
+# ## Add dependencies
 
 # In the code above we make use of the Python standard library `urllib` library.
 # This works great for static web pages, but many pages these days use javascript
@@ -154,7 +154,7 @@ async def get_links(cur_url: str) -> set[str]:
 # subsequent runs of the function it will not be rebuilt as long as the image
 # definition is the same.
 
-# ## Scaling out
+# ## Scale out
 
 # So far, our script only fetches the links for a single page. What if we want to
 # scrape a large list of links in parallel?
@@ -176,7 +176,7 @@ async def get_links(cur_url: str) -> set[str]:
 #             print(link)
 # ```
 
-# ## Schedules and deployments
+# ## Deploy it and run it on a schedule
 
 # Let's say we want to log the scraped links daily. We move the print loop into
 # its own Modal function and annotate it with a `modal.Period(days=1)` schedule -
@@ -206,7 +206,7 @@ async def get_links(cur_url: str) -> set[str]:
 # the code with any changes you have made - overwriting an existing deploy with
 # the same name ("example-webscraper" in this case).
 
-# ## Integrations and Secrets
+# ## Add Secrets and integrate with other systems
 
 # Instead of looking at the links in the run logs of our deployments, let's say we
 # wanted to post them to a `#scraped-links` Slack channel. To do this, we can

--- a/10_integrations/webscraper.py
+++ b/10_integrations/webscraper.py
@@ -1,17 +1,111 @@
 # # Web Scraping on Modal
+#
+# In this guide we'll introduce you to Modal by writing a simple web scraper.
+# We'll explain the foundations of a Modal application step by step.
+#
+# ## Set up your first Modal app
+#
+# Modal apps are orchestrated as Python scripts, but can theoretically run
+# anything you can run in a container. To get you started, make sure to install
+# the latest Modal Python package and set up an API token (the first two steps of
+# the [Getting started](/home) page).
+#
+# ## Finding links
+#
+# First, we create an empty Python file `scrape.py`. This file will contain our
+# application code. Lets write some basic Python code to fetch the contents of a
+# web page and print the links (href attributes) it finds in the document:
+#
+# ```python
+# import re
+# import sys
+# import urllib.request
+#
+#
+# def get_links(url):
+#     response = urllib.request.urlopen(url)
+#     html = response.read().decode("utf8")
+#     links = []
+#     for match in re.finditer('href="(.*?)"', html):
+#         links.append(match.group(1))
+#     return links
+#
+#
+# if __name__ == "__main__":
+#     links = get_links(sys.argv[1])
+#     print(links)
+# ```
+#
+# Now obviously this is just pure standard library Python code, and you can run it
+# on your machine:
+#
+# ```
+# $ python scrape.py http://example.com
+# ['https://www.iana.org/domains/example']
+# ```
+#
+# ## Running it in Modal
+#
+# To make the `get_links` function run in Modal instead of your local machine, all
+# you need to do is
+#
+# - Import `modal`
+# - Create a [`modal.App`](/docs/reference/modal.App) instance
+# - Add a `@app.function()` annotation to your function
+# - Replace the `if __name__ == "__main__":` block with a function decorated with
+#   [`@app.local_entrypoint()`](/docs/reference/modal.App#local_entrypoint)
+# - Call `get_links` using `get_links.remote`
+#
+# ```python
+# import re
+# import urllib.request
+# import modal
+#
+# app = modal.App(name="link-scraper")
+#
+#
+# @app.function()
+# def get_links(url):
+#     ...
+#
+#
+# @app.local_entrypoint()
+# def main(url):
+#     links = get_links.remote(url)
+#     print(links)
+# ```
+#
+# You can now run this with the Modal CLI, using `modal run` instead of `python`.
+# This time, you'll see additional progress indicators while the script is
+# running:
+#
+# ```
+# $ modal run scrape.py --url http://example.com
+# ✓ Initialized.
+# ✓ Created objects.
+# ['https://www.iana.org/domains/example']
+# ✓ App completed.
+# ```
+#
+# ## Custom containers
+#
+# In the code above we make use of the Python standard library `urllib` library.
+# This works great for static web pages, but many pages these days use javascript
+# to dynamically load content, which wouldn't appear in the loaded html file.
+# Let's use the [Playwright](https://playwright.dev/python/docs/intro) package to
+# instead launch a headless Chromium browser which can interpret any javascript
+# that might be on the page.
+#
+# We can pass custom container images (defined using
+# [`modal.Image`](/docs/reference/modal.Image)) to the `@app.function()`
+# decorator. We'll make use of the `modal.Image.debian_slim` pre-bundled image add
+# the shell commands to install Playwright and its dependencies:
 
-# This example shows how you can scrape links from a website and post them to a Slack channel using Modal.
-
-import os
 
 import modal
 
-app = modal.App("example-webscraper")
-
-
-playwright_image = modal.Image.debian_slim(
-    python_version="3.10"
-).run_commands(  # Doesn't work with 3.11 yet
+app = modal.App("link-scraper")
+playwright_image = modal.Image.debian_slim(python_version="3.10").run_commands(
     "apt-get update",
     "apt-get install -y software-properties-common",
     "apt-add-repository non-free",
@@ -22,61 +116,164 @@ playwright_image = modal.Image.debian_slim(
 )
 
 
+# Note that we don't have to install Playwright or Chromium on our development
+# machine since this will all run in Modal. We can now modify our `get_links`
+# function to make use of the new tools.
+# We also limit the numbers of links scraped to 10 to avoid rate limits.
+
+
 @app.function(image=playwright_image)
-async def get_links(url: str) -> set[str]:
+async def get_links(cur_url: str) -> set[str]:
     from playwright.async_api import async_playwright
 
     async with async_playwright() as p:
         browser = await p.chromium.launch()
         page = await browser.new_page()
-        await page.goto(url)
-        links = await page.eval_on_selector_all(
-            "a[href]", "elements => elements.map(element => element.href)"
-        )
+        await page.goto(cur_url)
+        links = await page.eval_on_selector_all("a[href]", "elements => elements.map(element => element.href)")
         await browser.close()
 
-    return set(links)
+    limited_links = links[:10]
+    print("Links", limited_links)
+    return set(limited_links)
 
 
-slack_sdk_image = modal.Image.debian_slim(python_version="3.10").pip_install(
-    "slack-sdk==3.27.1"
-)
+# Since Playwright has a nice async interface, we'll redeclare our `get_links`
+# function as async (Modal works with both sync and async functions).
+#
+# The first time you run the function after making this change, you'll notice that
+# the output first shows the progress of building the custom image you specified,
+# after which your function runs like before. This image is then cached so that on
+# subsequent runs of the function it will not be rebuilt as long as the image
+# definition is the same.
+#
+# ## Scaling out
+#
+# So far, our script only fetches the links for a single page. What if we want to
+# scrape a large list of links in parallel?
+#
+# We can do this easily with Modal, because of some magic: the function we wrapped
+# with the `@app.function()` decorator is no longer an ordinary function, but a
+# Modal [Function](https://modal.com/docs/reference/modal.Function) object. This
+# means it comes with a `map` property built in, that lets us run this function
+# for all inputs in parallel, scaling up to as many workers as needed.
+#
+# Let's change our code to scrape all urls we feed to it in parallel:
+#
+# ```python
+# @app.local_entrypoint()
+# def main():
+#     urls = ["http://modal.com", "http://github.com"]
+#     for links in get_links.map(urls):
+#         for link in links:
+#             print(link)
+# ```
+#
+# ## Schedules and deployments
+#
+# Let's say we want to log the scraped links daily. We move the print loop into
+# its own Modal function and annotate it with a `modal.Period(days=1)` schedule -
+# indicating we want to run it once per day. Since the scheduled function will not
+# run from our command line, we also add a hard-coded list of links to crawl for
+# now. In a more realistic setting we could read this from a database or other
+# accessible data source.
+#
+# ```python
+# @app.function(schedule=modal.Period(days=1))
+# def daily_scrape():
+#     urls = ["http://modal.com", "http://github.com"]
+#     for links in get_links.map(urls):
+#         for link in links:
+#             print(link)
+# ```
+#
+# To deploy this as a permanent app, run the command
+#
+# ```
+# modal deploy scrape.py
+# ```
+#
+# Running this command deploys this function and then closes immediately. We can
+# see the deployment and all of its runs, including the printed links, on the
+# Modal [Apps page](https://modal.com/apps). Rerunning the script will redeploy
+# the code with any changes you have made - overwriting an existing deploy with
+# the same name ("link-scraper" in this case).
+#
+# ## Integrations and Secrets
+#
+# Instead of looking at the links in the run logs of our deployments, let's say we
+# wanted to post them to our `#scraped-links` Slack channel. To do this, we can
+# make use of the [Slack API](https://api.slack.com/) and the `slack-sdk`
+# [PyPI package](https://pypi.org/project/slack-sdk/).
+# We also limit the number of links posted to 50 to avoid rate limits.
+#
+# The Slack SDK WebClient requires an API token to get access to our Slack
+# Workspace, and since it's bad practice to hardcode credentials into application
+# code we make use of Modal's **Secrets**. Secrets are snippets of data that will
+# be injected as environment variables in the containers running your functions.
+#
+# The easiest way to create Secrets is to go to the
+# [Secrets section of modal.com](https://modal.com/secrets). You can both create a
+# free-form secret with any environment variables, or make use of presets for
+# common services. We'll use the Slack preset and after filling in the necessary
+# information we are presented with a snippet of code that can be used to post to
+# Slack using our credentials:
+#
+import os
+
+slack_sdk_image = modal.Image.debian_slim(python_version="3.10").pip_install("slack-sdk")
 
 
 @app.function(
     image=slack_sdk_image,
-    secrets=[
-        modal.Secret.from_name(
-            "scraper-slack-secret", required_keys=["SLACK_BOT_TOKEN"]
-        )
-    ],
+    secrets=[modal.Secret.from_name("scraper-slack-secret", required_keys=["SLACK_BOT_TOKEN"])],
 )
 def bot_token_msg(channel, message):
     import slack_sdk
-    from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 
     client = slack_sdk.WebClient(token=os.environ["SLACK_BOT_TOKEN"])
-    rate_limit_handler = RateLimitErrorRetryHandler(max_retry_count=3)
-    client.retry_handlers.append(rate_limit_handler)
-
     print(f"Posting {message} to #{channel}")
     client.chat_postMessage(channel=channel, text=message)
 
 
+# Copy that code as-is, then amend the `daily_scrape` function to call
+# `bot_token_msg`.
+#
+
+
 @app.function()
 def scrape():
-    links_of_interest = ["http://modal.com"]
+    urls = ["http://modal.com", "http://github.com"]
 
-    for links in get_links.map(links_of_interest):
+    for links in get_links.map(urls):
         for link in links:
             bot_token_msg.remote("scraped-links", link)
 
 
 @app.function(schedule=modal.Period(days=1))
 def daily_scrape():
-    scrape.remote()
+    urls = ["http://modal.com", "http://github.com"]
+
+    for links in get_links.map(urls):
+        for link in links:
+            bot_token_msg.remote("scraped-links", link)
 
 
 @app.local_entrypoint()
 def run():
     scrape.remote()
+
+
+# Note that we are freely making function calls across completely different
+# container images, as if they were regular Python functions in the same program.
+#
+# We rerun the script which overwrites the old deploy with our updated code, and
+# now we get a daily feed of our scraped links in our Slack channel 🎉
+#
+# ## Summary
+#
+# We have shown how you can use Modal to develop distributed Python data
+# applications using custom containers. Through simple constructs we were able to
+# add parallel execution. With the change of a single line of code were were able
+# to go from experimental development code to a deployed application. We hope
+# this overview gives you a glimpse of what you are able to build using Modal.

--- a/10_integrations/webscraper_old.py
+++ b/10_integrations/webscraper_old.py
@@ -1,0 +1,82 @@
+# # Web Scraping on Modal
+
+# This example shows how you can scrape links from a website and post them to a Slack channel using Modal.
+
+import os
+
+import modal
+
+app = modal.App("example-webscraper")
+
+
+playwright_image = modal.Image.debian_slim(
+    python_version="3.10"
+).run_commands(  # Doesn't work with 3.11 yet
+    "apt-get update",
+    "apt-get install -y software-properties-common",
+    "apt-add-repository non-free",
+    "apt-add-repository contrib",
+    "pip install playwright==1.42.0",
+    "playwright install-deps chromium",
+    "playwright install chromium",
+)
+
+
+@app.function(image=playwright_image)
+async def get_links(url: str) -> set[str]:
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto(url)
+        links = await page.eval_on_selector_all(
+            "a[href]", "elements => elements.map(element => element.href)"
+        )
+        await browser.close()
+
+    return set(links)
+
+
+slack_sdk_image = modal.Image.debian_slim(python_version="3.10").pip_install(
+    "slack-sdk==3.27.1"
+)
+
+
+@app.function(
+    image=slack_sdk_image,
+    secrets=[
+        modal.Secret.from_name(
+            "scraper-slack-secret", required_keys=["SLACK_BOT_TOKEN"]
+        )
+    ],
+)
+def bot_token_msg(channel, message):
+    import slack_sdk
+    from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
+
+    client = slack_sdk.WebClient(token=os.environ["SLACK_BOT_TOKEN"])
+    rate_limit_handler = RateLimitErrorRetryHandler(max_retry_count=3)
+    client.retry_handlers.append(rate_limit_handler)
+
+    print(f"Posting {message} to #{channel}")
+    client.chat_postMessage(channel=channel, text=message)
+
+
+@app.function()
+def scrape():
+    links_of_interest = ["http://modal.com"]
+
+    for links in get_links.map(links_of_interest):
+        for link in links:
+            bot_token_msg.remote("scraped-links", link)
+
+
+@app.function(schedule=modal.Period(days=1))
+def daily_scrape():
+    scrape.remote()
+
+
+@app.local_entrypoint()
+def run():
+    scrape.remote()


### PR DESCRIPTION
Updating this example file so that it can replace the special-cased `/docs/examples/web-scraper`.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
  
 We expect the Slack SDK to be stable and are willing to fix any issues that arise from the unpinned version.