### PR TITLE
Bump verl to 0.5.0

### DIFF
--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -32,10 +32,10 @@ app = modal.App("example-grpo-verl")
 
 VERL_REPO_PATH: Path = Path("/root/verl")
 image = (
-    modal.Image.from_registry("verlai/verl:app-verl0.4-vllm0.8.5-mcore0.12.1")
+    modal.Image.from_registry("verlai/verl:app-verl0.5-vllm0.10.0-mcore0.13.0-te2.2")
     .apt_install("git")
-    .run_commands(f"git clone https://github.com/volcengine/verl {VERL_REPO_PATH}")
-    .pip_install("verl[vllm]==0.4.1")
+    .run_commands(f"git clone https://github.com/volcengine/verl --branch v0.5.0 {VERL_REPO_PATH}")
+    .pip_install(f"{VERL_REPO_PATH}[vllm]", extra_options="--no-deps")
 )
 
 # ## Defining the dataset


### PR DESCRIPTION
Bumped the verl version to 0.5.0 with its respective docker image. Also, the pip command now builds the local clone (like is done in verl docs) instead of downloading a wheel.

The protobuf installed in the docker image is 5.29.5, which modal does not support, so the image also requires `.pip_install(f"protobuf==4.25.3")`. I thought I would mention it here, along with the stack trace, instead of including it in the commit.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/pkg/modal/__init__.py", line 12, in <module>
    from ._runtime.execution_context import current_function_call_id, current_input_id, interact, is_local
  File "/pkg/modal/_runtime/execution_context.py", line 6, in <module>
    from modal._utils.async_utils import synchronize_api
  File "/pkg/modal/_utils/async_utils.py", line 29, in <module>
    from .logger import logger
  File "/pkg/modal/_utils/logger.py", line 47, in <module>
    configure_logger(logger, log_level, log_format)
  File "/pkg/modal/_utils/logger.py", line 7, in configure_logger
    from modal.config import config
  File "/pkg/modal/config.py", line 94, in <module>
    from modal_proto import api_pb2
  File "/pkg/modal_proto/api_pb2.py", line 16, in <module>
    from modal_proto import options_pb2 as modal__proto_dot_options__pb2
  File "/pkg/modal_proto/options_pb2.py", line 29, in <module>
    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(audit_target_attr)
AttributeError: type object 'FieldOptions' has no attribute 'RegisterExtension'
```

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
