### PR TITLE
Fix trtllm examples

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -89,6 +89,7 @@ tensorrt_image = tensorrt_image.apt_install(
     "tensorrt-llm==0.18.0",
     "pynvml<12",  # avoid breaking change to pynvml version API
     "flashinfer-python==0.2.5",
+    "cuda-python==12.9.1",
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )
@@ -129,6 +130,7 @@ tensorrt_image = tensorrt_image.pip_install(
     {
         "HF_HUB_ENABLE_HF_TRANSFER": "1",
         "HF_HOME": str(MODELS_PATH),
+        "TORCH_CUDA_ARCH_LIST": "9.0 9.0a",  # H100, silence noisy logs
     }
 )
 

--- a/06_gpu_and_ml/llm-serving/trtllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_throughput.py
@@ -64,6 +64,7 @@ tensorrt_image = tensorrt_image.apt_install(
 ).pip_install(
     "tensorrt_llm==0.14.0",
     "pynvml<12",  # avoid breaking change to pynvml version API
+    "cuda-python==12.9.1",
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
 )


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [x] Example updates (Bug fixes)

First reported by a user [here](https://modal-com.slack.com/archives/C069RAH7X4M/p1754789958335489).
Stacktrace:

```
Runner failed with exit code: 1
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in runmodule_as_main
  File "<frozen runpy>", line 88, in runcode
  File "/pkg/modal/_container_entrypoint.py", line 580, in <module>
    main(container_args, client)
  File "/pkg/modal/_container_entrypoint.py", line 468, in main
    obj._hydrate(object_id, _client, metadata)
  File "/pkg/modal/_object.py", line 113, in _hydrate
    self._hydrate_metadata(metadata)
  File "/pkg/modal/image.py", line 436, in hydratemetadata
    raise exc
  File "/pkg/modal/image.py", line 2272, in imports
    yield
  File "/root/latency.py", line 139, in <module>
    from tensorrt_llm import LLM, SamplingParams
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/init.py", line 36, in <module>
    import tensorrt_llm.functional as functional
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/functional.py", line 29, in <module>
    from . import graph_rewriting as gw
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/graph_rewriting.py", line 12, in <module>
    from .network import Network
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/network.py", line 31, in <module>
    from tensorrt_llm.module import Module
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/module.py", line 17, in <module>
    from ._common import default_net
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/_common.py", line 40, in <module>
    from .plugin import loadplugin_lib
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/plugin/init.py", line 15, in <module>
    from .plugin import (TRT_LLM_PLUGIN_NAMESPACE, PluginConfig, loadplugin_lib,
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/plugin/plugin.py", line 28, in <module>
    from .._ipc_utils import IpcMemory, can_access_peer
  File "/usr/local/lib/python3.12/site-packages/tensorrt_llm/_ipc_utils.py", line 20, in <module>
    from cuda import cuda, cudart
ImportError: cannot import name 'cuda' from 'cuda' (unknown location)
```

Looks similar to [this cuda-python issue](https://github.com/NVIDIA/cuda-python/issues/476). I suspect that the `cuda-python` version was out of sync with the underlying image - it was failing when it was 13.0.0. Resolved by pinning its version to 12.9.1