### PR TITLE
Fix verifiers by using uv pip install

### DIFF
--- a/06_gpu_and_ml/reinforcement-learning/learn_math.py
+++ b/06_gpu_and_ml/reinforcement-learning/learn_math.py
@@ -34,7 +34,7 @@ flash_attn_release = (
 image = (
     modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.11")
     .apt_install("git", "clang")
-    .pip_install(
+    .uv_pip_install(
         "huggingface_hub[hf_transfer]==0.33.5",
         "setuptools==69.0.3",
         "wheel==0.45.1",


### PR DESCRIPTION
Was getting a `pip._vendor.packaging.requirements.InvalidRequirement: Parse error at "'(>=0.24.'": Expected string_end` error (see run [here](https://github.com/modal-labs/modal-examples/actions/runs/17024473802)) which could be solved by upgrading pip however used uv_pip_install instead to fix this + speed up the installation. **No other changes.**

## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)

You're great! Thanks for your contribution.