### PR TITLE
Add error handling for test case gen

### DIFF
--- a/13_sandboxes/test_case_generator.py
+++ b/13_sandboxes/test_case_generator.py
@@ -152,8 +152,12 @@ class TestCaseClient:
             },
         )
         output = response.choices[0].message.content
-        output_contents = json.loads(output)["file_contents"]
-        return self.write_outputs(f"test_{file_name}", output_contents)
+        try:
+            output_contents = json.loads(output)["file_contents"]
+            return self.write_outputs(f"test_{file_name}", output_contents)
+        except Exception as e:
+            print(f"Error generating test file: {e}")
+            return None
 
 
 @app.function(


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

Test case generator example was being [flaky](https://modal-com.slack.com/archives/C044YUDC1QU/p1756857683821389). Further [inspection](https://github.com/user-attachments/files/22124146/output.txt) showed that the following line was throwing a JSONDecodeError ~25-50% of the time.

```python
output_contents = json.loads(output)["file_contents"]                                                                                                                                                                                                                               
```

This is due to the underlying model not outputting valid JSON, on occasion. Not ideal of course, but adding a try-catch. Could also catch the JSONDecodeError instead, but I'd also like to catch any errors where the JSON is valid but the expected `file_contents` key is not outputted. And any other LLM nonsense.
