### PR TITLE
wip replace model in vLLM inference example with a recent and more popular LLM

### DIFF
--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -42,7 +42,7 @@ default_args = [
     "--processes",
     str(workers),
     "--csv",
-    csv_file,
+    str(csv_file),
 ]
 
 MINUTES = 60  # seconds

--- a/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
@@ -25,7 +25,7 @@ class WebsiteUser(locust.HttpUser):
     @locust.task
     def chat_completion(self):
         payload = {
-            "model": "Qwen/Qwen3-8B",
+            "model": "Qwen/Qwen3-8B-FP8",
             "messages": messages,
         }
 

--- a/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/locustfile.py
@@ -25,7 +25,7 @@ class WebsiteUser(locust.HttpUser):
     @locust.task
     def chat_completion(self):
         payload = {
-            "model": "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16",
+            "model": "Qwen/Qwen3-8B",
             "messages": messages,
         }
 

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -49,9 +49,20 @@ vllm_image = (
 # it is trained with thinking capabilities. This means the model will
 # use its reasoning abilities to enhance the quality of generated responses.
 
+# Model parameters are often quantized to a lower precision during training
+# than they are run at during inference.
+# We'll use an eight bit floating point quantization.
+# Native hardware support for FP8 formats in [Tensor Cores](https://modal.com/gpu-glossary/device-hardware/tensor-core)
+# is limited to the latest [Streaming Multiprocessor architectures](https://modal.com/gpu-glossary/device-hardware/streaming-multiprocessor-architecture),
+# like those of Modal's [Hopper H100/H200 and Blackwell B200 GPUs](https://modal.com/blog/announcing-h200-b200).
 
-MODEL_NAME = "Qwen/Qwen3-8B"
-MODEL_REVISION = "b968826d9c46dd6066d109eabc6255188de91218"  # avoid nasty surprises when repos update!
+# You can swap this model out for another by changing the strings below.
+# A single H100 GPU has enough VRAM to store a 8,000,000 parameter model,
+# like Qwen3-8B, in eight bit precision, along with a very large KV cache.
+
+
+MODEL_NAME = "Qwen/Qwen3-8B-FP8"
+MODEL_REVISION = "220b46e3b2180893580a4454f21f22d3ebb187d3"  # avoid nasty surprises when repos update!
 
 # Although vLLM will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.
@@ -101,7 +112,7 @@ VLLM_PORT = 8000
 
 @app.function(
     image=vllm_image,
-    gpu=f"A100:{N_GPU}",
+    gpu=f"H100:{N_GPU}",
     scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
     timeout=10 * MINUTES,  # how long should we wait for container start?
     volumes={

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -35,10 +35,10 @@ import modal
 vllm_image = (
     modal.Image.from_registry("nvidia/cuda:12.8.0-devel-ubuntu22.04", add_python="3.12")
     .uv_pip_install(
-        "vllm==0.10.1.1",
-        "huggingface_hub[hf_transfer]==0.34.4",
+        "vllm==0.10.2",
+        "huggingface_hub[hf_transfer]==0.35.0",
         "flashinfer-python==0.2.8",
-        "torch==2.7.1",
+        "torch==2.8.0",
     )
     .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})  # faster model transfers
 )
@@ -59,8 +59,8 @@ vllm_image = (
 # A single H100 GPU has enough VRAM to store a 8,000,000 parameter model,
 # like Llama 3.1, in eight bit precision, along with a very large KV cache.
 
-MODEL_NAME = "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8"
-MODEL_REVISION = "12fd6884d2585dd4d020373e7f39f74507b31866"  # avoid nasty surprises when repos update!
+MODEL_NAME = "Qwen/Qwen3-4B-Thinking-2507-FP8"
+MODEL_REVISION = "953532f942706930ec4bb870569932ef63038fdf"  # avoid nasty surprises when repos update!
 
 # Although vLLM will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.
@@ -128,7 +128,7 @@ VLLM_PORT = 8000
 
 @app.function(
     image=vllm_image,
-    gpu=f"H100:{N_GPU}",
+    gpu=f"L40S:{N_GPU}",
     scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
     timeout=10 * MINUTES,  # how long should we wait for container start?
     volumes={
@@ -157,6 +157,8 @@ def serve():
         "0.0.0.0",
         "--port",
         str(VLLM_PORT),
+        "--gpu_memory_utilization",
+        "0.95",
     ]
 
     # enforce-eager disables both Torch compilation and CUDA graph capture

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -49,19 +49,9 @@ vllm_image = (
 # it is trained with thinking capabilities. This means the model will
 # use its reasoning abilities to enhance the quality of generated responses.
 
-# Model parameters are often quantized to a lower precision during training
-# than they are run at during inference.
-# We'll use an eight bit floating point quantization.
-# Native hardware support for FP8 formats in [Tensor Cores](https://modal.com/gpu-glossary/device-hardware/tensor-core)
-# is limited to the latest [Streaming Multiprocessor architectures](https://modal.com/gpu-glossary/device-hardware/streaming-multiprocessor-architecture),
-# like those of Modal's [Hopper H100/H200 and Blackwell B200 GPUs](https://modal.com/blog/announcing-h200-b200).
 
-# You can swap this model out for another by changing the strings below.
-# A single H100 GPU has enough VRAM to store a 8,000,000 parameter model,
-# like Qwen3-8B, in eight bit precision, along with a very large KV cache.
-
-MODEL_NAME = "Qwen/Qwen3-8B-FP8"
-MODEL_REVISION = "220b46e3b2180893580a4454f21f22d3ebb187d3"  # avoid nasty surprises when repos update!
+MODEL_NAME = "Qwen/Qwen3-8B"
+MODEL_REVISION = "b968826d9c46dd6066d109eabc6255188de91218"  # avoid nasty surprises when repos update!
 
 # Although vLLM will download weights from Hugging Face on-demand,
 # we want to cache them so we don't do it every time our server starts.


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->
This PR replaces Llama 3.1 with Qwen3 LLM in the vLLM inference example. 

`Qwen/Qwen3-8B-FP8` supports reasoning and provides decent throughput on L40S (a GPU class cheaper than H100s). 

<img width="1567" height="505" alt="image" src="https://github.com/user-attachments/assets/e0202612-9ec9-46fa-9121-84d1dfb2287b" />


## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
