### PR TITLE
Fix preview docs CI: change working dir for requirements install

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -36,7 +36,8 @@ jobs:
 
       - name: Install modal development packages
         run: |
-          uv pip install --system -r modal/requirements.dev.txt
+          uv pip install --system -r requirements.dev.txt
+        working-directory: modal
 
       - name: Install client
         run: |


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->
Context [here](https://modal-com.slack.com/archives/C044YUDC1QU/p1758553167055189). Failing run [here](https://github.com/modal-labs/modal-examples/actions/runs/17919363945). Working run [here](https://github.com/modal-labs/modal-examples/actions/runs/17919646099)

Afer the `-e modal_apps/docker_in_modal_tests` was added to `requirements.dev.txt` in the base modal repo, the working directory of the install is now relevant. Changed the CI command to enable this.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [x] Other (Changes to the codebase, but not to examples)
