### PR TITLE
datalab's marker model example

### DIFF
--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -13,7 +13,7 @@
 
 # Our job queue will handle a single task: running OCR transcription for images of receipts.
 # We'll use [Marker](https://github.com/datalab-to/marker) from [Datalab](https://www.datalab.to)
-# which can convert documents to markdown, JSON and HTML.
+# which can convert documents to Markdown, JSON and HTML.
 
 # Try it out for yourself [here](https://modal-labs-examples--example-doc-ocr-webapp-wrapper.modal.run/).
 
@@ -48,8 +48,11 @@ inference_image = (
 
 # ## Cache the pre-trained model on a Modal Volume
 
+# We can obtain the pre-trained model we want to run from Datalab
+# using the Marker library.
+
 # The logic for loading the model based on this information
-# is encapsulated in the `setup` function below.
+# is defined in the `setup` function below.
 
 def setup():
     from marker.models import create_model_dict
@@ -133,6 +136,8 @@ def parse_receipt(
             llm_service=config_parser.get_llm_service() if use_llm else None,
         )
         rendered_output = converter(temp_path.name)
+        metadata = rendered_output.metadata
+
         # Extract content based on output format
         json_content = None
         html_content = None
@@ -149,8 +154,6 @@ def parse_receipt(
                 html_content = text
             else:
                 markdown_content = text
-
-            metadata = rendered_output.metadata
 
         return {
             "success": True,

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -103,7 +103,6 @@ def parse_receipt(
     use_llm: Optional[bool] = False,
 ) -> dict:
     from tempfile import NamedTemporaryFile
-    import warnings
     from marker.converters.pdf import PdfConverter
     from marker.config.parser import ConfigParser
     from marker.settings import settings
@@ -219,3 +218,15 @@ def main(receipt_filename: Optional[str] = None):
             image = response.read()
         print(f"running OCR on sample from URL {receipt_url}")
     print(parse_receipt.remote(image))
+
+if __name__ == "__main__":
+    import urllib.request
+    from pathlib import Path
+
+    fn = modal.Function.from_name("example-doc-ocr-jobs", "parse_receipt")
+    receipt_url = "https://modal-cdn.com/cdnbot/Brandys-walmart-receipt-8g68_a_hk_f9c25fce.webp"
+    request = urllib.request.Request(receipt_url)
+    with urllib.request.urlopen(request) as response:
+        image = response.read()
+
+    print(fn.remote(image))

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -137,7 +137,6 @@ def parse_receipt(
         json_content = None
         html_content = None
         markdown_content = None
-        encoded_images = {}
 
         if output_format == "json":
             # For JSON, return the structured data directly

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -51,22 +51,8 @@ inference_image = (
 
 # ## Cache the pre-trained model on a Modal Volume
 
-# We can obtain the pre-trained model we want to run from Hugging Face
-# using its name and a revision identifier.
-
-MODEL_NAME = "ucaslcl/GOT-OCR2_0"
-MODEL_REVISION = "cf6b7386bc89a54f09785612ba74cb12de6fa17c"
-
-
 # The logic for loading the model based on this information
 # is encapsulated in the `setup` function below.
-
-
-def setup():
-    from marker.models import create_model_dict
-
-    model = create_model_dict()
-    return model
 
 
 # The `.from_pretrained` methods from Hugging Face are smart enough
@@ -116,11 +102,12 @@ with inference_image.imports():
     from marker.config.parser import ConfigParser
     from marker.settings import settings
     from marker.output import text_from_rendered
+    from marker.models import create_model_dict
 
 @app.cls(
     gpu="l40s",
     retries=3,
-    volumes={MODEL_CACHE_PATH: model_cache, MODEL_PATH_PREFIX: markers_cache},
+    # volumes={MODEL_CACHE_PATH: model_cache, MODEL_PATH_PREFIX: markers_cache},
     image=inference_image,
     enable_memory_snapshot=True,
     experimental_options={"enable_gpu_snapshot": True},
@@ -128,7 +115,8 @@ with inference_image.imports():
 class MarkerModelCls:
     @modal.enter(snap=True)
     def load(self):
-        self.models = setup()
+
+        self.models = create_model_dict()
 
     @modal.method()
     def parse_receipt(

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -12,8 +12,8 @@
 # application (for example, a regular Django app running on Kubernetes).
 
 # Our job queue will handle a single task: running OCR transcription for images of receipts.
-# We'll make use of a pre-trained model:
-# the [General OCR Theory (GOT) 2.0 model](https://huggingface.co/stepfun-ai/GOT-OCR2_0).
+# We'll use [Marker](https://github.com/datalab-to/marker) from [Datalab](https://www.datalab.to)
+# which can convert documents to markdown, JSON and HTML.
 
 # Try it out for yourself [here](https://modal-labs-examples--example-doc-ocr-webapp-wrapper.modal.run/).
 
@@ -40,11 +40,8 @@ inference_image = (
     .env({"TORCH_DEVICE": "cuda"})
     .pip_install(
         [
-            "marker-pdf[full]",
-            "fastapi==0.104.1",
-            "uvicorn==0.24.0",
-            "python-multipart==0.0.6",
-            "torch>=2.2.2,<3.0.0",
+            "marker-pdf[full]==1.9.3",
+            "torch==2.8.0",
         ]
     )
 )
@@ -54,9 +51,14 @@ inference_image = (
 # The logic for loading the model based on this information
 # is encapsulated in the `setup` function below.
 
+def setup():
+    from marker.models import create_model_dict
 
-# The `.from_pretrained` methods from Hugging Face are smart enough
-# to only download models if they haven't been downloaded before.
+    return create_model_dict()
+
+
+# The `create_model_dict` function downloads the model weights from Datalab's
+# cloud storage (S3 bucket) if it hasn't been downloaded before.
 # But in Modal's serverless environment, filesystems are ephemeral,
 # and so using this code alone would mean that models need to get downloaded
 # on every request.
@@ -64,21 +66,10 @@ inference_image = (
 # So instead, we create a Modal [Volume](https://modal.com/docs/guide/volumes)
 # to store the model -- a durable filesystem that any Modal Function can access.
 
-model_cache = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 MODEL_PATH_PREFIX = "/root/.cache/datalab/models"
 markers_cache = modal.Volume.from_name(
     "marker-models-modal-demo", create_if_missing=True
 )
-
-# We also update the environment variables for our Function
-# to include this new path for the model cache --
-# and to enable fast downloads with the `hf_transfer` library.
-
-MODEL_CACHE_PATH = "/root/models"
-inference_image = inference_image.env(
-    {"HF_HUB_CACHE": MODEL_CACHE_PATH, "HF_HUB_ENABLE_HF_TRANSFER": "1"}
-)
-
 
 # ## Run OCR inference on Modal by wrapping with `app.function`
 
@@ -94,9 +85,20 @@ inference_image = inference_image.env(
 # and have access to our [shared model cache](https://modal.com/docs/guide/volumes).
 
 
-with inference_image.imports():
-    import base64
-    import io
+@app.function(
+    gpu="l40s",
+    retries=3,
+    volumes={MODEL_PATH_PREFIX: markers_cache},
+    image=inference_image,
+)
+def parse_receipt(
+    image: bytes,
+    page_range: Optional[str] = None,
+    force_ocr: Optional[bool] = False,
+    paginate_output: bool = False,
+    output_format: str = "markdown",
+    use_llm: Optional[bool] = False,
+) -> dict:
     from tempfile import NamedTemporaryFile
     from marker.converters.pdf import PdfConverter
     from marker.config.parser import ConfigParser
@@ -104,92 +106,62 @@ with inference_image.imports():
     from marker.output import text_from_rendered
     from marker.models import create_model_dict
 
-@app.cls(
-    gpu="l40s",
-    retries=3,
-    # volumes={MODEL_CACHE_PATH: model_cache, MODEL_PATH_PREFIX: markers_cache},
-    image=inference_image,
-    enable_memory_snapshot=True,
-    experimental_options={"enable_gpu_snapshot": True},
-)
-class MarkerModelCls:
-    @modal.enter(snap=True)
-    def load(self):
+    models = setup()
 
-        self.models = create_model_dict()
+    with NamedTemporaryFile(delete=False, mode="wb+") as temp_path:
+        temp_path.write(image)
+        # Configure conversion parameters
+        config = {
+            "filepath": temp_path,
+            "page_range": page_range,
+            "force_ocr": force_ocr,
+            "paginate_output": paginate_output,
+            "output_format": output_format,
+            "use_llm": use_llm,
+        }
 
-    @modal.method()
-    def parse_receipt(
-            self,
-            image: bytes,
-            page_range: Optional[str] = None,
-            force_ocr: Optional[bool] = False,
-            paginate_output: bool = False,
-            output_format: str = "markdown",
-            use_llm: Optional[bool] = False,
-    ) -> dict:
-        with NamedTemporaryFile(delete=False, mode="wb+") as temp_path:
-            temp_path.write(image)
-            # Configure conversion parameters
-            config = {
-                "filepath": temp_path,
-                "page_range": page_range,
-                "force_ocr": force_ocr,
-                "paginate_output": paginate_output,
-                "output_format": output_format,
-                "use_llm": use_llm,
-            }
+        # Create converter
+        config_parser = ConfigParser(config)
+        config_dict = config_parser.generate_config_dict()
+        config_dict["pdftext_workers"] = 1
 
-            # Create converter
-            config_parser = ConfigParser(config)
-            config_dict = config_parser.generate_config_dict()
-            config_dict["pdftext_workers"] = 1
+        converter = PdfConverter(
+            config=config_dict,
+            artifact_dict=models,
+            processor_list=config_parser.get_processors(),
+            renderer=config_parser.get_renderer(),
+            llm_service=config_parser.get_llm_service() if use_llm else None,
+        )
+        rendered_output = converter(temp_path.name)
+        # Extract content based on output format
+        json_content = None
+        html_content = None
+        markdown_content = None
+        encoded_images = {}
 
-            converter = PdfConverter(
-                config=config_dict,
-                artifact_dict=self.models,
-                processor_list=config_parser.get_processors(),
-                renderer=config_parser.get_renderer(),
-                llm_service=config_parser.get_llm_service() if use_llm else None,
-            )
-            rendered_output = converter(temp_path.name)
-            # Extract content based on output format
-            json_content = None
-            html_content = None
-            markdown_content = None
-            encoded_images = {}
+        if output_format == "json":
+            # For JSON, return the structured data directly
+            json_content = rendered_output.model_dump()
+        else:
+            text, _, images = text_from_rendered(rendered_output)
 
-            if output_format == "json":
-                # For JSON, return the structured data directly
-                json_content = rendered_output.model_dump()
+            # Assign to appropriate content field
+            if output_format == "html":
+                html_content = text
             else:
-                text, _, images = text_from_rendered(rendered_output)
+                markdown_content = text
 
-                # Assign to appropriate content field
-                if output_format == "html":
-                    html_content = text
-                else:
-                    markdown_content = text
+            metadata = rendered_output.metadata
 
-                # Encode images as base64
-                for img_name, img_obj in images.items():
-                    byte_stream = io.BytesIO()
-                    img_obj.save(byte_stream, format=settings.OUTPUT_IMAGE_FORMAT)
-                    encoded_images[img_name] = base64.b64encode(
-                        byte_stream.getvalue()
-                    ).decode("utf-8")
-
-                metadata = rendered_output.metadata
-
-            return {
-                "success": True,
-                "output_format": output_format,
-                "json": json_content,
-                "html": html_content,
-                "markdown": markdown_content,
-                "metadata": metadata,
-                "page_count": len(metadata.get("page_stats", [])),
-            }
+        return {
+            "success": True,
+            "output_format": output_format,
+            "json": json_content,
+            "html": html_content,
+            "markdown": markdown_content,
+            "metadata": metadata,
+            "page_count": len(metadata.get("page_stats", [])),
+        }
 
 
 # ## Deploy
@@ -253,21 +225,4 @@ def _get_image(
 @app.local_entrypoint()
 def main(receipt_filename: Optional[str] = None):
     image_data = _get_image(receipt_filename)
-    MarkerModelCls = modal.Cls.from_name(app_name, "MarkerModelCls")
-    marker_model = MarkerModelCls()
-    print(marker_model.parse_receipt.remote(image_data))
-
-
-if __name__ == "__main__":
-    from rich import print
-
-    image_data = _get_image()
-    MarkerModelCls = modal.Cls.from_name(app_name, "MarkerModelCls")
-    marker_model = MarkerModelCls()
-    try:
-        result = marker_model.parse_receipt.remote(image_data, paginate_output=True, output_format="html", use_llm=False)
-        print(result)
-    except modal.exception.NotFoundError:
-        raise Exception(
-            f"To take advantage of GPU snapshots, deploy first with modal deploy {__file__}"
-        )
+    print(parse_receipt.remote(image_data))

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -103,19 +103,12 @@ def parse_receipt(
     use_llm: Optional[bool] = False,
 ) -> dict:
     from tempfile import NamedTemporaryFile
-    import warnings
     from marker.converters.pdf import PdfConverter
     from marker.config.parser import ConfigParser
     from marker.settings import settings
     from marker.output import text_from_rendered
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="`torch_dtype` is deprecated! Use `dtype` instead!",
-            category=UserWarning,
-        )
-        models = setup()
+    models = setup()
     with NamedTemporaryFile(delete=False, mode="wb+") as temp_path:
         temp_path.write(image)
         # Configure conversion parameters

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -217,15 +217,3 @@ def main(receipt_filename: Optional[str] = None):
             image = response.read()
         print(f"running OCR on sample from URL {receipt_url}")
     print(parse_receipt.remote(image))
-
-if __name__ == "__main__":
-    import urllib.request
-    from pathlib import Path
-
-    fn = modal.Function.from_name("example-doc-ocr-jobs", "parse_receipt")
-    receipt_url = "https://modal-cdn.com/cdnbot/Brandys-walmart-receipt-8g68_a_hk_f9c25fce.webp"
-    request = urllib.request.Request(receipt_url)
-    with urllib.request.urlopen(request) as response:
-        image = response.read()
-
-    print(fn.remote(image))

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -2,6 +2,7 @@
 # deploy: true
 # mypy: ignore-errors
 # ---
+
 # # Run a job queue for Datalab's Document Information Extraction
 
 # This tutorial shows you how to use Modal as an infinitely scalable job queue
@@ -12,8 +13,8 @@
 # application (for example, a regular Django app running on Kubernetes).
 
 # Our job queue will handle a single task: running OCR transcription for images of receipts.
-# We'll use [Marker](https://github.com/datalab-to/marker) from [Datalab](https://www.datalab.to)
-# which can convert documents to Markdown, JSON and HTML.
+# We'll use [Marker](https://github.com/datalab-to/marker) from [Datalab](https://www.datalab.to),
+# which can convert documents to Markdown, JSON, and HTML.
 
 # Try it out for yourself [here](https://modal-labs-examples--example-doc-ocr-webapp-wrapper.modal.run/).
 
@@ -28,8 +29,7 @@ from typing import Optional
 
 import modal
 
-app_name = "example-doc-ocr-jobs"
-app = modal.App(app_name)
+app = modal.App("example-doc-ocr-jobs")
 
 # We also define the dependencies for our Function by specifying an
 # [Image](https://modal.com/docs/guide/images).
@@ -49,9 +49,9 @@ inference_image = (
 # ## Cache the pre-trained model on a Modal Volume
 
 # We can obtain the pre-trained model we want to run from Datalab
-# using the Marker library.
+# by using the Marker library.
 
-# The logic for loading the model based on this information
+# The logic for loading the model with this information
 # is defined in the `setup` function below.
 
 def setup():
@@ -61,9 +61,9 @@ def setup():
 
 
 # The `create_model_dict` function downloads the model weights from Datalab's
-# cloud storage (S3 bucket) if it hasn't been downloaded before.
-# But in Modal's serverless environment, filesystems are ephemeral,
-# and so using this code alone would mean that models need to get downloaded
+# cloud storage (S3 bucket) if they haven't been downloaded before.
+# However, in Modal's serverless environment, filesystems are ephemeral,
+# so using this code alone would mean that models need to get downloaded
 # on every request.
 
 # So instead, we create a Modal [Volume](https://modal.com/docs/guide/volumes)
@@ -103,13 +103,19 @@ def parse_receipt(
     use_llm: Optional[bool] = False,
 ) -> dict:
     from tempfile import NamedTemporaryFile
+    import warnings
     from marker.converters.pdf import PdfConverter
     from marker.config.parser import ConfigParser
     from marker.settings import settings
     from marker.output import text_from_rendered
-    from marker.models import create_model_dict
 
-    models = setup()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="`torch_dtype` is deprecated! Use `dtype` instead!",
+            category=UserWarning,
+        )
+        models = setup()
     with NamedTemporaryFile(delete=False, mode="wb+") as temp_path:
         temp_path.write(image)
         # Configure conversion parameters

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -108,6 +108,15 @@ inference_image = inference_image.env(
 # and have access to our [shared model cache](https://modal.com/docs/guide/volumes).
 
 
+with inference_image.imports():
+    import base64
+    import io
+    from tempfile import NamedTemporaryFile
+    from marker.converters.pdf import PdfConverter
+    from marker.config.parser import ConfigParser
+    from marker.settings import settings
+    from marker.output import text_from_rendered
+
 @app.cls(
     gpu="l40s",
     retries=3,
@@ -131,14 +140,6 @@ class MarkerModelCls:
             output_format: str = "markdown",
             use_llm: Optional[bool] = False,
     ) -> dict:
-        import base64
-        import io, json
-        from tempfile import NamedTemporaryFile
-        from marker.converters.pdf import PdfConverter
-        from marker.config.parser import ConfigParser
-        from marker.settings import settings
-        from marker.output import text_from_rendered
-
         with NamedTemporaryFile(delete=False, mode="wb+") as temp_path:
             temp_path.write(image)
             # Configure conversion parameters

--- a/09_job_queues/doc_ocr_jobs.py
+++ b/09_job_queues/doc_ocr_jobs.py
@@ -263,7 +263,7 @@ def _get_image(
 
 @app.local_entrypoint()
 def main(receipt_filename: Optional[str] = None):
-    image_data = _get_image()
+    image_data = _get_image(receipt_filename)
     MarkerModelCls = modal.Cls.from_name(app_name, "MarkerModelCls")
     marker_model = MarkerModelCls()
     print(marker_model.parse_receipt.remote(image_data))

--- a/13_sandboxes/test_case_generator.py
+++ b/13_sandboxes/test_case_generator.py
@@ -152,8 +152,12 @@ class TestCaseClient:
             },
         )
         output = response.choices[0].message.content
-        output_contents = json.loads(output)["file_contents"]
-        return self.write_outputs(f"test_{file_name}", output_contents)
+        try:
+            output_contents = json.loads(output)["file_contents"]
+            return self.write_outputs(f"test_{file_name}", output_contents)
+        except Exception as e:
+            print(f"Error generating test file: {e}")
+            return None
 
 
 @app.function(


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

This PR updates the existing OCR model (now quite outdated) to Datalab's Surya OCR–based models with the [Marker](https://github.com/datalab-to/marker) library.

Most of the code remains the same, except for the model loading and prediction parts. 

**~WIP~**
- [x] Clean up old code
- [x] Update docs


## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
