### PR TITLE
Limit `max_inputs` concurrency to 20 in Sandbox pool example

### DIFF
--- a/13_sandboxes/sandbox_pool.py
+++ b/13_sandboxes/sandbox_pool.py
@@ -135,7 +135,7 @@ def is_still_good(sr: SandboxReference, check_health: bool) -> bool:
 # We deploy the Sandboxes in a separate Modal App called `example-sandbox-pool-sandboxes`,
 # to separate the control app (logs, etc.) from the Sandboxes.
 @app.function(image=server_image, retries=3)
-@modal.concurrent(max_inputs=100)
+@modal.concurrent(max_inputs=20)
 def add_sandbox_to_queue() -> None:
     sandbox_app = modal.App.lookup(
         "example-sandbox-pool-sandboxes", create_if_missing=True
@@ -192,7 +192,7 @@ def terminate_sandboxes(sandbox_ids: list[str]) -> int:
 # [3]: https://modal.com/docs/guide/webhook-urls
 @app.function(image=server_image)
 @modal.fastapi_endpoint()
-@modal.concurrent(max_inputs=100)
+@modal.concurrent(max_inputs=20)
 def claim_sandbox_web_endpoint(check_health: bool = True) -> str:
     return claim_sandbox.local(check_health=check_health)
 


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)
