### PR TITLE
restrict accepted encodings

### DIFF
--- a/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
+++ b/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
@@ -57,7 +57,6 @@ TORCH_CUDA_ARCH_LIST = "9.0 9.0a"  # Hopper, aka H100/H200
 toka_image = toka_image.env(
     {"HF_HUB_ENABLE_HF_TRANSFER": "1", "TORCH_CUDA_ARCH_LIST": TORCH_CUDA_ARCH_LIST}
 ).uv_pip_install(
-    "aiohttp==3.13.0",
     "tokasaurus==0.0.2",
     "huggingface_hub[hf_transfer]==0.33.0",
     "datasets==3.6.0",


### PR DESCRIPTION
zstd compression was [recently added to aiohttp](https://docs.aiohttp.org/en/stable/changes.html), in version 3.13.0 on 2025-10-06. The next day, we started picking up failures in this example in our synthetic monitoring system with the following error message:

```
ClientPayloadError: 400, message: Can not decode content-encoding: zstd
```

It appears that in some environments, installing aiohttp 3.13.0 does not also install dependencies for zstd decompression (and it's not in the stdlib before 3.14).

This seems like an aiohttp bug. But it's not worth investigating further, since we can work around it here by explicitly opting out of zstd as an encoding.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)