### PR TITLE
reduce max inputs

### DIFF
--- a/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
+++ b/06_gpu_and_ml/dreambooth/diffusers_lora_finetune.py
@@ -425,7 +425,7 @@ web_image = image.add_local_dir(
     image=web_image,
     max_containers=1,
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def fastapi_app():
     import gradio as gr

--- a/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
+++ b/06_gpu_and_ml/hyperparameter-sweep/hp_sweep_gpt.py
@@ -397,7 +397,7 @@ class VolumeMiddleware:
     image=torch_image,
     volumes={volume_path: volume},
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.wsgi_app()
 def monitor_training():
     board = tensorboard.program.TensorBoard()
@@ -576,7 +576,7 @@ def web_generate(request: GenerationRequest):
     max_containers=1,
     volumes={volume_path: volume},
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def ui():
     import gradio as gr

--- a/06_gpu_and_ml/image-to-video/image_to_video.py
+++ b/06_gpu_and_ml/image-to-video/image_to_video.py
@@ -309,7 +309,7 @@ web_image = (
 
 
 @app.function(image=web_image)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def ui():
     import fastapi.staticfiles

--- a/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
+++ b/06_gpu_and_ml/llm-serving/chat_with_pdf_vision.py
@@ -410,7 +410,7 @@ web_image = pdf_image.pip_install(
     # and allow it to scale to 1000 concurrent inputs
     max_containers=1,
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def ui():
     import uuid

--- a/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
+++ b/06_gpu_and_ml/llm-serving/openai_compatible/load_test.py
@@ -49,7 +49,7 @@ MINUTES = 60  # seconds
 
 
 @app.function(cpu=workers)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.web_server(port=8089)
 def serve():
     run_locust.local(default_args)

--- a/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
+++ b/06_gpu_and_ml/llm-serving/tokasaurus_throughput.py
@@ -155,7 +155,7 @@ PORT = 10210
     volumes=volumes,
     secrets=secrets,
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.web_server(port=PORT, startup_timeout=10 * MINUTES)
 def serve():
     import subprocess

--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/main.py
@@ -142,7 +142,7 @@ def populate_podcast_metadata(podcast_id: str):
     ),
     volumes={config.CACHE_DIR: volume},
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def fastapi_app():
     import fastapi.staticfiles

--- a/06_gpu_and_ml/protein-folding/esm3.py
+++ b/06_gpu_and_ml/protein-folding/esm3.py
@@ -223,7 +223,7 @@ def run_esm(sequence: str) -> str:
     volumes={VOLUME_PATH: volume},
     max_containers=1,  # Gradio requires sticky sessions
 )
-@modal.concurrent(max_inputs=1000)  # Gradio can handle many async inputs
+@modal.concurrent(max_inputs=100)  # Gradio can handle many async inputs
 @modal.asgi_app()
 def ui():
     import gradio as gr

--- a/06_gpu_and_ml/speech-to-text/streaming_kyutai_stt.py
+++ b/06_gpu_and_ml/speech-to-text/streaming_kyutai_stt.py
@@ -425,7 +425,7 @@ web_image = (
 
 
 @app.function(image=web_image, timeout=10 * MINUTES)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def ui():
     import fasthtml.common as fh

--- a/06_gpu_and_ml/speech-to-text/streaming_parakeet.py
+++ b/06_gpu_and_ml/speech-to-text/streaming_parakeet.py
@@ -225,7 +225,7 @@ class ParakeetModel:
 
 
 @app.cls(image=image)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 class WebServer:
     @modal.asgi_app()
     def web(self):

--- a/06_gpu_and_ml/stable_diffusion/text_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/text_to_image.py
@@ -235,7 +235,7 @@ web_image = (
 
 
 @app.function(image=web_image)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def ui():
     import fastapi.staticfiles

--- a/06_gpu_and_ml/text-to-audio/generate_music.py
+++ b/06_gpu_and_ml/text-to-audio/generate_music.py
@@ -226,7 +226,7 @@ def slugify(string):
     # and allow it to scale to 1000 concurrent inputs
     max_containers=1,
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def ui():
     import gradio as gr

--- a/07_web_endpoints/discord_bot.py
+++ b/07_web_endpoints/discord_bot.py
@@ -59,7 +59,7 @@ app = modal.App("example-discord-bot", image=image)
 
 
 @app.function()
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 async def fetch_api() -> str:
     import aiohttp
 
@@ -132,7 +132,7 @@ async def send_to_discord(payload: dict, app_id: str, interaction_token: str):
 
 
 @app.function()
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 async def reply(app_id: str, interaction_token: str):
     message = await fetch_api.local()
     await send_to_discord({"content": message}, app_id, interaction_token)
@@ -263,7 +263,7 @@ def create_slash_command(force: bool = False):
 
 
 @app.function(secrets=[discord_secret], min_containers=1)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def web_app():
     from fastapi import FastAPI, HTTPException, Request

--- a/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
+++ b/07_web_endpoints/fasthtml-checkboxes/cbx_load_test.py
@@ -47,7 +47,7 @@ MINUTES = 60  # seconds
 
 
 @app.function(cpu=workers)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.web_server(port=8089)
 def serve():
     run_locust.local(default_args)

--- a/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
+++ b/07_web_endpoints/fasthtml-checkboxes/fasthtml_checkboxes.py
@@ -39,7 +39,7 @@ css_path_remote = "/assets/styles.css"
     .add_local_file(css_path_local, remote_path=css_path_remote),
     max_containers=1,  # we currently maintain state in memory, so we restrict the server to one worker
 )
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def web():
     import fasthtml.common as fh

--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -109,7 +109,7 @@ image = image.add_local_dir(local_assets_path, remote_path="/assets")
 
 
 @app.function(image=image)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 @modal.asgi_app()
 def wrapper():
     web_app.mount("/", fastapi.staticfiles.StaticFiles(directory="/assets", html=True))

--- a/misc/xgboost_optuna_search.py
+++ b/misc/xgboost_optuna_search.py
@@ -133,7 +133,7 @@ if TYPE_CHECKING:
 
 
 @app.cls(cpu=2, memory=2048, volumes={"/data": volume}, max_containers=1)
-@modal.concurrent(max_inputs=1000)
+@modal.concurrent(max_inputs=100)
 class OptunaHead:
     @modal.enter()
     def create_study(self):


### PR DESCRIPTION
This PR reduces the number of `max_inputs` on `modal.concurrent` decorators to 100 in places where it was 1000.

Writing a web server that can handle high load is hard, and we don't load-test our examples at that scale. We should stick with a smaller default, relying on auto-scaling above that. Users can opt in to higher per-replica scales if they wish, but the need to update the value provides an opportunity for them to consider what else might need to change.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)