### PR TITLE
Small changes in gpt oss inference example

### DIFF
--- a/06_gpu_and_ml/llm-serving/gpt_oss_inference.py
+++ b/06_gpu_and_ml/llm-serving/gpt_oss_inference.py
@@ -35,8 +35,7 @@
 # ## Set up the container image
 
 # We'll start by defining a [custom container `Image`](https://modal.com/docs/guide/custom-container) that
-# installs all the necessary dependencies to run vLLM and the model. This includes a special-purpose vLLM prerelease
-# and a nightly PyTorch install for Triton support.
+# installs all the necessary dependencies to run vLLM and the model.
 
 import json
 import time
@@ -56,8 +55,6 @@ vllm_image = (
         "vllm==0.11.0",
         "huggingface_hub[hf_transfer]==0.35.0",
         "flashinfer-python==0.3.1",
-        pre=True,
-        
     )
 )
 
@@ -113,7 +110,7 @@ VLLM_PORT = 8000
 
 @app.function(
     image=vllm_image,
-    gpu=f"H200:{N_GPU}",
+    gpu=f"B200:{N_GPU}",
     scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
     timeout=30 * MINUTES,  # how long should we wait for container start?
     volumes={
@@ -259,6 +256,8 @@ async def _send_request(
                 print(delta["content"], end="")  # print the content as it comes in
             elif "reasoning_content" in delta:
                 print(delta["reasoning_content"], end="")
+            elif not delta:
+                print()
             else:
                 raise ValueError(f"Unsupported response delta: {delta}")
     print("")


### PR DESCRIPTION

Instead of giving nightly versions and all, tested it on 0.11.0. Its working flawlessly and for vllm we don't need to add torch explicitely as its already in Vllm dependency.  I have tested this code.



## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [☑️ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [ ] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
