### PR TITLE
use uv, pin onnx

### DIFF
--- a/06_gpu_and_ml/llm-serving/trtllm_latency.py
+++ b/06_gpu_and_ml/llm-serving/trtllm_latency.py
@@ -90,6 +90,7 @@ tensorrt_image = tensorrt_image.apt_install(
     "pynvml<12",  # avoid breaking change to pynvml version API
     "flashinfer-python==0.2.5",
     "cuda-python==12.9.1",
+    "onnx==1.19.1",
     pre=True,
     extra_index_url="https://pypi.nvidia.com",
     extra_options="--index-strategy unsafe-best-match",


### PR DESCRIPTION
This PR resolves a dangling issue from #1392 and #1393 -- updating the install in `trtllm_latency`.

I'm not 100% sure this will fix, but I'm making the PR to kick off remote testing while I'm in transit.

EDIT: it fixed.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)