### PR TITLE
Make it compatible with external yaml files

### DIFF
--- a/06_gpu_and_ml/protein-folding/boltz_predict.py
+++ b/06_gpu_and_ml/protein-folding/boltz_predict.py
@@ -62,6 +62,8 @@ def main(
 
     if input_yaml_path is None:
         input_yaml_path = here / "data" / "boltz_affinity.yaml"
+    else:
+        input_yaml_path = Path(input_yaml_path)
     input_yaml = input_yaml_path.read_text()
 
     print(f"🧬 running boltz with input from {input_yaml_path}")


### PR DESCRIPTION
Execution of `modal run boltz_predict.py` with local yaml files leads to an error. Using `Path()` fixes the problem.  

