### PR TITLE
make mcp_server_stateless testable, tighter pins

### DIFF
--- a/10_integrations/mcp_server_stateless.py
+++ b/10_integrations/mcp_server_stateless.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "serve", "10_integrations/mcp_server_stateless.py"]
+# cmd: ["modal", "run", "10_integrations/mcp_server_stateless.py::test_tool"]
 # ---
 
 # # Deploy a remote, stateless MCP server on Modal
@@ -130,9 +130,11 @@ async def test_tool(tool_name: str | None = None):
     async with client:
         tools = await client.list_tools()
 
-    for tool in tools:
-        print(tool)
-        if tool.name == tool_name:
-            return
+        for tool in tools:
+            print(tool)
+            if tool.name == tool_name:
+                result = await client.call_tool(tool_name)
+                print(result.data)
+                return
 
     raise Exception(f"could not find tool {tool_name}")


### PR DESCRIPTION
And promote it from `misc/` to `10_integrations`!

I think it might also be ready to go in the docs.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

Key addition here is testing of the server spin-up and tool execution by adding a `fastmcp.Client` in another Modal Function.

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability

I added a Pydantic version pin because there was an issue there -- and tightened the pins in general. A lot of this software is very fast-moving, so we should pin it tightly, regardless of what SemVer implies.

  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
