### PR TITLE
Bump vLLM examples to 0.14.0 and unify CUDA/Python base images

### DIFF
--- a/06_gpu_and_ml/llm-serving/gpt_oss_inference.py
+++ b/06_gpu_and_ml/llm-serving/gpt_oss_inference.py
@@ -47,14 +47,11 @@ import modal
 
 vllm_image = (
     modal.Image.from_registry(
-        "nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04",
+        "nvidia/cuda:12.9.1-devel-ubuntu24.04",
         add_python="3.12",
     )
     .entrypoint([])
-    .uv_pip_install(
-        "vllm==0.13.0",
-        "huggingface_hub[hf_transfer]==0.36.0",
-    )
+    .uv_pip_install("vllm==0.14.0")
     .env(  # fast Blackwell-specific MoE kernels
         {"VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8": "1"}
     )
@@ -189,6 +186,8 @@ def serve():
         "--async-scheduling",  # reduces host overhead, but might not be compatible with all features
     ]
 
+    # enforce-eager disables both Torch compilation and CUDA graph capture
+    # default is no-enforce-eager. see the --compilation-config flag for tighter control
     cmd += ["--enforce-eager" if FAST_BOOT else "--no-enforce-eager"]
 
     # assume multiple GPUs are for splitting up large matrix multiplications

--- a/06_gpu_and_ml/llm-serving/ministral3_inference.py
+++ b/06_gpu_and_ml/llm-serving/ministral3_inference.py
@@ -36,13 +36,9 @@ VLLM_PORT = 8000
 app = modal.App("example-ministral3-inference")
 
 vllm_image = (
-    modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
+    modal.Image.from_registry("nvidia/cuda:12.9.1-devel-ubuntu24.04", add_python="3.12")
     .entrypoint([])
-    .uv_pip_install(
-        "vllm==0.13.0",
-        "huggingface-hub==0.36.0",
-        "flashinfer-python==0.5.3",
-    )
+    .uv_pip_install("vllm==0.14.0")
 )
 
 # ## Download the Ministral weights

--- a/06_gpu_and_ml/llm-serving/vllm_inference.py
+++ b/06_gpu_and_ml/llm-serving/vllm_inference.py
@@ -33,9 +33,9 @@ import aiohttp
 import modal
 
 vllm_image = (
-    modal.Image.from_registry("nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04", add_python="3.12")
+    modal.Image.from_registry("nvidia/cuda:12.9.1-devel-ubuntu24.04", add_python="3.12")
     .entrypoint([])
-    .uv_pip_install("vllm==0.13.0")
+    .uv_pip_install("vllm==0.14.0")
     .env({"HF_XET_HIGH_PERFORMANCE": "1"})  # faster model transfers
 )
 

--- a/06_gpu_and_ml/llm-serving/vllm_low_latency.py
+++ b/06_gpu_and_ml/llm-serving/vllm_low_latency.py
@@ -41,8 +41,8 @@ HF_CACHE_VOL: modal.Volume = modal.Volume.from_name(
 HF_CACHE_PATH: str = "/root/.cache/huggingface"
 MODEL_PATH: str = f"{HF_CACHE_PATH}/{MODEL_NAME}"
 vllm_image: modal.Image = (
-    modal.Image.from_registry("nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11")
-    .uv_pip_install("vllm==0.11.2", "huggingface-hub==0.36.0")
+    modal.Image.from_registry("nvidia/cuda:12.9.1-devel-ubuntu24.04", add_python="3.12")
+    .uv_pip_install("vllm==0.14.0")
     .env(
         {
             "HF_HUB_CACHE": HF_CACHE_PATH,

--- a/06_gpu_and_ml/llm-serving/vllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/vllm_throughput.py
@@ -191,9 +191,9 @@ class Filing:
 # over SGLang, but either can work well.
 
 vllm_image = (
-    modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.13")
+    modal.Image.from_registry("nvidia/cuda:12.9.1-devel-ubuntu24.04", add_python="3.12")
     .entrypoint([])
-    .uv_pip_install("vllm==0.13.0", "huggingface-hub==0.36.0")
+    .uv_pip_install("vllm==0.14.0")
     .env({"HF_XET_HIGH_PERFORMANCE": "1"})  # faster model transfers
 )
 

--- a/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_trl.py
@@ -230,9 +230,9 @@ def get_latest_checkpoint_file_path():
 # We provide the code for setting up an OpenAI compatible inference endpoint here. For more details re. serving models on vLLM, check out [this example.](https://modal.com/docs/examples/vllm_inference#deploy-the-server)
 
 vllm_image = (
-    modal.Image.from_registry("nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04", add_python="3.12")
+    modal.Image.from_registry("nvidia/cuda:12.9.1-devel-ubuntu24.04", add_python="3.12")
     .entrypoint([])
-    .uv_pip_install("vllm==0.13.0")
+    .uv_pip_install("vllm==0.14.0")
 )
 
 vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)

--- a/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
+++ b/06_gpu_and_ml/reinforcement-learning/grpo_verl.py
@@ -241,9 +241,9 @@ def get_latest_checkpoint_file_path():
 # We provide the code for setting up an OpenAI compatible inference endpoint here. For more details re. serving models on vLLM, check out [this example.](https://modal.com/docs/examples/vllm_inference#deploy-the-server)
 
 vllm_image = (
-    modal.Image.from_registry("nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04", add_python="3.12")
+    modal.Image.from_registry("nvidia/cuda:12.9.1-devel-ubuntu24.04", add_python="3.12")
     .entrypoint([])
-    .uv_pip_install("vllm==0.13.0")
+    .uv_pip_install("vllm==0.14.0")
 )
 
 vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)

--- a/06_gpu_and_ml/reinforcement-learning/learn_math.py
+++ b/06_gpu_and_ml/reinforcement-learning/learn_math.py
@@ -21,7 +21,7 @@ import modal
 
 app = modal.App(name="example-learn-math")
 cuda_version = "12.9.1"
-flavor = "cudnn-devel"
+flavor = "devel"
 operating_sys = "ubuntu24.04"
 tag = f"{cuda_version}-{flavor}-{operating_sys}"
 


### PR DESCRIPTION
- bump every vllm example to latest vllm versions
- standardize all vllm-serving images on cuda 12.8.1 registry bases
- tune the gpt-oss example for blackwell b200 gpus with the recommended optimized settings
- migrate the cuda graph configuration to the new `--max-cudagraph-capture-size` api