### PR TITLE
move markdown out of code block

### DIFF
--- a/06_gpu_and_ml/speech-to-text/sortformer2_1_speaker_diarization.py
+++ b/06_gpu_and_ml/speech-to-text/sortformer2_1_speaker_diarization.py
@@ -5,10 +5,10 @@
 
 # # Streaming Speaker Diarization with Sortformer2.1
 
-# In this example, we show how to deploy a streaming speaker diarization service with NVIDIA's Sortformer2.1 on Modal.
-# Sortformer2.1 is a state-of-the-art speaker diarization model that is designed to operate on streams of audio, rather than on complete audio files.
+# In this example, we show how to deploy a streaming speaker diarization service with [NVIDIA's Sortformer2.1](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) on Modal.
+# Sortformer2.1 is a state-of-the-art speaker diarization model that is designed to operate on streams of audio.
 
-# Click the "View on GitHub" button to see the code. And [sign up for a Modal account](https://modal.com/signup) if you haven't already.
+# Try it yourself! Click the "View on GitHub" button to see the code. And [sign up for a Modal account](https://modal.com/signup) if you haven't already.
 
 # ## Setup
 
@@ -67,10 +67,21 @@ with image.imports():
 # so that we can separate out the model loading and setup code from the inference.
 # For more on lifecycle management with Clses and cold start penalty reduction on Modal, see
 # [this guide](https://modal.com/docs/guide/cold-start). In particular, the Sortformer2.1 model
-# is amenable to GPU snapshots.
+# is amenable to GPU snapshots which can significantly reduce cold start times.
 
 # We also include two configurations. The low latency configuration is used for real-time diarization,
 # and the high latency configuration is used for non-real-time diarization with higher accuracy.
+
+# ## Using WebSockets to stream audio and diarization results
+
+# We use a Modal [ASGI](https://modal.com/docs/guide/asgi) app to serve the diarization results
+# over WebSockets. This allows us to stream the diarization results to the client in real-time.
+
+# We use a simple queue-based architecture to handle the audio and diarization results.
+
+# The audio is received from the client over WebSockets and added to a queue.
+# The diarization results are then processed and added to a queue.
+# The diarization results are then sent to the client over WebSockets.
 
 
 @app.cls(
@@ -110,17 +121,6 @@ class Sortformer2_1_Speaker_Diarization:
         self.diarizer = NeMoStreamingDiarizer(
             cfg=self.config, model="nvidia/diar_streaming_sortformer_4spk-v2.1"
         )
-
-        # ## Using WebSockets to stream audio and diarization results
-
-        # We use a Modal [ASGI](https://modal.com/docs/guide/asgi) app to serve the diarization results
-        # over WebSockets. This allows us to stream the diarization results to the client in real-time.
-
-        # We use a simple queue-based architecture to handle the audio and diarization results.
-
-        # The audio is received from the client over WebSockets and added to a queue.
-        # The diarization results are then processed and added to a queue.
-        # The diarization results are then sent to the client over WebSockets.
 
         self.web_app = FastAPI()
 


### PR DESCRIPTION
Minor changes to get sections of markdown rendered.

## Type of Change


- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist


  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [ ] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [ ] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [ ] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist


### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [ ] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [ ] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [ ] Example specifies a `python_version` for the base image, if it is used 
    - [ ] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.
