### PR TITLE
adds memory snapshotting to ministral3 example

### DIFF
--- a/06_gpu_and_ml/llm-serving/ministral3_inference.py
+++ b/06_gpu_and_ml/llm-serving/ministral3_inference.py
@@ -1,10 +1,19 @@
-# # Serve Ministral 3 with vLLM
+# ---
+# deploy: true
+# cmd: ["python", "06_gpu_and_ml/llm-serving/ministral3_inference.py"]
+# ---
+
+# # Serverless Ministral 3 with vLLM and Modal
 
 # In this example, we show how to serve Mistral's Ministral 3 vision-language models on Modal.
 
 # The [Ministral 3](https://huggingface.co/collections/mistralai/ministral-3-more) model series
 # performs competitively with the Qwen 3-VL model series on benchmarks
 # (see model cards for details).
+
+# We also include instructions for cutting cold start times
+# for long-running deployments by an order of magnitude using Modal's
+# [CPU + GPU memory snapshots](https://modal.com/docs/guide/memory-snapshot).
 
 # ## Set up the container image
 
@@ -14,10 +23,15 @@
 # vLLM can be installed with `uv pip`, since Modal [provides the CUDA drivers](https://modal.com/docs/guide/cuda).
 
 import json
+import socket
+import subprocess
 from typing import Any
 
 import aiohttp
 import modal
+
+MINUTES = 60  # seconds
+VLLM_PORT = 8000
 
 app = modal.App("example-ministral3-inference")
 
@@ -25,7 +39,7 @@ vllm_image = (
     modal.Image.from_registry("nvidia/cuda:12.8.0-devel-ubuntu22.04", add_python="3.12")
     .entrypoint([])
     .uv_pip_install(
-        "vllm==0.11.2",
+        "vllm~=0.11.2",
         "huggingface-hub==0.36.0",
         "flashinfer-python==0.5.2",
     )
@@ -58,13 +72,13 @@ MODEL_NAME = "mistralai/Ministral-3-8B-Instruct-2512"
 # is limited to the latest [Streaming Multiprocessor architectures](https://modal.com/gpu-glossary/device-hardware/streaming-multiprocessor-architecture),
 # like those of Modal's [Hopper H100/H200 and Blackwell B200 GPUs](https://modal.com/blog/announcing-h200-b200).
 
-# At 80 GB VRAM, a single H100 GPU has enough space to store the 3B FP8 model weights (~3 GB)
+# At 80 GB VRAM, a single H100 GPU has enough space to store the 8B FP8 model weights (~8 GB)
 # and a very large KV cache. A single H100 is also enough to serve the 14B model in full precision,
 # but without as much room for KV (though still enough to handle the full sequence length).
 
 N_GPU = 1
 
-# ### Cacheing with Modal Volumes
+# ### Cache with Modal Volumes
 
 # Modal Functions are serverless: when they aren't being used,
 # their underlying containers spin down and all ephemeral resources,
@@ -80,42 +94,121 @@ N_GPU = 1
 hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
 vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
 
-# ## Serving Ministral 3 with vLLM
+# ## Serve Ministral 3 with vLLM
 
 # We serve Ministral 3 on Modal by spinning up a Modal Function
 # that acts as a [`web_server`](https://modal.com/docs/guide/webhooks)
 # and spins up a vLLM server in a subprocess
 # (via the `vllm serve` command).
 
-# The majority of the code in our Python function
-# constructs the arguments to this command
-# to configure the vLLM server.
+# ### Improve cold start time with snapshots
 
-# For autoscaling vLLM deployments,
-# one of the key knobs to turn is the amount of
-# work done at server startup -- typically
-# balancing [cold start performance](https://modal.com/docs/guide/cold-start)
-# and performance per request.
+# Starting up a vLLM server can be slow --
+# tens of seconds to minutes. Much of that time
+# is spent on JIT compilation of inference code.
 
-# We opt for faster boots.
-# We add a global variable to abstract away
-# the details of this choice.
+# We can skip most of that work and reduce startup times by a factor of 10
+# using Modal's [memory snapshots](https://modal.com/docs/guide/memory-snapshot),
+# which serialize the contents of CPU and GPU memory.
 
-FAST_BOOT = True
+# This adds quite some complexity to the code.
+# If you're looking for a minimal example, see
+# our [`vllm_inference` example here](https://modal.com/docs/examples/vllm_inference).
+
+# We'll need to set a few extra configuration values:
+
+vllm_image = vllm_image.env(
+    {
+        "VLLM_SERVER_DEV_MODE": "1",  # allow use of "Sleep Mode"
+        "TORCHINDUCTOR_COMPILE_THREADS": "1",  # improve compatibility with snapshots
+    }
+)
+
+# Setting the `DEV_MODE` flag allows us to use the `sleep`/`wake_up` endpoints
+# to toggle the server in and out of "sleep mode".
+
+with vllm_image.imports():
+    import requests
+
+
+def sleep(level=1):
+    requests.post(
+        f"http://localhost:{VLLM_PORT}/sleep?level={level}"
+    ).raise_for_status()
+
+
+def wake_up():
+    requests.post(f"http://localhost:{VLLM_PORT}/wake_up").raise_for_status()
+
+
+# Sleep Mode helps with memory snapshotting.
+# When the server is asleep, model weights are offloaded to CPU memory and the KV cache is emptied.
+# For details, see the [vLLM docs](https://docs.vllm.ai/en/stable/features/sleep_mode/).
+
+# We'll also need two helper functions.
+# Ther first, `wait_ready`, busy-polls the server until it is live.
+
+
+def wait_ready(proc: subprocess.Popen):
+    while True:
+        try:
+            socket.create_connection(("localhost", VLLM_PORT), timeout=1).close()
+            return
+        except OSError:
+            if proc.poll() is not None:
+                raise RuntimeError(f"vLLM exited with {proc.returncode}")
+
+
+# Once the server is live, we `warmup` inference with a few requests.
+# This is important for capturing non-serializable JIT compilation artifacts,
+# like CUDA graphs and some Torch compilation outputs,
+# in our snapshot.
+
+
+def warmup():
+    payload = {
+        "model": "llm",
+        "messages": [{"role": "user", "content": "Who are you?"}],
+        "max_tokens": 16,
+    }
+
+    for ii in range(3):
+        requests.post(
+            f"http://localhost:{VLLM_PORT}/v1/chat/completions",
+            json=payload,
+            timeout=300,
+        ).raise_for_status()
+
+
+# ### Define the server
 
 # We construct our web-serving Modal Function
-# by decorating a regular Python function.
+# by decorating a regular Python class.
 # The decorators include a number of configuration
 # options for deployment, including resources like GPUs and Volumes
 # and timeouts on container scaledown.
 # You can read more about the options
 # [here](https://modal.com/docs/reference/modal.App#function).
 
-MINUTES = 60  # seconds
-VLLM_PORT = 8000
+# We control memory snapshotting and container start behavior
+# by decorating the methods of the class.
+
+# We start the server, warm it up, and then put it to sleep
+# in the `start` method. This method has the `modal.enter`
+# decorator to ensure it runs when a new container starts
+# and we pass `snap=True` to turn on memory snapshotting.
+
+# The following method, `wake_up`, calls the `wake_up`
+# endpoint and then waits for the server to be ready.
+# It is run after the `start` method because it is defined later
+# in the code and also has the `modal.enter` decorator.
+# It has `snap=False` so that it isn't included in the snapshot.
+
+# Finally, we connect the vLLM server to the Internet
+# using the [`modal.web_server`](https://modal.com/docs/guide/webhooks#non-asgi-web-servers) decorator.
 
 
-@app.function(
+@app.cls(
     image=vllm_image,
     gpu=f"H100:{N_GPU}",
     scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
@@ -125,60 +218,89 @@ VLLM_PORT = 8000
         "/root/.cache/vllm": vllm_cache_vol,
     },
     secrets=[modal.Secret.from_name("huggingface-secret")],
+    enable_memory_snapshot=True,
+    experimental_options={"enable_gpu_snapshot": True},
 )
 @modal.concurrent(  # how many requests can one replica handle? tune carefully!
     max_inputs=32
 )
-@modal.web_server(port=VLLM_PORT, startup_timeout=10 * MINUTES)
-def serve():
-    import subprocess
+class VllmServer:
+    @modal.enter(snap=True)
+    def start(self):
+        cmd = [
+            "vllm",
+            "serve",
+            "--uvicorn-log-level=info",
+            MODEL_NAME,
+            "--served-model-name",
+            MODEL_NAME,
+            "llm",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(VLLM_PORT),
+            "--gpu_memory_utilization",
+            str(0.95),
+        ]
 
-    cmd = [
-        "vllm",
-        "serve",
-        "--uvicorn-log-level=info",
-        MODEL_NAME,
-        "--served-model-name",
-        MODEL_NAME,
-        "llm",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        str(VLLM_PORT),
-        "--gpu_memory_utilization",
-        str(0.99),
-    ]
+        # assume multiple GPUs are for splitting up large matrix multiplications
+        cmd += ["--tensor-parallel-size", str(N_GPU)]
 
-    # enforce-eager disables both Torch compilation and CUDA graph capture
-    # default is no-enforce-eager. see the --compilation-config flag for tighter control
-    cmd += ["--enforce-eager" if FAST_BOOT else "--no-enforce-eager"]
+        # add mistral config arguments
+        cmd += [
+            "--tokenizer_mode",
+            "mistral",
+            "--config_format",
+            "mistral",
+            "--load_format",
+            "mistral",
+            "--tool-call-parser",
+            "mistral",
+            "--enable-auto-tool-choice",
+        ]
 
-    # assume multiple GPUs are for splitting up large matrix multiplications
-    cmd += ["--tensor-parallel-size", str(N_GPU)]
+        # add config arguments for snapshotting
 
-    # add mistral config arguments
-    cmd += [
-        "--tokenizer_mode",
-        "mistral",
-        "--config_format",
-        "mistral",
-        "--load_format",
-        "mistral",
-        "--tool-call-parser",
-        "mistral",
-        "--enable-auto-tool-choice",
-    ]
+        cmd += [
+            "--enable-sleep-mode",
+            # make KV cache predictable / small
+            "--max-num-seqs",
+            "2",
+            "--max-model-len",
+            "12288",
+            "--max-num-batched-tokens",
+            "12288",
+        ]
 
-    print(*cmd)
+        print(*cmd)
 
-    subprocess.Popen(" ".join(cmd), shell=True)
+        self.vllm_proc = subprocess.Popen(cmd)
+
+        wait_ready(self.vllm_proc)
+
+        warmup()
+
+        sleep()
+
+    @modal.enter(snap=False)
+    def wake_up(self):
+        wake_up()
+        wait_ready(self.vllm_proc)
+
+    @modal.web_server(port=VLLM_PORT, startup_timeout=10 * MINUTES)
+    def serve(self):
+        pass
+
+    @modal.exit()
+    def stop(self):
+        self.vllm_proc.terminate()
 
 
 # ## Deploy the server
 
 # To deploy the API on Modal, just run
 # ```bash
-# modal deploy vllm_inference.py
+# modal deploy ministral3_inference.py
 # ```
 
 # This will create a new app on Modal, build the container image for it if it hasn't been built yet,
@@ -199,7 +321,7 @@ def serve():
 
 # To interact with the API programmatically in Python, we recommend the `openai` library.
 
-# ## Testing the server
+# ## Test the server
 
 # To make it easier to test the server setup, we also include a `local_entrypoint`
 # that does a healthcheck and then hits the server.
@@ -219,7 +341,7 @@ def serve():
 
 @app.local_entrypoint()
 async def test(test_timeout=10 * MINUTES, content=None, twice=True):
-    url = serve.get_web_url()
+    url = VllmServer().serve.get_web_url()
 
     system_prompt = {
         "role": "system",
@@ -250,17 +372,17 @@ async def test(test_timeout=10 * MINUTES, content=None, twice=True):
         print(f"Successful health check for server at {url}")
 
         print(f"Sending messages to {url}:", *messages, sep="\n\t")
-        await _send_request(session, "llm", messages)
+        await _send_request(session, "llm", messages, timeout=1 * MINUTES)
         if twice:
             messages[0]["content"] = """Yousa culled Jar Jar Binks.
-            Always be talkin' in da Gungan style, like thisa, okeyday?" +
+            Always be talkin' in da Gungan style, like thisa, okeyday?
             Helpin' da user with big big enthusiasm, makin' tings bombad clear!"""
             print(f"Sending messages to {url}:", *messages, sep="\n\t")
-            await _send_request(session, "llm", messages)
+            await _send_request(session, "llm", messages, timeout=1 * MINUTES)
 
 
 async def _send_request(
-    session: aiohttp.ClientSession, model: str, messages: list
+    session: aiohttp.ClientSession, model: str, messages: list, timeout: int
 ) -> None:
     # `stream=True` tells an OpenAI-compatible backend to stream chunks
     payload: dict[str, Any] = {
@@ -273,7 +395,7 @@ async def _send_request(
     headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
 
     async with session.post(
-        "/v1/chat/completions", json=payload, headers=headers, timeout=1 * MINUTES
+        "/v1/chat/completions", json=payload, headers=headers, timeout=timeout
     ) as resp:
         async for raw in resp.content:
             resp.raise_for_status()
@@ -290,3 +412,50 @@ async def _send_request(
             )  # or something went horribly wrong
             print(chunk["choices"][0]["delta"]["content"], end="")
     print()
+
+
+# ### Test memory snapshotting
+
+# Using `modal run` creates an ephemeral Modal App,
+# rather than a deployed Modal App.
+# Ephemeral Modal Apps are short-lived,
+# so they turn off snapshotting.
+
+# To test the memory snapshot version of the server,
+# first deploy it with `modal deploy`
+# and then hit it with a client.
+
+# You should observe startup improvements
+# after a handful of cold starts
+# (usually less than five).
+# If you want to see the speedup during a test,
+# we recommend heading to the deployed App in your
+# [Modal dashboard](https://modal.com/apps)
+# and manually stopping containers after they have served a request.
+
+# You can use the client code below to test the endpoint.
+# It can be run with the command
+
+# ```
+# python ministral3_inference.py
+# ```
+
+if __name__ == "__main__":
+    import asyncio
+
+    # after deployment, we can use the class from anywhere
+    VllmServer = modal.Cls.from_name("example-ministral3-inference", "VllmServer")
+    server = VllmServer()
+
+    async def test(url):
+        messages = [{"role": "user", "content": "Tell me a joke."}]
+        async with aiohttp.ClientSession(base_url=url) as session:
+            await _send_request(session, "llm", messages, timeout=10 * MINUTES)
+
+    try:
+        print("calling inference server")
+        asyncio.run(test(server.serve.get_web_url()))
+    except modal.exception.NotFoundError:
+        raise Exception(
+            f"To take advantage of GPU snapshots, deploy first with modal deploy {__file__}"
+        )


### PR DESCRIPTION
This PR adds memory snapshotting to the vLLM Ministral 3 example.

Memory snapshots can improve startup times for compiled models running in vLLM by an order of magnitude - 3m to 20s in the case of Ministral 3 8B FP8, 2m to 12s in the case of Ministral 3 8B FP8.

They add a lot of complexity, though, as evinced by the code here. There are also some changes in behavior, e.g. the reduction in max seqs and seq lens in this code. So we don't really yet want to include snapshotting in our "baseline" vLLM example.

Note: I'm breaking the rules and loosely pinning vLLM here. I expect a release of vLLM shortly with version 0.11.3 and improved support for Ministral 3. A loose pin lets users who run the example after that release get those benefits. I'm also not pinning the model revision, because I similarly expect release imminently.