### PR TITLE
remove hf secret from ministral 3 example

### DIFF
--- a/06_gpu_and_ml/llm-serving/ministral3_inference.py
+++ b/06_gpu_and_ml/llm-serving/ministral3_inference.py
@@ -217,7 +217,6 @@ def warmup():
         "/root/.cache/huggingface": hf_cache_vol,
         "/root/.cache/vllm": vllm_cache_vol,
     },
-    secrets=[modal.Secret.from_name("huggingface-secret")],
     enable_memory_snapshot=True,
     experimental_options={"enable_gpu_snapshot": True},
 )


### PR DESCRIPTION
The weights are now public and ungated, so the Secret is no longer needed