### PR TITLE
add sglang_snapshot

### DIFF
--- a/06_gpu_and_ml/llm-serving/sglang_snapshot.py
+++ b/06_gpu_and_ml/llm-serving/sglang_snapshot.py
@@ -359,7 +359,7 @@ class SGLang:
         self.process.terminate()
 
 
-## Deploy the server
+# ## Deploy the server
 
 # To deploy the server on Modal, just run
 
@@ -369,7 +369,7 @@ class SGLang:
 
 # This will create a new App on Modal and build the container image for it if it hasn't been built yet.
 
-## Interact with the server
+# ## Interact with the server
 
 # Once it is deployed, you'll see a URL appear in the command line,
 # something like `https://your-workspace-name--example-sglang-snapshot-sglang.modal.run`.
@@ -380,7 +380,7 @@ class SGLang:
 # and translate requests into `curl` commands.
 # For simple routes, you can even send a request directly from the docs page.
 
-## Test the server
+# ## Test the server
 
 # To make it easier to test the server setup, we also include a `local_entrypoint`
 # that hits the server with a simple client.
@@ -476,11 +476,6 @@ async def _send_request(
 # to ensure turnover.
 
 # You can use the client code below to test the endpoint.
-# It can be run with the command
-
-# ```bash
-# python sglang_snapshot.py
-# ```
 
 
 if __name__ == "__main__":
@@ -494,3 +489,9 @@ if __name__ == "__main__":
         raise Exception(
             f"To take advantage of GPU snapshots, deploy first with modal deploy {__file__}"
         ) from e
+
+# It can be run with the command
+
+# ```bash
+# python sglang_snapshot.py
+# ```


### PR DESCRIPTION
This PR brings back the SGLang snapshotting code @molocule added for the low latency example.

<img width="1454" height="1222" alt="Screenshot 2026-01-04 at 4 32 02 PM" src="https://github.com/user-attachments/assets/c239bb46-e56a-4a99-aeec-3bd23ee2a49b" />

We don't want to encourage snapshotting for ultra-low-latency inference services, because those applications only need it if they have highly variable loads or scale up from zero (and can tolerate cold starts in the user request path). Snapshotting requires code changes and adds some brittleness.

## Type of Change

- [x] New example for the GitHub repo
  - [x] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`