### PR TITLE
add code-complete draft of high-throughput vllm example

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/vllm_throughput.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "run", "--detach", "06_gpu_and_ml/llm-serving/vllm_throughput"]
+# cmd: ["modal", "run", "--detach", "06_gpu_and_ml/llm-serving/vllm_throughput.py"]
 # ---
 
 # # Run LLM inference at maximum throughput
@@ -11,7 +11,7 @@
 # [our guide](https://modal.com/docs/guide/high-performance-llm-inference).
 
 # As our sample application, we use an LLM to summarize thousands of filings with
-# the U.S. federal government's Securities and Exchange Commission,
+# the U.S. federal government's Securities and Exchange Commission (SEC),
 # made available to the public for free in daily data dumps
 # via the SEC's Electronic Data Gathering, Analysis, and Retrieval System
 # ([EDGAR](https://www.sec.gov/submit-filings/about-edgar)).


### PR DESCRIPTION
tl;dr -- summarize SEC filings at 30k input tok/s, 2k output tok/s per H100, for a rough price of 4¢ per megatoken, one fifth the cost of API providers.

API providers don't mention whether they quantize. If they don't, we'd still be cheaper, but not as much.

The Modal patterns here include `map` and `spawn`, including steps where we batch to improve throughput. I skipped `spawn_map` because that'd require external storage of results from inside the Function, and `map`/`spawn` seem to be doing just fine here.

## Type of Change

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [ ] **Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style**
  
  Will do this in a follow-up PR. IME, my writing is a lot better approaching code a second time.

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`