### PR TITLE
update aiortic version

### DIFF
--- a/07_web_endpoints/webrtc/webrtc_yolo.py
+++ b/07_web_endpoints/webrtc/webrtc_yolo.py
@@ -105,7 +105,6 @@
 # - install the necessary libs for processing video, `opencv` and `ffmpeg`, and
 # - install the necessary Python packages.
 
-import os
 from pathlib import Path
 
 import modal
@@ -129,7 +128,7 @@ video_processing_image = (
     .apt_install("python3-opencv", "ffmpeg")
     # install Python dependencies
     .uv_pip_install(
-        "aiortc==1.11.0",
+        "aiortc==1.14.0",
         "fastapi==0.115.12",
         "huggingface-hub[hf_xet]==0.30.2",
         "onnxruntime-gpu==1.21.0",
@@ -198,7 +197,7 @@ app = modal.App("example-webrtc-yolo")
     image=video_processing_image,
     gpu="A100-40GB",
     volumes=cache,
-    secrets=[modal.Secret.from_name("turn-credentials")],
+    # secrets=[modal.Secret.from_name("turn-credentials")],
     region="us-east",  # set to your region
 )
 @modal.concurrent(
@@ -240,18 +239,18 @@ class ObjDet(ModalWebRtcPeer):
                 )
 
     async def get_turn_servers(self, peer_id=None, msg=None) -> dict:
-        creds = {
-            "username": os.environ["TURN_USERNAME"],
-            "credential": os.environ["TURN_CREDENTIAL"],
-        }
+        # creds = {
+        #     "username": os.environ["TURN_USERNAME"],
+        #     "credential": os.environ["TURN_CREDENTIAL"],
+        # }
 
         turn_servers = [
-            {"urls": "stun:stun.relay.metered.ca:80"},  # STUN is free, no creds neeeded
-            # for TURN, sign up for the free service here: https://www.metered.ca/tools/openrelay/
-            {"urls": "turn:standard.relay.metered.ca:80"} | creds,
-            {"urls": "turn:standard.relay.metered.ca:80?transport=tcp"} | creds,
-            {"urls": "turn:standard.relay.metered.ca:443"} | creds,
-            {"urls": "turns:standard.relay.metered.ca:443?transport=tcp"} | creds,
+            # {"urls": "stun:stun.relay.metered.ca:80"},  # STUN is free, no creds neeeded
+            # # for TURN, sign up for the free service here: https://www.metered.ca/tools/openrelay/
+            # {"urls": "turn:standard.relay.metered.ca:80"} | creds,
+            # {"urls": "turn:standard.relay.metered.ca:80?transport=tcp"} | creds,
+            # {"urls": "turn:standard.relay.metered.ca:443"} | creds,
+            # {"urls": "turns:standard.relay.metered.ca:443?transport=tcp"} | creds,
         ]
 
         return {"type": "turn_servers", "ice_servers": turn_servers}


### PR DESCRIPTION
Update `aiortc` dependency to fix broken builds.

## Type of Change

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


