### PR TITLE
log decode tok/s more frequently

### DIFF
--- a/06_gpu_and_ml/llm-serving/sglang_low_latency.py
+++ b/06_gpu_and_ml/llm-serving/sglang_low_latency.py
@@ -383,7 +383,7 @@ class SGLang:
             f"{TARGET_INPUTS * 2}",
             "--enable-metrics",  # expose metrics endpoints for telemetry
             "--decode-log-interval",  # how often to log during decoding, in tokens
-            "250",
+            "100",
             "--mem-fraction",  # leave space for speculative model
             "0.8",
         ]


### PR DESCRIPTION
At the lower logging rate, we under-estimate peak tok/s by a lot. But the default logging rate is too high, so we set it in between.

## Type of Change
- [x] Example updates (Bug fixes, new features, etc.)