### PR TITLE
better config, update vllm, >250 tok/s

### DIFF
--- a/06_gpu_and_ml/llm-serving/gpt_oss_inference.py
+++ b/06_gpu_and_ml/llm-serving/gpt_oss_inference.py
@@ -58,7 +58,6 @@ vllm_image = (
     .env(  # fast Blackwell-specific MoE kernels
         {"VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8": "1"}
     )
-    .add_local_file("config.yaml", "/root/config.yaml")
 )
 
 


### PR DESCRIPTION
gpt-oss go brrrt

Adds a speculator I found online and a few handy flags from the [vLLM Recipes](https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html) docs.

Thanks @mmangkad for clueing me into the need to store FlashInfer JIT kernels with the new vLLM version, that was killing start times. And also for the nudge to upgrade via PR #1405 