### PR TITLE
Add Chronos-2 time series forecasting tutorial

### DIFF
--- a/06_gpu_and_ml/chronos/README.md
+++ b/06_gpu_and_ml/chronos/README.md
@@ -1,0 +1,22 @@
+# Chronos-2 Time Series Forecasting on Modal
+
+Deploy Amazon's [Chronos-2](https://huggingface.co/amazon/chronos-2) time series forecasting model on Modal.
+
+These examples parallel the official [SageMaker deployment notebook](https://github.com/amazon-science/chronos-forecasting/blob/main/notebooks/deploy-chronos-to-amazon-sagemaker.ipynb), demonstrating equivalent functionality with Modal's simpler Python-native approach.
+
+## Examples
+
+- `real_time_inference.py` - Real-time forecasting with four patterns: univariate, multiple series, covariates, and multivariate
+- `batch_transform.py` - Parallel batch processing using `.starmap()` for large-scale forecasting
+
+## Quick Start
+
+```bash
+modal run 06_gpu_and_ml/chronos/real_time_inference.py
+modal run 06_gpu_and_ml/chronos/batch_transform.py
+```
+
+## References
+
+- [Chronos-2 on HuggingFace](https://huggingface.co/amazon/chronos-2)
+- [SageMaker Deployment Notebook](https://github.com/amazon-science/chronos-forecasting/blob/main/notebooks/deploy-chronos-to-amazon-sagemaker.ipynb)

--- a/06_gpu_and_ml/chronos/batch_transform.py
+++ b/06_gpu_and_ml/chronos/batch_transform.py
@@ -1,0 +1,133 @@
+# ---
+# cmd: ["modal", "run", "06_gpu_and_ml/chronos/batch_transform.py"]
+# ---
+
+# # Batch Transform for Time Series
+#
+# Process thousands of time series in parallel using Modal's `.starmap()` for
+# horizontal scaling. This is Modal's equivalent of SageMaker Batch Transform.
+#
+# **When to use:**
+# - Large-scale batch forecasting (thousands of time series)
+# - Scheduled or periodic forecasting jobs
+# - When latency is not critical
+
+import io
+
+import modal
+import pandas as pd
+
+app = modal.App("chronos-batch-transform")
+
+image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "chronos-forecasting>=2.0",
+    "pandas[pyarrow]",
+)
+
+
+def df_to_bytes(df: pd.DataFrame) -> bytes:
+    buf = io.BytesIO()
+    df.to_parquet(buf)
+    return buf.getvalue()
+
+
+def bytes_to_df(b: bytes) -> pd.DataFrame:
+    return pd.read_parquet(io.BytesIO(b))
+
+
+# ## Deploy the Model
+
+
+@app.cls(image=image, gpu="T4")
+class Chronos:
+    @modal.enter()
+    def load_model(self):
+        from chronos import Chronos2Pipeline
+
+        self.pipeline = Chronos2Pipeline.from_pretrained(
+            "amazon/chronos-2",
+            device_map="cuda",
+        )
+
+    @modal.method()
+    def predict(
+        self,
+        df_bytes: bytes,
+        future_df_bytes: bytes | None = None,
+        id_column: str = "item_id",
+        timestamp_column: str = "timestamp",
+        target: str | list[str] = "target",
+        prediction_length: int | None = None,
+        quantile_levels: list[float] = [0.1, 0.5, 0.9],
+        batch_size: int = 256,
+        context_length: int | None = None,
+        cross_learning: bool = False,
+        validate_inputs: bool = True,
+        **predict_kwargs,
+    ) -> bytes:
+        # Thin wrapper around pipeline.predict_df with Parquet serialization for RPC.
+        pred_df = self.pipeline.predict_df(
+            bytes_to_df(df_bytes),
+            future_df=bytes_to_df(future_df_bytes) if future_df_bytes else None,
+            id_column=id_column,
+            timestamp_column=timestamp_column,
+            target=target,
+            prediction_length=prediction_length,
+            quantile_levels=quantile_levels,
+            batch_size=batch_size,
+            context_length=context_length,
+            cross_learning=cross_learning,
+            validate_inputs=validate_inputs,
+            **predict_kwargs,
+        )
+        return df_to_bytes(pred_df)
+
+
+# ## Run Batch Transform
+#
+# Uses the [grocery_sales dataset](https://autogluon.s3.amazonaws.com/datasets/timeseries/grocery_sales/test.csv)
+# from the official Chronos SageMaker tutorial.
+
+
+@app.local_entrypoint()
+def main():
+    # Load grocery sales dataset (same as SageMaker tutorial)
+    df = pd.read_csv(
+        "https://autogluon.s3.amazonaws.com/datasets/timeseries/grocery_sales/test.csv",
+        parse_dates=["timestamp"],
+    )
+
+    prediction_length = 8
+    target_col = "unit_sales"
+
+    # Use historical data as context (exclude last prediction_length rows per series)
+    past_df = df.groupby("item_id").head(-prediction_length)
+    future_df = df.groupby("item_id").tail(prediction_length).drop(columns=[target_col])
+
+    # Split into batches of 100 series each
+    series_ids = past_df["item_id"].unique()
+    batch_size = 100
+    batches = [
+        (
+            df_to_bytes(past_df[past_df["item_id"].isin(series_ids[i : i + batch_size])]),
+            df_to_bytes(future_df[future_df["item_id"].isin(series_ids[i : i + batch_size])]),
+        )
+        for i in range(0, len(series_ids), batch_size)
+    ]
+
+    # Process batches in parallel with .starmap()
+    print(f"Processing {len(series_ids)} series in {len(batches)} batches...")
+    model = Chronos()
+    results = list(
+        model.predict.starmap(
+            batches,
+            kwargs={"prediction_length": prediction_length, "target": target_col},
+        )
+    )
+
+    # Combine results
+    all_predictions = pd.concat([bytes_to_df(pred_bytes) for pred_bytes in results])
+    print(
+        f"Generated {len(all_predictions)} predictions for {all_predictions['item_id'].nunique()} series"
+    )
+    print(all_predictions.head(15))

--- a/06_gpu_and_ml/chronos/real_time_inference.py
+++ b/06_gpu_and_ml/chronos/real_time_inference.py
@@ -1,0 +1,176 @@
+# ---
+# cmd: ["modal", "run", "06_gpu_and_ml/chronos/real_time_inference.py"]
+# ---
+
+# # Deploy Chronos-2 to Modal
+
+# This tutorial shows how to deploy Chronos-2 to [Modal](https://modal.com), following the structure of the [official SageMaker deployment notebook](https://github.com/amazon-science/chronos-forecasting/blob/main/notebooks/deploy-chronos-to-amazon-sagemaker.ipynb).
+
+# ### Why Deploy to Modal?
+
+# Running models locally works for experimentation, but production use cases need reliability, scale, and integration into existing workflows. Modal lets you deploy Chronos-2 to the cloud with:
+
+# - Fast cold starts (~25 seconds including model loading, compared to ~5 minutes for SageMaker endpoint provisioning)
+# - Per-second billing (pay only for compute time)
+# - Automatic scaling (no instance management)
+# - No infrastructure setup (no IAM roles, endpoint configs, or S3 model artifacts)
+# - Native Python RPC (no JSON conversion overhead)
+
+# RPC stands for Remote Procedure Call—it lets you call functions running on Modal's servers as if they were local Python functions. Combined with Parquet serialization, this avoids the complex JSON conversion code required by HTTP-based endpoints.
+
+# ### Deployment Options
+
+# This tutorial covers two deployment patterns from the SageMaker notebook:
+
+# 1. Real-time Inference (GPU) - Highest throughput, ~25 second cold starts
+# 2. Batch Transform - Process thousands of time series in parallel (see batch_transform.py)
+
+# Unlike SageMaker, all Modal deployments scale to zero automatically and bill per-second. There's no separate "serverless" mode because Modal is serverless by default.
+import io
+
+import modal
+import pandas as pd
+
+app = modal.App("chronos-forecasting")
+
+
+image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "chronos-forecasting>=2.0",
+    "pandas[pyarrow]",
+)
+
+
+def df_to_bytes(df: pd.DataFrame) -> bytes:
+    buf = io.BytesIO()
+    df.to_parquet(buf)
+    return buf.getvalue()
+
+
+def bytes_to_df(b: bytes) -> pd.DataFrame:
+    return pd.read_parquet(io.BytesIO(b))
+
+
+@app.cls(image=image, gpu="T4")
+class Chronos:
+    @modal.enter()
+    def load_model(self):
+        from chronos import Chronos2Pipeline
+
+        self.pipeline = Chronos2Pipeline.from_pretrained(
+            "amazon/chronos-2",
+            device_map="cuda",
+        )
+
+    @modal.method()
+    def predict(
+        self,
+        df_bytes: bytes,
+        future_df_bytes: bytes | None = None,
+        id_column: str = "item_id",
+        timestamp_column: str = "timestamp",
+        target: str | list[str] = "target",
+        prediction_length: int | None = None,
+        quantile_levels: list[float] = [0.1, 0.5, 0.9],
+        batch_size: int = 256,
+        context_length: int | None = None,
+        cross_learning: bool = False,
+        validate_inputs: bool = True,
+        **predict_kwargs,
+    ) -> bytes:
+        # Thin wrapper around pipeline.predict_df with Parquet serialization for RPC.
+        pred_df = self.pipeline.predict_df(
+            bytes_to_df(df_bytes),
+            future_df=bytes_to_df(future_df_bytes) if future_df_bytes else None,
+            id_column=id_column,
+            timestamp_column=timestamp_column,
+            target=target,
+            prediction_length=prediction_length,
+            quantile_levels=quantile_levels,
+            batch_size=batch_size,
+            context_length=context_length,
+            cross_learning=cross_learning,
+            validate_inputs=validate_inputs,
+            **predict_kwargs,
+        )
+        return df_to_bytes(pred_df)
+
+
+@app.local_entrypoint()
+def main():
+    # Demonstrates four forecasting patterns from the SageMaker notebook.
+    model = Chronos()
+
+    print("Section 1: Real-time Inference (GPU)")
+
+    print("(a) Univariate forecasting")
+    context_df = pd.DataFrame(
+        {
+            "item_id": "id",
+            "timestamp": pd.date_range("2026-01-01", periods=20, freq="D"),
+            "target": [0, 4, 5, 1.5, -3, -5, -3, 1.5, 5, 4, 0, -4, -5, -1.5, 3, 5, 3, -1.5, -5, -4],
+        }
+    )
+    pred_bytes = model.predict.remote(df_to_bytes(context_df), prediction_length=10)
+    print(bytes_to_df(pred_bytes))
+
+    print("(b) Multiple time series")
+    product_a = pd.DataFrame(
+        {
+            "item_id": "product_A",
+            "timestamp": pd.date_range("2024-01-01T01:00:00", periods=9, freq="1h"),
+            "target": [1.0, 2.0, 3.0, 2.0, 0.5, 2.0, 3.0, 2.0, 1.0],
+        }
+    )
+    product_b = pd.DataFrame(
+        {
+            "item_id": "product_B",
+            "timestamp": pd.date_range("2024-02-02T03:00:00", periods=7, freq="1h"),
+            "target": [5.4, 3.0, 3.0, 2.0, 1.5, 2.0, -1.0],
+        }
+    )
+    context_df = pd.concat([product_a, product_b], ignore_index=True)
+    pred_bytes = model.predict.remote(df_to_bytes(context_df), prediction_length=5)
+    print(bytes_to_df(pred_bytes))
+
+    print("(c) Forecasting with covariates")
+    context_df = pd.DataFrame(
+        {
+            "item_id": "id",
+            "timestamp": pd.date_range("2026-01-01", periods=9, freq="D"),
+            "target": [1.0, 2.0, 3.0, 2.0, 0.5, 2.0, 3.0, 2.0, 1.0],
+            "feat_1": [3.0, 6.0, 9.0, 6.0, 1.5, 6.0, 9.0, 6.0, 3.0],
+            "feat_2": ["A", "B", "B", "B", "A", "A", "A", "A", "B"],
+            "feat_3": [10.0, 20.0, 30.0, 20.0, 5.0, 20.0, 30.0, 20.0, 10.0],  # past only
+        }
+    )
+    future_df = pd.DataFrame(
+        {
+            "item_id": "id",
+            "timestamp": pd.date_range("2026-01-10", periods=3, freq="D"),
+            "feat_1": [2.5, 2.2, 3.3],
+            "feat_2": ["B", "A", "A"],
+        }
+    )
+    pred_bytes = model.predict.remote(
+        df_to_bytes(context_df),
+        future_df_bytes=df_to_bytes(future_df),
+        prediction_length=3,
+    )
+    print(bytes_to_df(pred_bytes))
+
+    print("(d) Multivariate forecasting")
+    context_df = pd.DataFrame(
+        {
+            "item_id": "id",
+            "timestamp": pd.date_range("2026-01-01", periods=8, freq="D"),
+            "target_1": [1, 2, 3, 2, 1, 2, 3, 4.0],
+            "target_2": [5, 4, 3, 4, 5, 4, 3, 2.0],
+            "target_3": [2, 2.5, 3, 2.5, 2, 2.5, 3, 3.5],
+        }
+    )
+    pred_bytes = model.predict.remote(
+        df_to_bytes(context_df),
+        target=["target_1", "target_2", "target_3"],
+        prediction_length=4,
+    )
+    print(bytes_to_df(pred_bytes))


### PR DESCRIPTION
Chronos is a popular encoder-only time series foundation model for zero-shot forecasting developed by Amazon: <https://github.com/amazon-science/chronos-forecasting>, <https://huggingface.co/amazon/chronos-2>.

Recently the Chronos team published a tutorial how to deploy Chronos-2 to AWS with Amazon SageMaker: <https://github.com/amazon-science/chronos-forecasting/blob/main/notebooks/deploy-chronos-to-amazon-sagemaker.ipynb>.

This CR demonstrates how to run Chronos-2 on Modal instead.

## Type of Change

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

N/A - GitHub repo only

## Outside Contributors

First-time contributor. Happy to address any feedback!
