### PR TITLE
put a stricter limit in place for document length

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/vllm_throughput.py
@@ -519,7 +519,7 @@ def clean_xml(xml: str) -> str:
     return xml.strip()
 
 
-def truncate_head_tail(text: str, head: int = 30000, tail: int = 3000) -> str:
+def truncate_head_tail(text: str, head: int = 13_000, tail: int = 2_000) -> str:
     if len(text) <= head + tail:
         return text
     return text[:head].rstrip() + "\n\n[...TRUNCATED...]\n\n" + text[-tail:].lstrip()


### PR DESCRIPTION
A new document in the SEC EDGAR Feed led to this example failing. We don't explicitly limit the token count in documents, just the character count, and our conservative heuristic failed, resulting in a prompt with token count 17,149, above the `max_model_len` of 16,384.

If we limit the documents to approximately 15k characters, they can only produce a document with token count at most a bit over 15k. That leaves room for 1k tokens of output and the short prompt in our `max_model_len`.