### PR TITLE
skip links that are slow to load

### DIFF
--- a/10_integrations/webscraper.py
+++ b/10_integrations/webscraper.py
@@ -130,8 +130,10 @@ playwright_image = modal.Image.debian_slim(python_version="3.10").run_commands(
 
 @app.function(image=playwright_image)
 async def get_links(cur_url: str) -> list[str]:
-    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
-    from playwright.async_api import async_playwright
+    from playwright.async_api import (
+        TimeoutError as PlaywrightTimeoutError,
+        async_playwright,
+    )
 
     async with async_playwright() as p:
         browser = await p.chromium.launch()


### PR DESCRIPTION
Adds a short timeout and skip logic for the playwright page load.

Noticed some flakes in this example, and they appear to come from pages taking a long time to load.

We don't have control of the loaded pages -- and you generally don't when running a webscraper! -- so we need to skip here.