### PR TITLE
add auth fix

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,7 +1,7 @@
 name: Run changed examples
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -12,11 +12,16 @@ on:
     paths:
       - "**.py"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to test (e.g., refs/pull/123/head or a branch name)'
+        required: false
+        type: string
 
 # Cancel previous runs of the same PR but do not cancel previous runs on main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event.pull_request.number != '' || github.ref != 'refs/heads/main' }}
 
 env:
   TERM: linux
@@ -34,6 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Find changed examples
@@ -56,6 +62,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
## Fix: Enable GitHub Actions for External Contributor PRs

### Problem

External contributors' PRs are failing the "Run example" GitHub check with authentication errors:

```
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Token missing. Could not authenticate client.                                │
╰──────────────────────────────────────────────────────────────────────────────╯
```

**Root Cause:** The workflow uses the `pull_request` trigger, which does not expose repository secrets to PRs from forks for security reasons. This prevents Modal authentication from working for external contributors, while internal PRs work fine.

### Solution

Switch from `pull_request` to `pull_request_target` trigger. This change allows the workflow to:
- Run in the context of the base repository (has access to secrets)
- Authenticate with Modal using the repository's credentials
- Still test the PR's code by explicitly checking out the PR head SHA

### Changes

1. **Updated workflow trigger** (`pull_request` → `pull_request_target`)
   - Workflow now runs with access to `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` secrets
   
2. **Explicit PR code checkout**
   ```yaml
   ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
   ```
   - Ensures the workflow tests the PR's code, not the base branch
   - Includes cascading fallback for push events and manual runs

3. **Fixed concurrency group**
   ```yaml
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   ```
   - Uses PR number instead of `github.ref` (which would always be `main` with `pull_request_target`)
   - Ensures proper cancellation of duplicate runs per PR

4. **Added manual testing capability**
   - New `workflow_dispatch` input allows testing any PR or branch manually
   - Useful for debugging workflow issues without waiting for PR updates

### Security Considerations

⚠️ **`pull_request_target` gives untrusted PR code access to `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`**

**Important**: Workflows do NOT run automatically for external PRs. Org members must manually trigger them after reviewing the PR code.

#### Maintainer Responsibility

Before manually triggering workflows on external PRs, maintainers should review the code and watch for:

- **Access environment variables**: `os.environ`, `os.getenv("MODAL_TOKEN_*")`, printing env vars
- **Make external network calls**: Unexpected use of `requests`, `urllib`, `httpx`, `socket`, etc.
- **Execute arbitrary commands**: Suspicious `subprocess`, `os.system`, `exec`, `eval` usage
- **Exfiltrate data**: Writing secrets to files, logging tokens, sending data to external services
- **Access unrelated Modal resources**: Connecting to environments/apps outside the example's scope

Most legitimate examples will use Modal's APIs normally and won't access these environment variables directly (Modal SDK handles authentication internally).

### Manually Triggering Checks

Manually test run this workflow on a(n external) PR:

```bash
# Manually trigger workflow on an external PR
gh workflow run run-examples.yml \
  --ref <branch> \
  -f ref=refs/pull/<PR_NUMBER>/head
```

The value of `branch` will usually be `main`, but if you want to test an updated version of this workflow from a different branch you can do that as well.

Or via GitHub UI:
1. Actions → "Run changed examples" → "Run workflow"
2. Select branch for workflow
3. Enter `refs/pull/<PR_NUMBER>/head` in the ref input
4. Click "Run workflow"

### References

- [GitHub Docs: `pull_request_target` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
- [Keeping workflows secure with `pull_request_target`](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)


## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [ ] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (Changes to the codebase, but not to examples)
