### PR TITLE
adds a simple example for Cls.with_options

### DIFF
--- a/03_scaling_out/cls_with_options.py
+++ b/03_scaling_out/cls_with_options.py
@@ -1,8 +1,16 @@
+# ---
+# mypy: ignore-errors
+# ---
+
 # # Override Modal resource options (GPU, scaling) at runtime with `Cls.with_options`
 
-# `Cls.with_options` lets you override the resource configuration of a
-# Modal class at runtime. This is useful when the same code needs to run
-# with different resource allocations depending on the workload.
+# [`Cls.with_options`](https://modal.com/docs/reference/modal.Cls#with_options)
+# lets you override the resource configuration of a
+# Modal [Cls](https://modal.com/docs/guide/lifecycle-functions) at runtime.
+# This is useful when the same code needs to run
+# with different resource allocations -- say, with a GPU or with out,
+# or with a large [warm pool of containers](https://modal.com/docs/guide/cold-start)
+# -- at different times -- say, when iterating on code and when in production.
 
 # Each call to `with_options` returns a new class handle that scales
 # independently from the original.


### PR DESCRIPTION
This PR adds a simple example for dynamic resource configuration with `Cls.with_options`.

This is a common question, as @rchalamala pointed out, but we don't use it in any of the existing examples and the reference docs are not easily discoverable based on the queries users are likely to have ("change GPUs", "runtime override GPUs", "add more containers").

We could probably stand to add some material in the `guide` section of the docs as well, but this example seems like a good start.

## Type of Change


- [x] New example for the GitHub repo
  - [x] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - **[ ] Example specifies a `python_version` for the base image, if it is used**. This one is simple enough that I am comfortable skipping.
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`