### PR TITLE
adds a 'kitchen sink' example for sglang + qwen

### DIFF
--- a/06_gpu_and_ml/llm-serving/sglang_kitchen_sink.py
+++ b/06_gpu_and_ml/llm-serving/sglang_kitchen_sink.py
@@ -31,11 +31,13 @@ sglang_image = (
     ).entrypoint([])  # silence chatty logs on container start
 )
 
-sglang_image.env({  # bleeding-edge SGLang perf opt settings
-    "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_DFLASH_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
-})
+sglang_image.env(
+    {  # bleeding-edge SGLang perf opt settings
+        "SGLANG_ENABLE_SPEC_V2": "1",
+        "SGLANG_ENABLE_DFLASH_SPEC_V2": "1",
+        "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    }
+)
 
 # ## Choose a GPU
 


### PR DESCRIPTION
This PR adds an example for the "kitchen sink" of high performance SGLang Qwen 3 8B FP8 serving on Modal.

It has 
- B200s
- custom SGLang
- custom FA4
- DFlash speculation
- snapshotting

The only thing it is missing is tensor parallelism.

It has little by way of explanation, which is deferred to other documentation.

## Type of Change

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`