### PR TITLE
add longer timeouts, fix edgartools pytz issue

### DIFF
--- a/06_gpu_and_ml/llm-serving/vllm_throughput.py
+++ b/06_gpu_and_ml/llm-serving/vllm_throughput.py
@@ -348,7 +348,13 @@ class Vllm:
 # in our project by putting it in a separate container Image.
 
 data_proc_image = modal.Image.debian_slim(python_version="3.13").uv_pip_install(
-    "edgartools==5.11.1"
+    # pin transitive deps to avoid surprises like this one:
+    # https://www.edgartools.io/pandas-3-0-and-edgartools/
+    "edgartools==5.8.3",
+    "httpx==0.28.1",
+    "httpxthrottlecache==0.3.0",
+    "pandas<3",
+    "pyrate-limiter==3.9.0",
 )
 
 # Instead of hitting the SEC's EDGAR Feed API every time we want to run a job,


### PR DESCRIPTION
The `vllm_throughput` example was failing in synmons. The pipeline is not as robust to failures as it could be.

One common failure is from timeouts, resolved in this PR. As written, I actually think this example would fail on first run for users in most cases, since the `orchestrate` Function usually takes more than five minutes if the data isn't already in the Volume.

I'm leaving off fixing the underlying reliability problem for now, since that's less user-facing. Will keep an eye on synthetic monitoring and hope to catch more failure modes.

Separately, the example was failing during rebuild ([sample failure](https://github.com/modal-labs/modal-examples/actions/runs/21503073888/job/61953393313)). The cause was a transitive dependency of a dependency -- [pandas 3 dropped pytz and edgartools uses pytz](https://www.edgartools.io/pandas-3-0-and-edgartools/). This PR bumps our edgartools version to fix this.