### PR TITLE
skip overwriting config yaml

### DIFF
--- a/06_gpu_and_ml/llm-serving/very_large_models.py
+++ b/06_gpu_and_ml/llm-serving/very_large_models.py
@@ -193,7 +193,9 @@ if modal.is_local():
     if local_config_path is None:
         local_config_path = here / "config_very_large_models.yaml"
 
-        local_config_path.write_text(default_config)
+        if not local_config_path.exists():
+            local_config_path.write_text(default_config)
+
         print(
             f"Using default config from {local_config_path.relative_to(here)}:",
             default_config,


### PR DESCRIPTION
We were _always_ overwriting the default config YAML file for the `very_large_models` example. This PR stops doing that.

It's bad for users, who probably expect to be able to change things in that file and have those changes respected, and it's bad for the synmon environment, which has a read-only filesystem outside of `/tmp`.