### PR TITLE
works

### DIFF
--- a/05_scheduling/custom_retries.py
+++ b/05_scheduling/custom_retries.py
@@ -1,0 +1,95 @@
+# ---
+# cmd: ["modal", "run", "05_scheduling.custom_retries"]
+# ---
+
+# # Custom retries by exception type
+# There are two types of retries in Modal:
+# 1. When a function execution is interrupted by [preemption](https://modal.com/docs/guide/preemption#preemption), the input will be retried. This behavior is not configurable at this time.
+# 2. When a function execution fails, ie by a raised Exception, Modal will retry the function call if you have [`modal.Retries`](https://modal.com/docs/reference/modal.Retries) configured.
+# This example is about customizing the latter to only retry on certain exception types.
+# For example, you may only want to retry on certain expected errors (e.g. timeouts, or
+# transient network errors) and crash immediately on others (e.g. OOM, bad input).
+
+# The trick is to:
+# 1. Raise retryable errors in the usual way to trigger `modal.Retries`
+# 2. Catch and `return` non-retryable errors.
+# For #2, Modal will see a successful function call execution and return the exception
+# to your client/server to handle as desired.
+
+import modal
+
+app = modal.App("example-custom-retries")
+
+# ## Define retryable vs. crashable exceptions
+
+retry_exceptions = (
+    TimeoutError,
+    ConnectionError,
+    # transient CUDA errors, network blips, etc.
+)
+
+crashable_exceptions = (
+    MemoryError,
+    ValueError,
+    # OOM, bad input — retrying won't help
+)
+
+# ## Use a Dict to track call count across retries
+#
+# Each retry runs in a new container invocation, so we use a
+# [`modal.Dict`](https://modal.com/docs/reference/modal.Dict) to share
+# state and make the demo deterministic.
+
+call_counter = modal.Dict.from_name(
+    "custom-retries-demo-counter", create_if_missing=True
+)
+
+# ## Demo App
+#
+# This function follows a scripted sequence to demonstrate the behavior:
+#
+# 1. **Call 1** — raises `TimeoutError` (retryable → Modal retries)
+# 2. **Call 2** — raises `ConnectionError` (retryable → Modal retries)
+# 3. **Call 3** — raises `MemoryError` (crashable → returned, no more retries)
+#
+# So you'll see two retries, then a clean stop on the third attempt.
+
+
+@app.function(retries=modal.Retries(max_retries=5, initial_delay=1.0))
+def flaky_task():
+    call_count = call_counter.get("calls", 0) + 1
+    call_counter["calls"] = call_count
+    print(f"Attempt {call_count}")
+
+    # Scripted error sequence
+    errors = [
+        TimeoutError("GPU timed out"),  # attempt 1: retryable
+        ConnectionError("lost connection to data server"),  # attempt 2: retryable
+        MemoryError("CUDA out of memory"),  # attempt 3: crashable
+    ]
+    error = errors[min(call_count, len(errors)) - 1]
+
+    print(f"  Hit: {error!r}")
+
+    if isinstance(error, retry_exceptions):
+        print("  -> retryable, re-raising so Modal retries")
+        raise error
+
+    # Return instead of raise — Modal sees success, stops retrying
+    print("  -> non-retryable, returning error to stop retries")
+    return error
+
+
+# ## Entrypoint
+#
+# The caller checks whether the return value is an exception.
+
+
+@app.local_entrypoint()
+def main():
+    call_counter["calls"] = 0  # reset counter
+    result = flaky_task.remote()
+    if isinstance(result, Exception):
+        print(f"Stopped with non-retryable error: {result!r}")
+    else:
+        print(f"Result: {result}")


### PR DESCRIPTION
## Type of Change
This is a bit of a workaround for "custom retries" (i.e. retrying via `modal.Retries` on some exceptions, and circumventing retries on other, more fatal errors). It's based on [this demo](https://modal-com.slack.com/archives/C056CGAANRM/p1751476558083609?thread_ts=1748545573.144129&cid=C056CGAANRM) I made for Achira last year, and I'm bringing it up again because another customer asked for it [here](https://modal-com.slack.com/archives/C0AHC1HLAVB/p1774522930956879).

The demo follows a scripted sequence of errors that requires each function execution to "know" which iteration it's on. This is accomplished with a `modal.Dict` but could potentially simplify this by perhaps choosing a random error? (but then, it's random)
<img width="666" height="813" alt="image" src="https://github.com/user-attachments/assets/93479c97-067b-47cc-afc1-08761bbbd0e0" />


- [X] New example for the GitHub repo

## Monitoring Checklist

  - [X] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [X Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [X] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [X] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [X] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [X] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [X] Example pins all dependencies in container images
    - [X] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [] Example specifies a `python_version` for the base image, if it is used 
    - --> **currently just using default image, should i add `.debian_slim(add_python=...)`**?
    - [X] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [X] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modal-labs/modal-examples/pull/1531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
