### PR TITLE
Pin transformers~=4.49.0 in gpu_packing.py to fix CI

### DIFF
--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -27,7 +27,7 @@ def download_model():
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .uv_pip_install("sentence-transformers==3.2.0", "transformers==4.51")
+    .uv_pip_install("sentence-transformers==3.2.0", "transformers==4.51", "accelerate")
     .run_function(download_model)
 )
 

--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -27,7 +27,7 @@ def download_model():
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .uv_pip_install("sentence-transformers==3.2.0", "transformers==4.51", "accelerate")
+    .uv_pip_install("sentence-transformers==3.2.0", "transformers~=4.50.0")
     .run_function(download_model)
 )
 

--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -27,7 +27,7 @@ def download_model():
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .uv_pip_install("sentence-transformers==3.2.0", "transformers~=4.50.0")
+    .uv_pip_install("sentence-transformers==3.2.0", "transformers~=4.49.0")
     .run_function(download_model)
 )
 

--- a/06_gpu_and_ml/gpu_packing.py
+++ b/06_gpu_and_ml/gpu_packing.py
@@ -27,7 +27,7 @@ def download_model():
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .uv_pip_install("sentence-transformers==3.2.0")
+    .uv_pip_install("sentence-transformers==3.2.0", "transformers==4.51")
     .run_function(download_model)
 )
 


### PR DESCRIPTION
Pins `transformers~=4.49.0` in the `gpu_packing.py` image definition to fix a CI failure where `SentenceTransformer("/model.bge", device="cuda")` raises:

```
OSError: Can't load the configuration of '/model.bge'
```

Root cause: an unpinned `transformers` transitive dependency introduced a breaking change in `cached_files()` (new in 4.50.0) that validates the path as a HuggingFace repo ID — rejecting paths starting with `/` — before checking if it's a local directory.

### Versions tested

| Version | Result |
|---|---|
| `transformers==4.51` | ❌ Same `cached_files()` bug |
| `transformers~=4.50.0` | ❌ `cached_files()` was introduced in 4.50.0 |
| `transformers~=4.49.0` | ✅ Last minor before the breaking change |

Tested locally with `MODAL_FORCE_BUILD=1 modal run 06_gpu_and_ml/gpu_packing.py` — fresh image build and full 100-request inference benchmark both completed successfully.

Failed run: https://github.com/modal-labs/modal-examples/actions/runs/24437604134/job/71395226154

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

- [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
  - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter
  - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter
  - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally

## Human Review Checklist

- [ ] Verify `transformers~=4.49.0` is compatible with `sentence-transformers==3.2.0`
- [ ] Consider whether `sentence-transformers` should be upgraded to a version compatible with `transformers>=4.50` for a longer-term fix

Link to Devin session: https://modal.devinenterprise.com/sessions/e71ce1ecfe4b4037a9ddbd59b4031614
Requested by: @charlesfrye
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
