### PR TITLE
Drop -FP8 from Qwen model name in 01_getting_started examples

### DIFF
--- a/01_getting_started/inference.py
+++ b/01_getting_started/inference.py
@@ -16,9 +16,7 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(
-        model="Qwen/Qwen3-1.7B-FP8", device_map="cuda", max_new_tokens=1024
-    )
+    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference.py
+++ b/01_getting_started/inference.py
@@ -2,9 +2,6 @@ from pathlib import Path
 
 import modal
 
-MODEL_NAME = "Qwen/Qwen3-1.7B"
-MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
-
 app = modal.App("example-inference")
 image = modal.Image.debian_slim().uv_pip_install("transformers[torch]")
 
@@ -19,12 +16,7 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(
-        model=MODEL_NAME,
-        revision=MODEL_REVISION,
-        device_map="cuda",
-        max_new_tokens=1024,
-    )
+    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference.py
+++ b/01_getting_started/inference.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import modal
 
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
+
 app = modal.App("example-inference")
 image = modal.Image.debian_slim().uv_pip_install("transformers[torch]")
 
@@ -16,7 +19,12 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
+    chatbot = pipeline(
+        model=MODEL_NAME,
+        revision=MODEL_REVISION,
+        device_map="cuda",
+        max_new_tokens=1024,
+    )
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_endpoint.py
+++ b/01_getting_started/inference_endpoint.py
@@ -5,9 +5,6 @@ from pathlib import Path
 
 import modal
 
-MODEL_NAME = "Qwen/Qwen3-1.7B"
-MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
-
 app = modal.App("example-inference-endpoint")
 image = (
     modal.Image.debian_slim()
@@ -27,12 +24,7 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(
-        model=MODEL_NAME,
-        revision=MODEL_REVISION,
-        device_map="cuda",
-        max_new_tokens=1024,
-    )
+    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_endpoint.py
+++ b/01_getting_started/inference_endpoint.py
@@ -24,9 +24,7 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(
-        model="Qwen/Qwen3-1.7B-FP8", device_map="cuda", max_new_tokens=1024
-    )
+    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_endpoint.py
+++ b/01_getting_started/inference_endpoint.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 import modal
 
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
+
 app = modal.App("example-inference-endpoint")
 image = (
     modal.Image.debian_slim()
@@ -24,7 +27,12 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
+    chatbot = pipeline(
+        model=MODEL_NAME,
+        revision=MODEL_REVISION,
+        device_map="cuda",
+        max_new_tokens=1024,
+    )
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_full.py
+++ b/01_getting_started/inference_full.py
@@ -29,7 +29,7 @@ class Chat:
     @modal.enter()
     def init(self):
         self.chatbot = pipeline(
-            model="Qwen/Qwen3-1.7B-FP8", device_map="cuda", max_new_tokens=1024
+            model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024
         )
 
     @modal.fastapi_endpoint(docs=True)

--- a/01_getting_started/inference_full.py
+++ b/01_getting_started/inference_full.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import modal
 
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
+
 app = modal.App("example-inference-full")
 image = (
     modal.Image.debian_slim()
@@ -29,7 +32,10 @@ class Chat:
     @modal.enter()
     def init(self):
         self.chatbot = pipeline(
-            model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024
+            model=MODEL_NAME,
+            revision=MODEL_REVISION,
+            device_map="cuda",
+            max_new_tokens=1024,
         )
 
     @modal.fastapi_endpoint(docs=True)

--- a/01_getting_started/inference_full.py
+++ b/01_getting_started/inference_full.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import modal
 
-MODEL_NAME = "Qwen/Qwen3-1.7B"
-MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
-
 app = modal.App("example-inference-full")
 image = (
     modal.Image.debian_slim()
@@ -32,10 +29,7 @@ class Chat:
     @modal.enter()
     def init(self):
         self.chatbot = pipeline(
-            model=MODEL_NAME,
-            revision=MODEL_REVISION,
-            device_map="cuda",
-            max_new_tokens=1024,
+            model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024
         )
 
     @modal.fastapi_endpoint(docs=True)

--- a/01_getting_started/inference_map.py
+++ b/01_getting_started/inference_map.py
@@ -16,9 +16,7 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(
-        model="Qwen/Qwen3-1.7B-FP8", device_map="cuda", max_new_tokens=1024
-    )
+    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_map.py
+++ b/01_getting_started/inference_map.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import modal
 
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
+
 app = modal.App("example-inference-map")
 image = modal.Image.debian_slim().uv_pip_install("transformers[torch]")
 
@@ -16,7 +19,12 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
+    chatbot = pipeline(
+        model=MODEL_NAME,
+        revision=MODEL_REVISION,
+        device_map="cuda",
+        max_new_tokens=1024,
+    )
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_map.py
+++ b/01_getting_started/inference_map.py
@@ -33,5 +33,4 @@ def main():
             f"/no_think Read this code.\n\n{(root_dir / path).read_text()}\nIn one paragraph, what does the code do?"
         )
 
-    for result in chat.map(examples):
-        print(result[0]["generated_text"][-1]["content"])
+    chat.for_each(examples[:100], ignore_exceptions=True)

--- a/01_getting_started/inference_map.py
+++ b/01_getting_started/inference_map.py
@@ -2,14 +2,11 @@ from pathlib import Path
 
 import modal
 
-MODEL_NAME = "Qwen/Qwen3-1.7B"
-MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
-
 app = modal.App("example-inference-map")
 image = modal.Image.debian_slim().uv_pip_install("transformers[torch]")
 
 
-@app.function(gpu="h100", image=image, timeout=600)
+@app.function(gpu="h100", image=image)
 def chat(prompt: str | None = None) -> list[dict]:
     from transformers import pipeline
 
@@ -19,12 +16,7 @@ def chat(prompt: str | None = None) -> list[dict]:
     print(prompt)
     context = [{"role": "user", "content": prompt}]
 
-    chatbot = pipeline(
-        model=MODEL_NAME,
-        revision=MODEL_REVISION,
-        device_map="cuda",
-        max_new_tokens=1024,
-    )
+    chatbot = pipeline(model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024)
     result = chatbot(context)
     print(result[0]["generated_text"][-1]["content"])
 

--- a/01_getting_started/inference_map.py
+++ b/01_getting_started/inference_map.py
@@ -9,7 +9,7 @@ app = modal.App("example-inference-map")
 image = modal.Image.debian_slim().uv_pip_install("transformers[torch]")
 
 
-@app.function(gpu="h100", image=image)
+@app.function(gpu="h100", image=image, timeout=600)
 def chat(prompt: str | None = None) -> list[dict]:
     from transformers import pipeline
 

--- a/01_getting_started/inference_perf.py
+++ b/01_getting_started/inference_perf.py
@@ -29,7 +29,7 @@ class Chat:
     @modal.enter()
     def init(self):
         self.chatbot = pipeline(
-            model="Qwen/Qwen3-1.7B-FP8", device_map="cuda", max_new_tokens=1024
+            model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024
         )
 
     @modal.fastapi_endpoint(docs=True)

--- a/01_getting_started/inference_perf.py
+++ b/01_getting_started/inference_perf.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import modal
 
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
+
 app = modal.App("example-inference-perf")
 image = (
     modal.Image.debian_slim()
@@ -29,7 +32,10 @@ class Chat:
     @modal.enter()
     def init(self):
         self.chatbot = pipeline(
-            model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024
+            model=MODEL_NAME,
+            revision=MODEL_REVISION,
+            device_map="cuda",
+            max_new_tokens=1024,
         )
 
     @modal.fastapi_endpoint(docs=True)

--- a/01_getting_started/inference_perf.py
+++ b/01_getting_started/inference_perf.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import modal
 
-MODEL_NAME = "Qwen/Qwen3-1.7B"
-MODEL_REVISION = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"  # pin to avoid surprises!
-
 app = modal.App("example-inference-perf")
 image = (
     modal.Image.debian_slim()
@@ -32,10 +29,7 @@ class Chat:
     @modal.enter()
     def init(self):
         self.chatbot = pipeline(
-            model=MODEL_NAME,
-            revision=MODEL_REVISION,
-            device_map="cuda",
-            max_new_tokens=1024,
+            model="Qwen/Qwen3-1.7B", device_map="cuda", max_new_tokens=1024
         )
 
     @modal.fastapi_endpoint(docs=True)


### PR DESCRIPTION
Switch all `01_getting_started/` inference examples from `Qwen/Qwen3-1.7B-FP8` to `Qwen/Qwen3-1.7B`.

The FP8 variant requires Triton kernels for FP8 matmul that aren't installed in the example images (`transformers[torch]` + `fastapi` only). Without Triton, the `_load_triton_kernel` helper returns `None`, causing an `AttributeError` at inference time ([failed CI run](https://github.com/modal-labs/modal-examples/actions/runs/24490555866/job/71574546001)).

The base (non-quantized) 1.7B model doesn't require Triton and avoids the extra dependency.

**Files changed:** `inference.py`, `inference_map.py`, `inference_endpoint.py`, `inference_perf.py`, `inference_full.py`

### CI notes

- `inference.py` and `inference_endpoint.py` pass ✓
- `inference_full.py` and `inference_perf.py` have `deploy: true` — their CI tests run `python <file>` which calls `modal.Cls.from_name()` to hit the **existing deployment** (still running the old FP8 model). These will pass once the PR is merged and the CD pipeline redeploys.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

No changes to test configuration or frontmatter — these examples are already configured for synthetic monitoring.

## Human Review Checklist

- [ ] `inference_full.py` and `inference_perf.py` use `enable_memory_snapshot=True` — old snapshots from the FP8 model may need to be invalidated after merge

Link to Devin session: https://modal.devinenterprise.com/sessions/e80078412acd44b3896e6b1409107855
Requested by: @charlesfrye
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
