### PR TITLE
yolo: add curl to image for ultralytics download retry path

### DIFF
--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -36,7 +36,7 @@ import modal
 image = (
     modal.Image.debian_slim(python_version="3.10")
     .apt_install(  # install system libraries for graphics handling
-        ["libgl1-mesa-glx", "libglib2.0-0"]
+        ["libgl1-mesa-glx", "libglib2.0-0", "curl"]
     )
     .uv_pip_install(  # install python libraries for computer vision
         ["ultralytics~=8.2.68", "roboflow~=1.1.37", "opencv-python~=4.10.0"]

--- a/06_gpu_and_ml/yolo/finetune_yolo.py
+++ b/06_gpu_and_ml/yolo/finetune_yolo.py
@@ -35,7 +35,7 @@ import modal
 
 image = (
     modal.Image.debian_slim(python_version="3.10")
-    .apt_install(  # install system libraries for graphics handling
+    .apt_install(  # install system libraries for graphics handling, model download
         ["libgl1-mesa-glx", "libglib2.0-0", "curl"]
     )
     .uv_pip_install(  # install python libraries for computer vision


### PR DESCRIPTION
# Clanker Output
<details><summary>Adds `curl` to the `apt_install` list in the YOLO fine-tuning example's image definition.
</summary>
## Why

`ultralytics.utils.downloads.safe_download` uses `torch.hub.download_url_to_file` (urllib) for its first download attempt, but falls back to shelling out to `curl` on retries. If the initial urllib download fails (e.g., a transient GitHub/network flake), the retry path raises `FileNotFoundError` because `curl` is not installed in `debian_slim`, which ultralytics then surfaces as `ConnectionError: Retry limit reached`.

This was the root cause of the CI failure on this example. Adding `curl` hardens the retry path so that download retries actually work. The underlying upstream download flake may still occur, but retries will now succeed instead of failing due to a missing binary.

## Test plan

- [x] Ran `modal run 06_gpu_and_ml/yolo/finetune_yolo.py` — completed successfully with training and inference on both datasets
</details>
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
