### PR TITLE
Add restricted volumes example

### DIFF
--- a/08_advanced/restricted_volumes.py
+++ b/08_advanced/restricted_volumes.py
@@ -22,49 +22,43 @@ sandbox = modal.Sandbox.create(app=app, image=image, volumes={"/data": volume})
 sandbox_id = sandbox.object_id
 print("Sandbox ID: ", sandbox_id)
 
-
-def sandbox_restricted_exec(sandbox: modal.Sandbox, command: str, user: str):
-    """Execute a command in a Sandbox as a restricted user."""
-    p = sandbox.exec("su", "-", user, "-c", f"{command}")
-    for line in p.stdout:
-        print(line, end="")
-    for line in p.stderr:
-        print(line, end="")
-    return p
-
-
 print("⌛Setting up sandbox...")
-p = sandbox.exec("sh", "-c", "mkdir -p /data/user1")
-p.wait()
-p = sandbox.exec("sh", "-c", "mkdir -p /data/user2")
-p.wait()
-p = sandbox.exec(
-    "sh", "-c", "chown -R user1:user1 /data/user1  && chmod 700 /data/user1"
-)
-p.wait()
-p = sandbox.exec(
-    "sh", "-c", "chown -R user2:user2 /data/user2  && chmod 700 /data/user2"
-)
-p.wait()
+sandbox.exec("sh", "-c", "mkdir -p /data/user1").wait()
+sandbox.exec("sh", "-c", "mkdir -p /data/user2").wait()
+sandbox.exec(
+    "sh", "-c", "chown -R user1:user1 /data/user1 && chmod 700 /data/user1"
+).wait()
+sandbox.exec(
+    "sh", "-c", "chown -R user2:user2 /data/user2 && chmod 700 /data/user2"
+).wait()
 print("Sandbox setup complete.")
 
 print("\n🟢 Baseline exec (unrestricted, should succeed):")
 p = sandbox.exec("sh", "-c", "ls -la /data/user1")
-p.wait()
 for line in p.stdout:
     print(line, end="")
+p.wait()
+assert p.returncode == 0, "Unrestricted exec should succeed"
 
 print("\n🟢 Restricted user1 exec (should succeed):")
-p = sandbox_restricted_exec(sandbox, "ls -la /data/user1", "user1")
+p = sandbox.exec("su", "-", "user1", "-c", "ls -la /data/user1")
+for line in p.stdout:
+    print(line, end="")
+for line in p.stderr:
+    print(line, end="")
 p.wait()
+assert p.returncode == 0, "user1 should access own directory"
 
 print("\n🔴 Restricted user1 exec (should fail):")
-p = sandbox_restricted_exec(sandbox, "ls -la /data/user2", "user1")
+p = sandbox.exec("su", "-", "user1", "-c", "ls -la /data/user2")
+for line in p.stdout:
+    print(line, end="")
+for line in p.stderr:
+    print(line, end="")
 p.wait()
+assert p.returncode != 0, "user1 should not access user2's directory"
 
 url = f"https://modal.com/id/{sandbox_id}"
-
 print(
     f"\n☀️ Sandbox live! See: {url}\nYou can use modal.Sandbox.from_id('{sandbox_id}') to run additional commands."
 )
-# sandbox = modal.Sandbox.from_id(sandbox_id)

--- a/08_advanced/restricted_volumes.py
+++ b/08_advanced/restricted_volumes.py
@@ -4,8 +4,10 @@
 # ---
 import modal
 
-app = modal.App.lookup(name="restricted-sb-app", create_if_missing=True)
-volume = modal.Volume.from_name("restricted-sb-data", create_if_missing=True, version=2)
+app = modal.App.lookup(name="example-restricted-volumes", create_if_missing=True)
+volume = modal.Volume.from_name(
+    "example-restricted-volumes-data", create_if_missing=True, version=2
+)
 
 image = (
     modal.Image.debian_slim()
@@ -17,7 +19,8 @@ image = (
 )
 
 sandbox = modal.Sandbox.create(app=app, image=image, volumes={"/data": volume})
-print("Sandbox ID: ", sandbox.object_id)
+sandbox_id = sandbox.object_id
+print("Sandbox ID: ", sandbox_id)
 
 
 def sandbox_restricted_exec(sandbox: modal.Sandbox, command: str, user: str):
@@ -32,22 +35,36 @@ def sandbox_restricted_exec(sandbox: modal.Sandbox, command: str, user: str):
 
 print("⌛Setting up sandbox...")
 p = sandbox.exec("sh", "-c", "mkdir -p /data/user1")
+p.wait()
 p = sandbox.exec("sh", "-c", "mkdir -p /data/user2")
+p.wait()
 p = sandbox.exec(
     "sh", "-c", "chown -R user1:user1 /data/user1  && chmod 700 /data/user1"
 )
+p.wait()
 p = sandbox.exec(
     "sh", "-c", "chown -R user2:user2 /data/user2  && chmod 700 /data/user2"
 )
+p.wait()
 print("Sandbox setup complete.")
 
 print("\n🟢 Baseline exec (unrestricted, should succeed):")
 p = sandbox.exec("sh", "-c", "ls -la /data/user1")
+p.wait()
 for line in p.stdout:
     print(line, end="")
 
 print("\n🟢 Restricted user1 exec (should succeed):")
 p = sandbox_restricted_exec(sandbox, "ls -la /data/user1", "user1")
+p.wait()
 
 print("\n🔴 Restricted user1 exec (should fail):")
 p = sandbox_restricted_exec(sandbox, "ls -la /data/user2", "user1")
+p.wait()
+
+url = f"https://modal.com/id/{sandbox_id}"
+
+print(
+    f"\n☀️ Sandbox live! See: {url}\nYou can use modal.Sandbox.from_id('{sandbox_id}') to run additional commands."
+)
+# sandbox = modal.Sandbox.from_id(sandbox_id)

--- a/08_advanced/restricted_volumes.py
+++ b/08_advanced/restricted_volumes.py
@@ -1,0 +1,53 @@
+# ---
+# cmd: ["python", "08_advanced/restricted_volumes.py"]
+# pytest: false
+# ---
+import modal
+
+app = modal.App.lookup(name="restricted-sb-app", create_if_missing=True)
+volume = modal.Volume.from_name("restricted-sb-data", create_if_missing=True, version=2)
+
+image = (
+    modal.Image.debian_slim()
+    .apt_install("sudo")
+    .run_commands(
+        "sudo adduser --disabled-password --gecos '' user1",
+        "sudo adduser --disabled-password --gecos '' user2",
+    )
+)
+
+sandbox = modal.Sandbox.create(app=app, image=image, volumes={"/data": volume})
+print("Sandbox ID: ", sandbox.object_id)
+
+
+def sandbox_restricted_exec(sandbox: modal.Sandbox, command: str, user: str):
+    """Execute a command in a Sandbox as a restricted user."""
+    p = sandbox.exec("su", "-", user, "-c", f"{command}")
+    for line in p.stdout:
+        print(line, end="")
+    for line in p.stderr:
+        print(line, end="")
+    return p
+
+
+print("⌛Setting up sandbox...")
+p = sandbox.exec("sh", "-c", "mkdir -p /data/user1")
+p = sandbox.exec("sh", "-c", "mkdir -p /data/user2")
+p = sandbox.exec(
+    "sh", "-c", "chown -R user1:user1 /data/user1  && chmod 700 /data/user1"
+)
+p = sandbox.exec(
+    "sh", "-c", "chown -R user2:user2 /data/user2  && chmod 700 /data/user2"
+)
+print("Sandbox setup complete.")
+
+print("\n🟢 Baseline exec (unrestricted, should succeed):")
+p = sandbox.exec("sh", "-c", "ls -la /data/user1")
+for line in p.stdout:
+    print(line, end="")
+
+print("\n🟢 Restricted user1 exec (should succeed):")
+p = sandbox_restricted_exec(sandbox, "ls -la /data/user1", "user1")
+
+print("\n🔴 Restricted user1 exec (should fail):")
+p = sandbox_restricted_exec(sandbox, "ls -la /data/user2", "user1")

--- a/08_advanced/restricted_volumes.py
+++ b/08_advanced/restricted_volumes.py
@@ -10,7 +10,7 @@ volume = modal.Volume.from_name(
 )
 
 image = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.12")
     .apt_install("sudo")
     .run_commands(
         "sudo adduser --disabled-password --gecos '' user1",
@@ -18,7 +18,9 @@ image = (
     )
 )
 
-sandbox = modal.Sandbox.create(app=app, image=image, volumes={"/data": volume})
+sandbox = modal.Sandbox.create(
+    app=app, image=image, volumes={"/data": volume}, timeout=300
+)
 sandbox_id = sandbox.object_id
 print("Sandbox ID: ", sandbox_id)
 
@@ -36,6 +38,8 @@ print("Sandbox setup complete.")
 print("\n🟢 Baseline exec (unrestricted, should succeed):")
 p = sandbox.exec("sh", "-c", "ls -la /data/user1")
 for line in p.stdout:
+    print(line, end="")
+for line in p.stderr:
     print(line, end="")
 p.wait()
 assert p.returncode == 0, "Unrestricted exec should succeed"


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Type of Change
Code for showing how to set up a restricted, shared Volume for multiple Sandboxes to access. Each Sandbox has r/w access to one folder.

This PR focuses on example content only: plaintext / copy will be added in a future change.

- [x] New example for the GitHub repo

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
