### PR TITLE
ltx2_two_stage: pin torch==2.7.0 in second uv_pip_install

### DIFF
--- a/06_gpu_and_ml/text-to-video/ltx2_two_stage.py
+++ b/06_gpu_and_ml/text-to-video/ltx2_two_stage.py
@@ -51,11 +51,14 @@ image = (
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .uv_pip_install(
+        "torch==2.7.0",
+        "torchaudio==2.7.0",
         "transformers>=4.52,<5",
         f"git+https://github.com/Lightricks/LTX-2.git@{ltx2_commit}#subdirectory=packages/ltx-core",
         f"git+https://github.com/Lightricks/LTX-2.git@{ltx2_commit}#subdirectory=packages/ltx-pipelines",
         f"git+https://github.com/Lightricks/LTX-2.git@{ltx2_commit}#subdirectory=packages/ltx-trainer",
         "https://huggingface.co/alexnasa/flash-attn-3/resolve/main/128/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl",
+        extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .env(
         {

--- a/06_gpu_and_ml/text-to-video/ltx2_two_stage.py
+++ b/06_gpu_and_ml/text-to-video/ltx2_two_stage.py
@@ -58,7 +58,6 @@ image = (
         f"git+https://github.com/Lightricks/LTX-2.git@{ltx2_commit}#subdirectory=packages/ltx-pipelines",
         f"git+https://github.com/Lightricks/LTX-2.git@{ltx2_commit}#subdirectory=packages/ltx-trainer",
         "https://huggingface.co/alexnasa/flash-attn-3/resolve/main/128/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl",
-        extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .env(
         {


### PR DESCRIPTION
The CI job [Build and run random example](https://github.com/modal-labs/modal-examples/actions/runs/24711177001/job/72275967185) selected `06_gpu_and_ml/text-to-video/ltx2_two_stage.py` and failed at runtime with:

```
RuntimeError: cuDNN Frontend error: [cudnn_frontend] Error: No valid execution plans built.
```

from `torch.nn.functional.scaled_dot_product_attention` inside the Gemma‑3 text encoder used by the LTX‑2 prompt enhancer.

**Root cause:** the second `uv_pip_install(...)` call (installing `transformers`, the three `ltx-*` packages, and the Flash‑Attention 3 wheel) ran without `torch`/`torchaudio` pinned and without the cu128 extra index, so the resolver upgraded the pinned cu128 wheels from the first layer:

```
- torch==2.7.0+cu128     → + torch==2.11.0
- torchaudio==2.7.0+cu128 → + torchaudio==2.11.0
- triton==3.3.0          → + triton==3.6.0
```

The resulting torch 2.11.0 ships a cuDNN that lacks a valid SDPA plan for Gemma‑3 attention on the selected GPU, producing the crash above.

**Fix:** re‑declare the `torch==2.7.0` / `torchaudio==2.7.0` pins and the `extra_index_url="https://download.pytorch.org/whl/cu128"` on the second `uv_pip_install` call, so uv cannot resolver‑upgrade them while pulling in `transformers` and the LTX packages.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally

## Review notes

- Fix is based on reading the failed build log; not re‑verified by building the image end‑to‑end locally. Reviewer should confirm via the randomized example CI (or by manually triggering a build) that the image now installs `torch==2.7.0+cu128` and that the pipeline runs.
- No changes to runtime code or model logic.

Link to Devin session: https://modal.devinenterprise.com/sessions/e866aa38017049798bdcba2447b06324
Requested by: @charlesfrye
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
