### PR TITLE
Fix async usage warning in doc_ocr_webapp

### DIFF
--- a/09_job_queues/doc_ocr_webapp.py
+++ b/09_job_queues/doc_ocr_webapp.py
@@ -69,7 +69,7 @@ async def parse(request: fastapi.Request):
 async def poll_results(call_id: str):
     function_call = modal.functions.FunctionCall.from_id(call_id)
     try:
-        result = function_call.get(timeout=0)
+        result = await function_call.get.aio(timeout=0)
     except TimeoutError:
         return fastapi.responses.JSONResponse(content="", status_code=202)
 


### PR DESCRIPTION
Fixes the `AsyncUsageWarning` emitted when calling `function_call.get(timeout=0)` inside the async `poll_results` endpoint by switching to the async interface `await function_call.get.aio(timeout=0)`.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally

Link to Devin session: https://modal.devinenterprise.com/sessions/78a2e3309a2442bcb0c868f2b8d2f723
Requested by: @freider