### PR TITLE
fix typo in deepgemm-cache path

### DIFF
--- a/06_gpu_and_ml/llm-serving/sglang_kitchen_sink.py
+++ b/06_gpu_and_ml/llm-serving/sglang_kitchen_sink.py
@@ -66,7 +66,7 @@ sglang_image = sglang_image.env(
 # JIT DeepGEMM kernels are on by default, but we explicitly enable them via an environment variable.
 
 DG_CACHE_VOL = modal.Volume.from_name("deepgemm-cache", create_if_missing=True)
-DG_CACHE_PATH = "/root/.cache/deepgemm"
+DG_CACHE_PATH = "/root/.cache/deep_gemm"
 
 sglang_image = sglang_image.env({"SGLANG_ENABLE_JIT_DEEPGEMM": "1"})
 

--- a/06_gpu_and_ml/llm-serving/sglang_low_latency.py
+++ b/06_gpu_and_ml/llm-serving/sglang_low_latency.py
@@ -103,7 +103,7 @@ sglang_image = sglang_image.env(
 # We store these in a Modal Volume as well.
 
 DG_CACHE_VOL = modal.Volume.from_name("deepgemm-cache", create_if_missing=True)
-DG_CACHE_PATH = "/root/.cache/deepgemm"
+DG_CACHE_PATH = "/root/.cache/deep_gemm"
 
 # JIT DeepGEMM kernels are on by default, but we explicitly enable them via an environment variable.
 

--- a/06_gpu_and_ml/llm-serving/sglang_snapshot.py
+++ b/06_gpu_and_ml/llm-serving/sglang_snapshot.py
@@ -119,7 +119,7 @@ sglang_image = sglang_image.env(
 # We store these in a Modal Volume as well.
 
 DG_CACHE_VOL = modal.Volume.from_name("deepgemm-cache", create_if_missing=True)
-DG_CACHE_PATH = "/root/.cache/deepgemm"
+DG_CACHE_PATH = "/root/.cache/deep_gemm"
 
 # JIT DeepGEMM kernels are on by default, but we explicitly enable them via an environment variable.
 

--- a/06_gpu_and_ml/llm-serving/sglang_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sglang_vlm.py
@@ -62,7 +62,7 @@ HF_CACHE_VOL = modal.Volume.from_name("huggingface-cache", create_if_missing=Tru
 HF_CACHE_PATH = "/root/.cache/huggingface"
 
 DG_CACHE_VOL = modal.Volume.from_name("deepgemm-cache", create_if_missing=True)
-DG_CACHE_PATH = "/root/.cache/deepgemm"
+DG_CACHE_PATH = "/root/.cache/deep_gemm"
 
 # We configure the behavior and performance of the weight and compilation
 # caches via environment variables.


### PR DESCRIPTION
`SGLANG_DG_CACHE_DIR = EnvStr(os.path.expanduser("~/.cache/deep_gemm"))`
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->