### PR TITLE
Add PII detection demo with ab-ai/PII-Model-Phi3-Mini

### DIFF
--- a/06_gpu_and_ml/llm-serving/pii_detection.py
+++ b/06_gpu_and_ml/llm-serving/pii_detection.py
@@ -1,0 +1,242 @@
+# ---
+# pytest: false
+# ---
+
+# # Detect PII with a fine-tuned Phi-3 Mini on Modal
+
+# This example shows how to serve
+# [ab-ai/PII-Model-Phi3-Mini](https://huggingface.co/ab-ai/PII-Model-Phi3-Mini)
+# on Modal for detecting personally identifiable information (PII) in text.
+
+# The model is a fine-tuned version of
+# [Phi-3 Mini](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct)
+# trained to recognize 50+ PII entity types including names, emails, SSNs,
+# credit card numbers, addresses, and more.
+# Given an input text, it returns a JSON object mapping entity types to their detected values.
+
+# We serve it with [vLLM](https://docs.vllm.ai/) behind an OpenAI-compatible API
+# and include a `local_entrypoint` for quick testing from the command line.
+
+# ## Set up the container image
+
+# vLLM can be installed with `uv pip`
+# since Modal [provides the CUDA drivers](https://modal.com/docs/guide/cuda).
+# The model requires `trust_remote_code`, so we also install a compatible
+# version of `transformers`.
+
+import json
+from typing import Any
+
+import aiohttp
+import modal
+
+vllm_image = (
+    modal.Image.from_registry("nvidia/cuda:12.8.1-devel-ubuntu22.04", add_python="3.12")
+    .entrypoint([])
+    .uv_pip_install(
+        "vllm==0.19.0",
+        "transformers>=4.51",
+    )
+)
+
+# ## Configure the model
+
+# The PII model is ~4B parameters (BF16), so it fits comfortably on a single T4 GPU.
+# We cache the model weights in a [Modal Volume](https://modal.com/docs/guide/volumes)
+# to avoid re-downloading them on each cold start.
+
+MODEL_NAME = "ab-ai/PII-Model-Phi3-Mini"
+
+hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
+vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
+
+# ## The PII detection prompt
+
+# The model was fine-tuned with a specific prompt structure
+# that lists all 50+ detectable entity types and asks for JSON output.
+
+PII_ENTITIES = ", ".join(
+    [
+        "companyname",
+        "pin",
+        "currencyname",
+        "email",
+        "phoneimei",
+        "litecoinaddress",
+        "currency",
+        "eyecolor",
+        "street",
+        "mac",
+        "state",
+        "time",
+        "vehiclevin",
+        "jobarea",
+        "date",
+        "bic",
+        "currencysymbol",
+        "currencycode",
+        "age",
+        "nearbygpscoordinate",
+        "amount",
+        "ssn",
+        "ethereumaddress",
+        "zipcode",
+        "buildingnumber",
+        "dob",
+        "firstname",
+        "middlename",
+        "ordinaldirection",
+        "jobtitle",
+        "bitcoinaddress",
+        "jobtype",
+        "phonenumber",
+        "height",
+        "password",
+        "ip",
+        "useragent",
+        "accountname",
+        "city",
+        "gender",
+        "secondaryaddress",
+        "iban",
+        "sex",
+        "prefix",
+        "ipv4",
+        "maskednumber",
+        "url",
+        "username",
+        "lastname",
+        "creditcardcvv",
+        "county",
+        "vehiclevrm",
+        "ipv6",
+        "creditcardissuer",
+        "accountnumber",
+        "creditcardnumber",
+    ]
+)
+
+SYSTEM_PROMPT = (
+    "### Instruction:\n\n"
+    "Identify and extract the following PII entities from the text, "
+    f"if present: {PII_ENTITIES}. Return the output in JSON format."
+)
+
+
+def build_pii_prompt(text: str) -> str:
+    """Format input text into the model's expected prompt structure."""
+    return f"{SYSTEM_PROMPT}\n\n### Input:\n{text}\n\n### Output:\n"
+
+
+# ## Serve the model
+
+# We use [`@modal.web_server`](https://modal.com/docs/guide/webhooks#non-asgi-web-servers)
+# to expose vLLM's OpenAI-compatible API on the internet.
+
+app = modal.App("example-pii-detection")
+
+MINUTES = 60
+VLLM_PORT = 8000
+
+
+@app.function(
+    image=vllm_image,
+    gpu="T4",
+    scaledown_window=5 * MINUTES,
+    timeout=10 * MINUTES,
+    volumes={
+        "/root/.cache/huggingface": hf_cache_vol,
+        "/root/.cache/vllm": vllm_cache_vol,
+    },
+)
+@modal.concurrent(max_inputs=10)
+@modal.web_server(port=VLLM_PORT, startup_timeout=5 * MINUTES)
+def serve():
+    import subprocess
+
+    cmd = [
+        "vllm",
+        "serve",
+        MODEL_NAME,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(VLLM_PORT),
+        "--trust-remote-code",
+        "--enforce-eager",
+    ]
+
+    print(*cmd)
+    subprocess.Popen(" ".join(cmd), shell=True)
+
+
+# ## Deploy
+
+# To deploy a persistent API endpoint:
+# ```bash
+# modal deploy pii_detection.py
+# ```
+
+# Once deployed, you can hit the OpenAI-compatible API at the URL printed in the terminal.
+# The model expects a raw text prompt via the `/v1/completions` endpoint
+# (not `/v1/chat/completions`), since the PII prompt format
+# doesn't use chat-style messages.
+
+# ## Test locally
+
+# The `local_entrypoint` spins up a fresh replica on Modal and sends
+# a sample PII detection request from your local machine:
+# ```bash
+# modal run pii_detection.py
+# ```
+
+# You can also pass custom text:
+# ```bash
+# modal run pii_detection.py --text "Call John Smith at john@example.com"
+# ```
+
+SAMPLE_TEXT = (
+    "Hi Abner, just a reminder that your next primary care appointment "
+    "is on 23/03/1926. Please confirm by replying to this email "
+    "Nathen15@hotmail.com or call 555-123-4567."
+)
+
+
+@app.local_entrypoint()
+async def main(text: str = SAMPLE_TEXT, test_timeout: int = 10 * MINUTES):
+    url = await serve.get_web_url.aio()
+
+    prompt = build_pii_prompt(text)
+
+    async with aiohttp.ClientSession(base_url=url) as session:
+        print(f"Checking server health at {url} ...")
+        async with session.get(
+            "/health", timeout=aiohttp.ClientTimeout(total=test_timeout)
+        ) as resp:
+            assert resp.status == 200, f"Health check failed: {resp.status}"
+        print("Server is healthy.\n")
+
+        print(f"Detecting PII in:\n  {text}\n")
+
+        payload: dict[str, Any] = {
+            "model": MODEL_NAME,
+            "prompt": prompt,
+            "max_tokens": 256,
+            "temperature": 0.1,
+        }
+
+        async with session.post(
+            "/v1/completions",
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        ) as resp:
+            resp.raise_for_status()
+            result = await resp.json()
+
+        output = result["choices"][0]["text"]
+        print("Detected PII:")
+        try:
+            parsed = json.loads(output)
+            print(json.dumps(parsed, indent=2))
+        except json.JSONDecodeError:
+            print(output)


### PR DESCRIPTION
Adds a new example showing how to serve [ab-ai/PII-Model-Phi3-Mini](https://huggingface.co/ab-ai/PII-Model-Phi3-Mini) on Modal for detecting personally identifiable information (PII) in text.

The model is a fine-tuned Phi-3 Mini (~4B params) that identifies 50+ PII entity types (names, emails, SSNs, credit cards, addresses, etc.) and returns structured JSON output.

The demo includes:
- **Web endpoint**: vLLM serving behind an OpenAI-compatible API via `@modal.web_server`
- **Local entrypoint**: Sends a sample PII detection request via `modal run` for quick testing
- Proper prompt formatting matching the model's expected `### Instruction / ### Input / ### Output` structure
- HuggingFace cache volume for fast cold starts

## Type of Change

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)

## Monitoring Checklist

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [x] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

Link to Devin session: https://modal.devinenterprise.com/sessions/127382c2f2524e00a7ed2345420651c6
Requested by: @zhang-lucy
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->