### PR TITLE
extend timeouts

### DIFF
--- a/.github/workflows/build-and-run-example.yml
+++ b/.github/workflows/build-and-run-example.yml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Run a random example with MODAL_IGNORE_CACHE set
         run: |
-          MODAL_IGNORE_CACHE=1 python3 -m internal.run_example --timeout 1800
+          MODAL_IGNORE_CACHE=1 python3 -m internal.run_example --timeout 3600

--- a/internal/run_example.py
+++ b/internal/run_example.py
@@ -8,6 +8,9 @@ import time
 from . import utils
 
 MINUTES = 60
+# NB: Max runtime for AWS Lambda is 15 minutes.
+# Asynchronous monitoring is managed by Lambda, so max timeout here is limited.
+# ref: https://docs.aws.amazon.com/lambda/latest/dg/configuration-timeout.html
 DEFAULT_TIMEOUT = 14 * MINUTES
 
 

--- a/internal/run_example.py
+++ b/internal/run_example.py
@@ -8,7 +8,7 @@ import time
 from . import utils
 
 MINUTES = 60
-DEFAULT_TIMEOUT = 12 * MINUTES
+DEFAULT_TIMEOUT = 14 * MINUTES
 
 
 def run_script(example, timeout=DEFAULT_TIMEOUT):


### PR DESCRIPTION
This PR extends the default timeout for examples to the maximum allowed in the synmon system and extends the timeout for builds.

We have some longer-running examples that serve big MoEs. These often have very expensive image builds (~10min) and expensive JIT compilation steps. We have a few threads of work that can speed up these boots, but in the interim we want to extend our timeouts.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->