### PR TITLE
sandboxes/sandbox_pool: fix healthy sandbox incorrectly terminated during pool maintenance

### DIFF
--- a/13_sandboxes/sandbox_pool.py
+++ b/13_sandboxes/sandbox_pool.py
@@ -254,9 +254,8 @@ def maintain_pool():
             to_terminate.append(sr.id)
             continue
 
-        # Found first good sandbox, but don't put it back in the queue to preserve
-        # queue ordering.
-        to_terminate.append(sr.id)
+        # Found first good sandbox; put it back to keep it available for claiming.
+        pool_queue.put(sr)
         break
 
     if to_terminate:


### PR DESCRIPTION
During pool maintenance, `maintain_pool()` drains the queue to remove expiring
or unhealthy sandboxes. When it encounters the first healthy sandbox, it should
stop draining and return that sandbox to the queue — but instead it was
appending the healthy sandbox's ID to `to_terminate`, causing it to be killed
along with the bad ones.

This replaces `to_terminate.append(sr.id)` with `pool_queue.put(sr)` at the
point where the first good sandbox is found, so healthy sandboxes survive
maintenance runs.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Monitoring Checklist

- [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
  - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
  - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`)
  - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally

## Documentation Site Checklist

N/A — this is a bug fix to an existing example, not a new documentation page.

## Outside Contributors

Happy to adjust anything based on reviewer feedback. Thanks for maintaining this repo!
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->