### PR TITLE
update links to quant.exposed now that it's in llm-almanac

### DIFF
--- a/06_gpu_and_ml/llm-serving/nemotron_inference.py
+++ b/06_gpu_and_ml/llm-serving/nemotron_inference.py
@@ -49,7 +49,7 @@ sglang_image = modal.Image.from_registry("lmsysorg/sglang:v0.5.9").entrypoint(
 # We also choose a [GPU](https://modal.com/docs/guide/gpu) to deploy our inference server onto.
 # We choose the [B200 GPU](https://modal.com/blog/introducing-b200),
 # which offers excellent price-performance
-# and supports both 8 bit and 4 bit [quantized floating point](https://quant.exposed)
+# and supports both 8 bit and 4 bit [quantized floating point](https://modal.com/llm-almanac/quant-formats)
 # operations.
 
 GPU_TYPE, N_GPUS = "B200", 1
@@ -59,7 +59,7 @@ GPU = f"{GPU_TYPE}:{N_GPUS}"
 
 # We'll serve [NVIDIA's Nemotron 3 Super](https://arxiv.org/abs/2512.20856).
 # For lower latency, we pick the intermediate-sized model (120B params)
-# quantized to [lower precision floating point](https://quant.exposed).
+# quantized to [lower precision floating point](https://modal.com/llm-almanac/quant-formats).
 # This reduces the amount of data that needs to be loaded
 # [from GPU RAM into SM SRAM](https://modal.com/gpu-glossary/perf/memory-bandwidth)
 # in each forward pass.

--- a/06_gpu_and_ml/llm-serving/sglang_low_latency.py
+++ b/06_gpu_and_ml/llm-serving/sglang_low_latency.py
@@ -42,7 +42,7 @@ sglang_image = modal.Image.from_registry(
 # We also choose a [GPU](https://modal.com/docs/guide/gpu) to deploy our inference server onto.
 # We choose the [H100 GPU](https://modal.com/blog/introducing-h100),
 # which offers excellent price-performance
-# and supports [8bit floating point operations](https://quant.exposed), which are the
+# and supports [8bit floating point operations](https://modal.com/llm-almanac/quant-formats), which are the
 # lowest precision well-supported in the relevant [GPU kernels](https://modal.com/gpu-glossary/device-software/kernel)
 # across a variety of model architectures.
 

--- a/06_gpu_and_ml/llm-serving/sglang_vlm.py
+++ b/06_gpu_and_ml/llm-serving/sglang_vlm.py
@@ -37,7 +37,7 @@ sglang_image = modal.Image.from_registry(
 # [Qwen3.6-35B-A3B-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8)
 # is a vision-language reasoning foundational model with 35B total parameters,
 # of which only 3B are activated per input sequence per forward pass.
-# We use the [8bit quantized floating point](https://quant.exposed)
+# We use the [8bit quantized floating point](https://modal.com/llm-almanac/quant-formats)
 # version of the model for faster [cold starts](https://modal.com/docs/guide/cold-start)
 # and faster inference with negligible behavior differences.
 

--- a/06_gpu_and_ml/llm-serving/very_large_models.py
+++ b/06_gpu_and_ml/llm-serving/very_large_models.py
@@ -100,7 +100,8 @@ def download_model(repo_id, revision=None):
 
 # To run the function, we need to pick a specific model to download.
 # We'll use Z.ai's GLM 4.7 in eight bit
-# [floating point quantization](https://modal.com/llm-almanac/quant-formats/)
+# [floating point quantization](https://modal.com/llm-almanac/quant-formats).
+
 # This model takes about thirty minutes to an hour to download from Hugging Face.
 
 REPO_ID = "zai-org/GLM-4.7-FP8"

--- a/06_gpu_and_ml/llm-serving/very_large_models.py
+++ b/06_gpu_and_ml/llm-serving/very_large_models.py
@@ -100,7 +100,7 @@ def download_model(repo_id, revision=None):
 
 # To run the function, we need to pick a specific model to download.
 # We'll use Z.ai's GLM 4.7 in eight bit
-# [floating point quantization](https://quant.exposed).
+# [floating point quantization](https://modal.com/llm-almanac/quant-formats/)
 # This model takes about thirty minutes to an hour to download from Hugging Face.
 
 REPO_ID = "zai-org/GLM-4.7-FP8"


### PR DESCRIPTION
We recently migrated quant.exposed into the LLM Engineer's Almanac. I added a redirect, but we should keep our docs up to date.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->