### PR TITLE
Add Modal Notebook link to sandbox_agent.py example

### DIFF
--- a/13_sandboxes/sandbox_agent.py
+++ b/13_sandboxes/sandbox_agent.py
@@ -10,7 +10,7 @@
 # The Sandbox provides an isolated environment where the agent can safely execute code
 # and examine files.
 
-# You can also run this in a [Modal Notebook](https://modal.com/notebooks/modal-labs/_/nb-30WInxiigR3Wc8kQ3jU7Hr).
+# You can also run this in a [Modal Notebook](https://modal.com/notebooks/modal-labs/_/nb-30WInxiigR3Wc8kQ3jU7Hr)!
 
 import modal
 from modal.container_process import ContainerProcess

--- a/13_sandboxes/sandbox_agent.py
+++ b/13_sandboxes/sandbox_agent.py
@@ -10,6 +10,8 @@
 # The Sandbox provides an isolated environment where the agent can safely execute code
 # and examine files.
 
+# You can also run this in a [Modal Notebook](https://modal.com/notebooks/modal-labs/_/nb-30WInxiigR3Wc8kQ3jU7Hr).
+
 import modal
 from modal.container_process import ContainerProcess
 


### PR DESCRIPTION
Adds a second paragraph after the intro in `sandbox_agent.py` linking to the corresponding Modal Notebook for the Claude Code Sandbox example.

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)


Link to Devin session: https://modal.devinenterprise.com/sessions/f1a260214c4744e8a8c9b65f9258cfaa
Requested by: @zhang-lucy
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->