### PR TITLE
internal/deploy: fix incorrect cwd when deploying example modules

### DIFF
--- a/internal/deploy.py
+++ b/internal/deploy.py
@@ -82,7 +82,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     results = [
         deploy(
             deployable=bool(ex_mod.metadata.get("deploy")),
-            module_with_app=Path(ex_mod.module),
+            module_with_app=Path(ex_mod.filename),
             dry_run=arguments.dry_run,
             filter_pttrn=filter_pttrn,
             env=ex_mod.metadata.get("env"),

--- a/internal/deploy.py
+++ b/internal/deploy.py
@@ -30,7 +30,7 @@ def deploy(
         print(f"⏩ skipping: '{module_with_app.name}' is not marked for deploy")
         return None
 
-    deploy_command = f"modal deploy -m {module_with_app.name}"
+    deploy_command = f"modal deploy -m {module_with_app.stem}"
     if dry_run:
         print(f"🌵  dry-run: '{module_with_app.name}' would have deployed")
     else:

--- a/internal/test_deploy.py
+++ b/internal/test_deploy.py
@@ -1,0 +1,87 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import deploy as dep
+
+
+class FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_deploy_uses_correct_cwd(monkeypatch):
+    """deploy() must set cwd to the example file's parent directory, not '.'."""
+    captured = {}
+
+    def fake_run(args, cwd, capture_output, env):
+        captured["cwd"] = cwd
+        return FakeCompletedProcess(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    example_file = Path("/repo/06_gpu_and_ml/text_to_speech.py")
+    dep.deploy(
+        deployable=True,
+        module_with_app=example_file,
+        dry_run=False,
+        filter_pttrn=None,
+        env={},
+    )
+
+    assert captured["cwd"] == Path("/repo/06_gpu_and_ml"), (
+        f"Expected cwd to be the example's directory, got {captured['cwd']!r}"
+    )
+
+
+def test_deploy_uses_stem_for_module_flag(monkeypatch):
+    """deploy() must pass the file stem (no extension) to 'modal deploy -m'."""
+    captured = {}
+
+    def fake_run(args, cwd, capture_output, env):
+        captured["args"] = args
+        return FakeCompletedProcess(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    example_file = Path("/repo/06_gpu_and_ml/text_to_speech.py")
+    dep.deploy(
+        deployable=True,
+        module_with_app=example_file,
+        dry_run=False,
+        filter_pttrn=None,
+        env={},
+    )
+
+    assert "text_to_speech" in captured["args"], (
+        "Expected module stem in deploy args"
+    )
+    assert "text_to_speech.py" not in captured["args"], (
+        "File extension must not appear in deploy -m argument"
+    )
+
+
+def test_deploy_skips_non_deployable(monkeypatch):
+    """deploy() returns None immediately when deployable=False."""
+    called = []
+
+    def fake_run(*args, **kwargs):
+        called.append(True)
+        return FakeCompletedProcess()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = dep.deploy(
+        deployable=False,
+        module_with_app=Path("/repo/06_gpu_and_ml/text_to_speech.py"),
+        dry_run=False,
+        filter_pttrn=None,
+        env={},
+    )
+
+    assert result is None
+    assert not called, "subprocess.run must not be called for non-deployable examples"


### PR DESCRIPTION
`deploy.py` passed `Path(ex_mod.module)` to the `deploy()` function, where
`ex_mod.module` is a dotted Python import path like `06_gpu_and_ml.text_to_speech`.
Wrapping that in `Path(...)` means `.parent` resolves to `.` (the current working
directory) instead of the actual example subdirectory. As a result, `subprocess.run`
was executing `modal deploy` from the wrong directory, which would cause Modal to
fail to resolve the module.

**Fix:** pass `Path(ex_mod.filename)` instead, so `.parent` correctly points to the
example's subdirectory, and use `.stem` for the `-m` flag so the extension is stripped.

Added `internal/test_deploy.py` with three tests that cover the corrected `cwd`,
the correct module flag, and the no-op path for non-deployable examples.

## Type of Change

- [x] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

N/A — this change is to `internal/deploy.py`, not to any example.

## Documentation Site Checklist

N/A — no example files were added or modified.

## Outside Contributors

You're great! Thanks for your contribution.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->