### PR TITLE
Shababo/esmfoldw esmc binder design

### DIFF
--- a/06_gpu_and_ml/binder-design/binder_design/__init__.py
+++ b/06_gpu_and_ml/binder-design/binder_design/__init__.py
@@ -1,0 +1,43 @@
+"""Helper package for the ``esmfold2_binder_design`` example.
+
+Contains the heavy lifting (model loading, prompt factories, target sequences,
+loss/score functions, the gradient-guided binder optimization loop, and the
+``ESMFold2Designer`` orchestration class) that would otherwise clutter the
+example page rendered from ``esmfold2_binder_design.py``.
+
+All top-level imports across this package assume the
+``example-esmfold2-binder-design`` Modal Image is active; modules here are
+only ever imported from inside its container.
+
+Submodule layout:
+
+- ``constants``: token tables and design-loop hyperparameters.
+- ``prompts``: ``PromptFactory``, the bundled binder templates, and target sequences.
+- ``losses``: structure losses, distogram iPTM proxy, and ESMC pseudoperplexity.
+- ``folding``: ESMFold2 input prep, forward pass, and ``ProteinComplex`` reconstruction.
+- ``design``: the gradient-guided ``design_binder`` loop and its tensor primitives.
+- ``models``: HF model loading and the ``ESMFold2Designer`` orchestrator.
+
+The canonical reference for the algorithms is
+[Language Modeling Materializes a World Model of Protein Biology]
+(https://biohub.ai/papers/esm_protein.pdf).
+"""
+
+# ---
+# lambda-test: false  # auxiliary helper package
+# ---
+
+import logging
+
+import torch
+
+# Required for `torch.use_deterministic_algorithms(True)`; matches the
+# `CUBLAS_WORKSPACE_CONFIG=:4096:8` env var set in the example's Modal Image.
+torch.use_deterministic_algorithms(True)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logging.getLogger("binder_design").setLevel(logging.INFO)
+
+from .models import ESMFold2Designer  # noqa: E402
+
+__all__ = ["ESMFold2Designer"]

--- a/06_gpu_and_ml/binder-design/binder_design/constants.py
+++ b/06_gpu_and_ml/binder-design/binder_design/constants.py
@@ -1,0 +1,44 @@
+"""Token tables, element tables, and design-loop hyperparameters."""
+
+import logging
+
+from esm.models.esmfold2 import ELEMENT_NUMBER_TO_SYMBOL
+from esm.models.esmfold2.constants import PROTEIN_1TO3, RES_TYPE_TO_CCD
+
+logger = logging.getLogger("binder_design")
+
+
+# ---- Token / element tables ----
+
+TOKENS = ["<pad>", "-"] + [RES_TYPE_TO_CCD[i] for i in range(2, 33)]
+
+ELEMENTS = ["X"] * (max(ELEMENT_NUMBER_TO_SYMBOL) + 1)
+ELEMENTS[0] = "<pad>"
+for _atomic_num, _symbol in ELEMENT_NUMBER_TO_SYMBOL.items():
+    ELEMENTS[_atomic_num] = _symbol[:1] + _symbol[1:].lower()
+
+TOKEN_IDS = {token: idx for idx, token in enumerate(TOKENS)}
+
+AA_DIMS = 20
+# Cysteine index in the 20-dim AA space (TOKEN_IDS are offset by 2 for <pad> and -).
+CYS_IDX = TOKEN_IDS[PROTEIN_1TO3["C"]] - 2
+
+# Marker character used inside binder prompt strings for "this position is mutable".
+MUTABLE_TOKEN = "#"
+
+
+# ---- Design-loop hyperparameters ----
+
+LOSS_WEIGHTS = {"intra_contact": 0.5, "inter_contact": 0.5, "glob": 0.2}
+STEPS = 10
+LOG_INTERVAL = 5
+LEARNING_RATE = 0.1
+TEMPERATURE_MIN = 1e-2
+ESMC_MASK_FRACTION = 0.15
+CHECKPOINT_LM = False
+COMPILE = False
+# NOTE - This significantly reduces VRAM usage.
+# On config (target_name="cd45", binder_name="trastuzumab_framework_vhvl", batch_size=1)
+# this reduces VRAM from 51GB -> 27GB and enables increasing batch size up to 6.
+# We are testing this setting in silico, and may change the default to True in the future.
+REUSE_ESMC = False

--- a/06_gpu_and_ml/binder-design/binder_design/design.py
+++ b/06_gpu_and_ml/binder-design/binder_design/design.py
@@ -1,0 +1,316 @@
+"""Gradient-guided binder sequence optimization.
+
+`design_binder` is the entry point: given pre-loaded ESMFold2 inversion models,
+HF critic models, and an ESMC LM, plus a target/binder spec, it runs the
+gradient-descent loop from Algorithm 11 of the ESM protein paper and scores
+the best per-batch sequences with each critic.
+
+The smaller helpers in this module (`build_initial_soft_sequence_logits`,
+`build_gradient_mask`, `normalized_gradient_tensor`, `sequence_to_one_hot`)
+are sequence/gradient setup primitives that are tightly bound to the loop and
+not used elsewhere.
+"""
+
+import math
+import random
+
+import torch
+import torch.nn.functional as F
+import torch.optim as optim
+from esm.models.esmfold2.constants import PROTEIN_1TO3
+from transformers.models.esmc.modeling_esmc import ESMCForMaskedLM
+from transformers.models.esmfold2.modeling_esmfold2_common import (
+    _seed_context as seed_context,
+)
+from transformers.models.esmfold2.modeling_esmfold2_experimental import (
+    ESMFold2ExperimentalModel,
+)
+
+from .constants import (
+    AA_DIMS,
+    CYS_IDX,
+    LEARNING_RATE,
+    LOG_INTERVAL,
+    MUTABLE_TOKEN,
+    STEPS,
+    TEMPERATURE_MIN,
+    TOKEN_IDS,
+    TOKENS,
+    logger,
+)
+from .folding import build_complex, fold_and_get_distogram
+from .losses import (
+    compute_distogram_iptm_proxy,
+    compute_esmc_pseudoperplexity_nll,
+    compute_structure_losses,
+)
+from .prompts import BINDER_PROMPT_FACTORIES, TARGET_SEQUENCES
+
+# ---- Sequence / gradient setup ----
+
+
+def sequence_to_one_hot(sequence: str, device="cuda") -> torch.Tensor:
+    """Convert an amino-acid sequence to a one-hot tensor [1, L, num_tokens]."""
+    const_dict = {token: i for i, token in enumerate(TOKENS)}
+    target_index = [const_dict[PROTEIN_1TO3[letter]] for letter in sequence]
+    one_hot = F.one_hot(torch.tensor(target_index), num_classes=len(TOKENS))
+    return one_hot.to(device).unsqueeze(0).float()
+
+
+def build_initial_soft_sequence_logits(sequence: str, batch_size: int) -> torch.Tensor:
+    """Initial logits with high confidence at fixed positions, ~0 at mutable positions, -1e6 at cysteines."""
+    if all(aa == MUTABLE_TOKEN for aa in sequence):
+        logits = 0.01 * torch.randn([batch_size, len(sequence), AA_DIMS])
+        logits[:, :, CYS_IDX] = -1e6  # remove cysteines
+    else:
+        logits = torch.zeros([batch_size, len(sequence), AA_DIMS])
+        for i, aa in enumerate(sequence):
+            if aa == MUTABLE_TOKEN:  # mutable position - random
+                logits[:, i, :] = 0.01 * torch.randn(batch_size, AA_DIMS)
+                logits[:, i, CYS_IDX] = -1e6
+            else:  # fixed position
+                assert aa in PROTEIN_1TO3, aa
+                token_id = TOKEN_IDS[PROTEIN_1TO3[aa]]
+                logits[:, i, token_id - 2] = 10.0
+
+    return logits.requires_grad_(True)
+
+
+def build_gradient_mask(sequence: str, batch_size: int) -> torch.Tensor:
+    """Per-position [B, L, V] gradient mask: 1 only at non-cysteine, mutable positions."""
+    mask = torch.ones([batch_size, len(sequence), AA_DIMS])
+    fixed_positions = [i for i, aa in enumerate(sequence) if aa != MUTABLE_TOKEN]
+    mask[:, fixed_positions, :] = 0.0
+    mask[:, :, CYS_IDX] = 0.0
+    return mask
+
+
+def normalized_gradient_tensor(
+    grad: torch.Tensor, gradient_mask: torch.Tensor
+) -> torch.Tensor:
+    masked_grad = grad * gradient_mask
+    index_has_nonzero_grad = torch.square(masked_grad).sum(-1) > 0  # (B, L)
+    eff_L = index_has_nonzero_grad.sum(-1)  # (B,)
+    grad_norm = torch.linalg.norm(masked_grad, axis=(-1, -2))  # (B,)
+    normalized_grad = (masked_grad / (grad_norm[:, None, None] + 1e-7)) * torch.sqrt(
+        eff_L[:, None, None]
+    )
+    return normalized_grad * gradient_mask
+
+
+# ---- Optimization loop ----
+
+
+def design_binder(
+    inversion_models: dict[str, ESMFold2ExperimentalModel],
+    hf_critic_models: dict[str, ESMFold2ExperimentalModel],
+    esmc_model: ESMCForMaskedLM,
+    target_name: str | None,
+    target_sequence: str | None,
+    binder_name: str | None,
+    binder_sequence: str | None,
+    is_antibody: bool | None,
+    seed: int,
+    batch_size: int = 1,
+) -> tuple[list[str], dict[int, dict[str, torch.Tensor]], list[dict]]:
+    """Algorithm 11 Gradient-Guided Binder Sequence Optimization.
+
+    Run the full optimization loop. Returns (best_sequences, trajectory, critic_results).
+
+    Every critic is folded once on the best designed sequence via HF ESMFold2.
+    Hero critics expose iPTM; scaling critics contribute distogram scores only.
+    `distogram_binding_confidence` / `cdr_distogram_binding_confidence` come from
+    the distogram in all cases.
+    """
+    assert (target_name is None) ^ (target_sequence is None), (
+        "Provide either target name or sequence."
+    )
+    assert (binder_name is None) ^ (binder_sequence is None), (
+        "Provide either binder name or sequence."
+    )
+
+    device = "cuda"
+    if target_name is not None:
+        target_sequence = TARGET_SEQUENCES[target_name]
+    else:
+        assert target_sequence is not None
+    target_one_hot = sequence_to_one_hot(target_sequence, device=device)
+
+    if binder_name is None:
+        assert binder_sequence is not None
+        # If no binder_name and is_antibody is not specified, assume False.
+        if is_antibody is None:
+            is_antibody = False
+    else:
+        binder_prompt_factor = BINDER_PROMPT_FACTORIES[binder_name]
+        if is_antibody is not None:
+            assert binder_prompt_factor.is_antibody == is_antibody, (
+                "Conflict in is_antibody settings."
+            )
+        is_antibody = binder_prompt_factor.is_antibody
+        binder_sequence = binder_prompt_factor.sample(seed=seed)
+
+    binder_length = len(binder_sequence)
+
+    # By default, we only support single binder and target chains.
+    # To support multi-chain cases, remove the asserts below and check that losses
+    # and selection metrics are appropriate for your setup.
+    assert "|" not in target_sequence
+    assert "|" not in binder_sequence
+
+    with seed_context(seed), torch.device(device):
+        logits = build_initial_soft_sequence_logits(
+            binder_sequence, batch_size=batch_size
+        )
+        gradient_mask = build_gradient_mask(binder_sequence, batch_size=batch_size)
+
+    # step -> {loss_name: [B] tensor on CPU}
+    trajectory: dict[int, dict[str, torch.Tensor]] = {}
+    global_step = 0
+
+    def run_step(
+        logits: torch.Tensor,
+        optimizer: optim.Optimizer,
+        temperature: float,
+        calculate_confidence: bool,
+    ) -> tuple[torch.Tensor, list[str], list[float] | None]:
+        nonlocal global_step
+        optimizer.zero_grad()
+
+        random.seed(seed + global_step)
+        replicate_choice = random.randint(0, len(inversion_models) - 1)
+        inversion_model = list(inversion_models.values())[replicate_choice]
+        design = F.softmax(logits / temperature, dim=-1)
+
+        fold_result = fold_and_get_distogram(
+            inversion_model,
+            target_sequence,
+            target_one_hot,
+            design,
+            num_loops=1,
+            num_sampling_steps=50 if calculate_confidence else 1,
+            calculate_confidence=calculate_confidence,
+            seed=seed + global_step,
+        )
+        sequences: list[str] = fold_result["seq_list"]
+        losses = compute_structure_losses(
+            fold_result["distogram_logits"], binder_length
+        )
+        structure_loss = losses["total_loss"]
+        structure_grad = torch.autograd.grad(structure_loss.mean(), logits)[0]
+
+        # Recompute the logits -> design transform for a fresh graph.
+        design = F.softmax(logits / temperature, dim=-1)
+        score_mask = gradient_mask.sum(dim=-1) > 0
+        with seed_context(seed + global_step):
+            plm_loss = compute_esmc_pseudoperplexity_nll(
+                esmc_model=esmc_model,
+                binder_design=design,
+                score_mask=score_mask,
+                batch_size=4,
+                n_passes=4,
+            )
+        plm_grad = torch.autograd.grad(plm_loss.mean(), logits)[0]
+
+        logits.grad = normalized_gradient_tensor(structure_grad, gradient_mask) + (
+            0.05 if is_antibody else 0.15
+        ) * normalized_gradient_tensor(plm_grad, gradient_mask)
+
+        for g in optimizer.param_groups:
+            g["lr"] = LEARNING_RATE * temperature
+
+        optimizer.step()
+
+        step = global_step
+        step_losses = {k: v.detach().cpu() for k, v in losses.items()}
+        step_losses["plm_loss"] = plm_loss.detach().cpu()
+        step_losses["total_loss"] = (structure_loss + plm_loss).detach().cpu()
+        trajectory[step] = step_losses
+        loss_str = "  ".join(
+            f"{k}={v.mean().item():.4f}" for k, v in step_losses.items()
+        )
+        if step % LOG_INTERVAL == 0:
+            logger.info(f"  step {step:3d}  |  {loss_str}  T={temperature:.4f}")
+        global_step += 1
+        return logits, sequences, fold_result.get("iptm", None)
+
+    optimizer = optim.SGD([logits], lr=LEARNING_RATE)
+    best_iptm: list[float] = [-1.0] * batch_size
+    best_sequences: list[str] = [""] * batch_size
+    for step in range(STEPS):
+        # Cosine schedule
+        t = (step + 1) / STEPS
+        remaining = 0.5 * (1 + math.cos(math.pi * t))
+        temperature = TEMPERATURE_MIN + (1 - TEMPERATURE_MIN) * remaining
+        logits, sequences, iptm = run_step(
+            logits,
+            optimizer,
+            temperature=temperature,
+            calculate_confidence=temperature < 0.05,
+        )
+        if iptm is not None:
+            for b in range(batch_size):
+                if iptm[b] is not None and iptm[b] > best_iptm[b]:
+                    best_iptm[b] = iptm[b]
+                    best_sequences[b] = sequences[b]
+    assert all(seq != "" for seq in best_sequences)
+
+    # Score every batch index against every critic.
+    critic_results: list[dict] = []
+    target_length = len(target_sequence.replace("|", ""))
+    for batch_idx in range(batch_size):
+        best_seq = best_sequences[batch_idx]
+        binder_seq = best_seq.split("|")[-1]
+        binder_design = sequence_to_one_hot(binder_seq)[..., 2:22]
+        for critic_name, critic_model in hf_critic_models.items():
+            is_scaling_critic = "ESMFold2-Experimental-Fast-base" in critic_name
+            if is_scaling_critic:
+                critic_model.cuda()
+            final_fold = fold_and_get_distogram(
+                critic_model,
+                target_sequence,
+                target_one_hot,
+                binder_design,
+                num_loops=3,
+                num_sampling_steps=200,
+                calculate_confidence=True,
+                seed=seed,
+            )
+            if is_scaling_critic:
+                critic_model.cpu()
+            pred_complex = build_complex(final_fold["inputs"], final_fold["output"])
+            iptm_proxy_scores = compute_distogram_iptm_proxy(
+                final_fold["distogram_logits"], target_length, binder_seq, is_antibody
+            )
+            iptm = final_fold["iptm"].item() if final_fold["iptm"] is not None else None
+            critic_results.append(
+                {
+                    "is_antibody": is_antibody,
+                    "critic_name": critic_name,
+                    "batch_idx": batch_idx,
+                    "designed_sequence": best_seq,
+                    "complex": pred_complex,
+                    "final_loss": trajectory[global_step - 1]["total_loss"][
+                        batch_idx
+                    ].item(),
+                    "iptm": iptm,
+                    "logits": logits[batch_idx].detach().cpu(),
+                    **iptm_proxy_scores,
+                }
+            )
+
+    if not critic_results:
+        for batch_idx in range(batch_size):
+            critic_results.append(
+                {
+                    "is_antibody": is_antibody,
+                    "batch_idx": batch_idx,
+                    "designed_sequence": best_sequences[batch_idx],
+                    "final_loss": trajectory[global_step - 1]["total_loss"][
+                        batch_idx
+                    ].item(),
+                    "logits": logits[batch_idx].detach().cpu(),
+                }
+            )
+
+    return best_sequences, trajectory, critic_results

--- a/06_gpu_and_ml/binder-design/binder_design/folding.py
+++ b/06_gpu_and_ml/binder-design/binder_design/folding.py
@@ -1,0 +1,243 @@
+"""Structure-prediction glue: feature prep, ESMFold2 forward pass, and complex reconstruction.
+
+`fold_and_get_distogram` is the central call. Given a target sequence and a
+soft binder design, it stitches together a target|binder `StructurePredictionInput`,
+runs the ESMFold2 model, and returns the distogram logits used by the design
+losses (plus optional iPTM / pTM / pLDDT confidence scores when requested).
+
+`build_complex` and its helpers convert the model's atom-coordinate output back
+into an `esm.ProteinComplex` for downstream visualisation / serialisation.
+"""
+
+import string
+from functools import cache
+from typing import Any
+
+import biotite.structure
+import numpy as np
+import torch
+import torch.nn.functional as F
+from esm.models.esmfold2 import (
+    ProteinInput,
+    StructurePredictionInput,
+    load_ccd,
+    prepare_esmfold2_input,
+)
+from esm.models.esmfold2.constants import MOL_TYPE_NONPOLYMER, PROTEIN_3TO1
+from esm.utils.structure.protein_chain import ProteinChain
+from esm.utils.structure.protein_complex import ProteinComplex
+from transformers.models.esmfold2.modeling_esmfold2_common import (
+    _seed_context as seed_context,
+)
+from transformers.models.esmfold2.modeling_esmfold2_experimental import (
+    ESMFold2ExperimentalModel,
+)
+
+from .constants import ELEMENTS, TOKENS
+
+# ---- Feature preparation ----
+
+
+def _resize_tensor(tensor: torch.Tensor, *, dim: int, size: int) -> torch.Tensor:
+    current = tensor.shape[dim]
+    if current >= size:
+        return tensor.narrow(dim, 0, size)
+
+    pad_shape = list(tensor.shape)
+    pad_shape[dim] = size - current
+    pad = torch.zeros(pad_shape, dtype=tensor.dtype, device=tensor.device)
+    return torch.cat((tensor, pad), dim=dim)
+
+
+_ATOM_FEATURE_DIMS = {
+    "ref_pos": 0,
+    "ref_element": 0,
+    "ref_charge": 0,
+    "ref_atom_name_chars": 0,
+    "ref_space_uid": 0,
+    "atom_attention_mask": 0,
+    "atom_to_token": 0,
+    "is_resolved": 0,
+    "gt_coords": 1,
+}
+
+
+@cache
+def _ensure_ccd_loaded() -> None:
+    load_ccd()
+
+
+def prepare_esmfold2_tensors(
+    input: StructurePredictionInput,
+    max_tokens: int | None = None,
+    max_atoms: int | None = None,
+    max_seqs: int = 16384,
+    pad_to_max_seqs: bool = False,
+    seed: int | None = None,
+    use_vectorized_msa_assembly: bool = True,
+) -> dict[str, torch.Tensor]:
+    del max_tokens, max_seqs, pad_to_max_seqs, use_vectorized_msa_assembly
+    _ensure_ccd_loaded()
+    features, _ = prepare_esmfold2_input(input, seed=seed)
+    if max_atoms is not None:
+        for key, dim in _ATOM_FEATURE_DIMS.items():
+            if key in features:
+                features[key] = _resize_tensor(features[key], dim=dim, size=max_atoms)
+    return features
+
+
+# ---- Folding ----
+
+
+def fold_and_get_distogram(
+    model: ESMFold2ExperimentalModel,
+    target_seq: str,
+    target_one_hot: torch.Tensor,
+    design: torch.Tensor,
+    num_loops: int = 0,
+    num_sampling_steps: int = 1,
+    calculate_confidence: bool = False,
+    seed: int | None = None,
+) -> dict:
+    """Prepare inputs, run model forward, return distogram logits + raw output."""
+    padding = (2, 11)
+    padded_design = F.pad(design, padding, mode="constant", value=0)
+
+    # Argmax to get the designed sequence string.
+    token_lists = torch.argmax(padded_design, dim=-1)
+    designed_seq = [
+        [PROTEIN_3TO1[TOKENS[int(tkn.item())]] for tkn in token_list]
+        for token_list in token_lists
+    ]
+    seq_list = [target_seq + "|" + "".join(seq) for seq in designed_seq]
+    max_atoms = None if len(seq_list) == 1 else ((len(seq_list[0]) - 1) * 14) // 32 * 32
+
+    inputs_list = []
+    for seq in seq_list:
+        sequences = {
+            sequence: [str(idx)] for idx, sequence in enumerate(seq.split("|"))
+        }
+        inputs_raw = StructurePredictionInput(
+            sequences=[
+                ProteinInput(id=chain_id, sequence=sequence, msa=None)
+                for sequence, chain_id in sequences.items()
+            ]
+        )
+        inputs_list.append(prepare_esmfold2_tensors(inputs_raw, max_atoms=max_atoms))
+
+    inputs = {
+        key: torch.stack([inp[key] for inp in inputs_list], dim=0).cuda()
+        for key in inputs_list[0]
+    }
+    inputs["res_type_soft"] = torch.cat(
+        (target_one_hot.repeat(design.size(0), 1, 1), padded_design), dim=1
+    )
+
+    with seed_context(seed):
+        output = model(
+            **inputs,
+            num_diffusion_samples=1,
+            num_sampling_steps=num_sampling_steps,
+            num_loops=num_loops,
+            calculate_confidence=calculate_confidence,
+            seed=seed,
+        )
+
+    result: dict = {
+        "distogram_logits": output["distogram_logits"],
+        "inputs": inputs,
+        "inputs_list": inputs_list,
+        "output": output,
+        "seq_list": seq_list,
+    }
+    if calculate_confidence:
+        result.update(
+            {
+                "ptm": output.get("ptm"),
+                "iptm": output.get("iptm"),
+                "plddt": output.get("plddt"),
+            }
+        )
+    return result
+
+
+# ---- Atom array / ProteinComplex reconstruction ----
+
+
+_CHAIN_ID_ALPHABET = string.ascii_uppercase + string.ascii_lowercase + string.digits
+
+
+def _asym_id_to_chain_label(asym_id: int) -> str:
+    if asym_id < 0:
+        raise ValueError(f"asym_id must be >= 0, got {asym_id}")
+    label = ""
+    n = len(_CHAIN_ID_ALPHABET)
+    while True:
+        label = _CHAIN_ID_ALPHABET[asym_id % n] + label
+        asym_id = asym_id // n - 1
+        if asym_id < 0:
+            return label
+
+
+def to_atom_array(
+    coords: np.ndarray,
+    atom_to_token: np.ndarray,
+    res_type: np.ndarray,
+    residue_index: np.ndarray,
+    asym_id: np.ndarray,
+    mol_type: np.ndarray,
+    ref_atom_name_chars: np.ndarray,
+    ref_element: np.ndarray,
+    atom_attention_mask: np.ndarray,
+    plddt_per_atom: np.ndarray | None = None,
+) -> biotite.structure.AtomArray:
+    atoms = []
+    for atom_i, (
+        atom_coord,
+        token_idx,
+        atom_name_chars,
+        element_idx,
+        is_not_pad,
+    ) in enumerate(
+        zip(
+            coords, atom_to_token, ref_atom_name_chars, ref_element, atom_attention_mask
+        )
+    ):
+        if not is_not_pad:
+            continue
+        atoms.append(
+            biotite.structure.Atom(
+                coord=atom_coord,
+                chain_id=_asym_id_to_chain_label(int(asym_id[token_idx])),
+                res_id=residue_index[token_idx] + 1,
+                res_name=TOKENS[res_type[token_idx]],
+                atom_name="".join(chr(c + 32) for c in atom_name_chars if c != 0),
+                element=ELEMENTS[element_idx],
+                ins_code=" ",
+                hetero=mol_type[token_idx] == MOL_TYPE_NONPOLYMER,
+                b_factor=float(plddt_per_atom[atom_i])
+                if plddt_per_atom is not None
+                else 0.0,
+            )
+        )
+    return biotite.structure.array(atoms)
+
+
+def build_complex(
+    inputs: dict[str, torch.Tensor], output: dict[str, Any]
+) -> ProteinComplex:
+    """Build a `ProteinComplex` from model output."""
+    atom_arr = to_atom_array(
+        coords=output["sample_atom_coords"][0].cpu().numpy(),
+        atom_to_token=inputs["atom_to_token"][0].cpu().numpy(),
+        res_type=inputs["res_type"][0].cpu().numpy(),
+        residue_index=inputs["token_index"][0].cpu().numpy(),
+        asym_id=inputs["asym_id"][0].cpu().numpy(),
+        mol_type=inputs["mol_type"][0].cpu().numpy(),
+        ref_atom_name_chars=inputs["ref_atom_name_chars"][0].cpu().numpy(),
+        ref_element=inputs["ref_element"][0].cpu().numpy(),
+        atom_attention_mask=inputs["atom_attention_mask"][0].cpu().numpy(),
+    )
+    return ProteinComplex.from_chains(
+        [ProteinChain.from_atomarray(a) for a in biotite.structure.chain_iter(atom_arr)]
+    )

--- a/06_gpu_and_ml/binder-design/binder_design/losses.py
+++ b/06_gpu_and_ml/binder-design/binder_design/losses.py
@@ -1,0 +1,379 @@
+"""Scoring functions used by the binder design loop.
+
+Three groups of scores live here:
+
+- **Structure losses** (Algorithms 12 + 13 in the ESM protein paper):
+  intra-chain contacts, inter-chain contacts, and a globularity term computed
+  from the predicted distogram. Combined into a single weighted total by
+  `compute_structure_losses`.
+- **Distogram iPTM proxy** (Algorithm 15): a binding-confidence score derived
+  from the distogram entropy at the binder/target interface. Has both a
+  whole-binder version and a CDR-restricted version for antibodies.
+- **ESMC pseudoperplexity NLL** (Algorithm 14): a sequence-prior regulariser
+  that nudges designed sequences toward "language-model-plausible" residues.
+"""
+
+import math
+from functools import cache
+
+import torch
+import torch.nn.functional as F
+from esm.models.esmfold2.constants import PROTEIN_1TO3
+from transformers.models.esmc.modeling_esmc import ESMCForMaskedLM
+from transformers.models.esmc.tokenization_esmc import ESMCTokenizer
+
+from .constants import ESMC_MASK_FRACTION, LOSS_WEIGHTS, TOKENS
+
+# ---- Tensor primitives shared by the loss functions ----
+
+
+def get_mid_points() -> torch.Tensor:
+    """128 distance bin midpoints (2-52 Angstrom range)."""
+    boundaries = torch.linspace(2, 52.0, 127)
+    lower = torch.tensor([1.0])
+    upper = torch.tensor([52.0 + 5.0])
+    exp_boundaries = torch.cat((lower, boundaries, upper))
+    return (exp_boundaries[:-1] + exp_boundaries[1:]) / 2
+
+
+def binned_entropy(
+    dgram: torch.Tensor, bin_distance: torch.Tensor, cutoff: float
+) -> torch.Tensor:
+    """Entropy of distance distribution within `cutoff` (design losses only)."""
+    bin_mask = ~(bin_distance < cutoff)
+    masked_dgram = dgram - (1e7 * bin_mask)
+    px = torch.softmax(masked_dgram, dim=-1)
+    log_px = torch.log_softmax(dgram, dim=-1)
+    return -(px * log_px).sum(-1)
+
+
+def masked_min_k(x: torch.Tensor, mask: torch.Tensor, k: int) -> torch.Tensor:
+    """Mean of the smallest k values in `x` under `mask` along the last dimension."""
+    mask = mask.bool()
+    y = torch.sort(torch.where(mask, x, float("nan")))[0]
+    k_mask = (torch.arange(y.shape[-1]).to(y.device) < k) & (~torch.isnan(y))
+    return torch.where(k_mask, y, 0).sum(-1) / (k_mask.sum(-1) + 1e-8)
+
+
+def masked_average(x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Masked mean along the last axis."""
+    mask = mask.bool()
+    return torch.where(mask, x, 0).sum(-1) / (torch.where(mask, 1, 0).sum(-1) + 1e-8)
+
+
+# ---- Structure losses ----
+
+
+def compute_contact_loss(
+    distogram_logits: torch.Tensor,
+    bin_distance: torch.Tensor,
+    num_contacts: int,
+    min_sep: int,
+    cutoff: float,
+    chain_mask: torch.Tensor,
+    binder_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Algorithm 12 Contact Losses.
+
+    Entropy-based contact loss with a sequence-separation constraint."""
+    con_loss = binned_entropy(distogram_logits, bin_distance, cutoff)
+    position = torch.arange(distogram_logits.shape[1])
+    p_dist = position[:, None] - position[None, :]
+    if min_sep > 0:
+        separation_mask = (torch.abs(p_dist) >= min_sep).to(distogram_logits.device)
+        binder_mask = torch.logical_and(separation_mask, binder_mask)
+    per_residue = masked_min_k(con_loss, mask=binder_mask, k=num_contacts).to(
+        distogram_logits.device
+    )
+    return masked_average(per_residue, mask=chain_mask).to(distogram_logits.device)
+
+
+def compute_intra_contact_loss(
+    distogram_logits: torch.Tensor, binder_length: int, bin_distance: torch.Tensor
+) -> torch.Tensor:
+    """Binder internal contacts (k=2, min_sep=9, cutoff=14A)."""
+    full_len = distogram_logits.shape[1]
+    is_binder = torch.ones(full_len, device=distogram_logits.device)
+    is_binder[:-binder_length] *= 0.0
+    return compute_contact_loss(
+        distogram_logits,
+        bin_distance,
+        num_contacts=2,
+        min_sep=9,
+        cutoff=14.0,
+        chain_mask=is_binder,
+        binder_mask=is_binder,
+    )
+
+
+def compute_inter_contact_loss(
+    distogram_logits: torch.Tensor, binder_length: int, bin_distance: torch.Tensor
+) -> torch.Tensor:
+    """Binder-target interface (k=1, min_sep=0, cutoff=22A)."""
+    full_len = distogram_logits.shape[1]
+    is_binder = torch.ones(full_len, device=distogram_logits.device)
+    is_binder[:-binder_length] *= 0.0
+    return compute_contact_loss(
+        distogram_logits,
+        bin_distance,
+        num_contacts=1,
+        min_sep=0,
+        cutoff=22.0,
+        chain_mask=1 - is_binder,
+        binder_mask=is_binder,
+    )
+
+
+def compute_globularity_loss(
+    distogram_logits: torch.Tensor, binder_length: int, bin_distance: torch.Tensor
+) -> torch.Tensor:
+    """Algorithm 13 Globularity Loss.
+
+    Radius of gyration vs theoretical packed protein."""
+    binder_disto = distogram_logits[:, -binder_length:, -binder_length:, :]
+    n = binder_disto.shape[1]
+    disto_probs = torch.softmax(binder_disto, dim=-1)
+    bin_distance = bin_distance.clamp(max=27)
+    e_sq_dist = torch.sum(disto_probs * torch.square(bin_distance), dim=-1)
+    sum_sq_dist = torch.sum(torch.tril(e_sq_dist, diagonal=-1), dim=(1, 2))
+    rg_term = torch.sqrt(sum_sq_dist / (n * n))
+    rg_th = 2.38 * (n**0.365)
+    return F.elu(rg_term - rg_th)
+
+
+def compute_structure_losses(
+    distogram_logits: torch.Tensor, binder_length: int
+) -> dict[str, torch.Tensor]:
+    """Compute the structural losses and their weighted total."""
+    bin_distance = get_mid_points().to(distogram_logits.device)
+    losses: dict[str, torch.Tensor] = {}
+    losses["intra_contact_loss"] = compute_intra_contact_loss(
+        distogram_logits, binder_length, bin_distance
+    )
+    losses["inter_contact_loss"] = compute_inter_contact_loss(
+        distogram_logits, binder_length, bin_distance
+    )
+    losses["glob_loss"] = compute_globularity_loss(
+        distogram_logits, binder_length, bin_distance
+    )
+    B = distogram_logits.size(0)
+    total = torch.tensor([0.0] * B, device=distogram_logits.device, requires_grad=True)
+    total = total + LOSS_WEIGHTS["intra_contact"] * losses["intra_contact_loss"]
+    total = total + LOSS_WEIGHTS["inter_contact"] * losses["inter_contact_loss"]
+    total = total + LOSS_WEIGHTS["glob"] * losses["glob_loss"]
+    losses["total_loss"] = total
+    return losses
+
+
+# ---- Distogram iPTM proxy ----
+
+
+def _binding_confidence_entropy(
+    dgram: torch.Tensor, bin_distance: torch.Tensor, cutoff: float
+) -> torch.Tensor:
+    """Pair entropy within `cutoff`."""
+    probs = torch.softmax(dgram, dim=-1)
+    cutoff_mask = bin_distance < cutoff
+    p_cut = probs[..., cutoff_mask]
+    p_cut = p_cut / (p_cut.sum(-1, keepdim=True) + 1e-8)
+    return -(p_cut * torch.log(p_cut + 1e-10)).sum(-1)
+
+
+def _entropy_to_confidence(mean_entropy: float) -> float:
+    """Map mean pair entropy to [0, 1]; lower entropy → higher score."""
+    return float(max(0.0, min(1.0, 1.0 - mean_entropy / math.log(51))))
+
+
+def _cdr_indices(binder_sequence: str) -> list[int]:
+    """0-based binder indices for all Chothia CDRs."""
+    from abnumber import Chain
+    from abnumber.common import _anarci_align
+
+    result = _anarci_align(
+        sequences=[binder_sequence], scheme="chothia", allowed_species=None
+    )[0]
+    chains = [
+        Chain("".join(result[i][0].values()), scheme="chothia")
+        for i in range(len(result))
+    ]
+    if len(chains) == 2 and not chains[0].is_heavy_chain():
+        chains.reverse()
+    indices: list[int] = []
+    for chain in chains:
+        for cdr in (chain.cdr1_seq, chain.cdr2_seq, chain.cdr3_seq):
+            start = binder_sequence.find(cdr)
+            assert start >= 0
+            indices.extend(range(start, start + len(cdr)))
+    return indices
+
+
+def compute_distogram_iptm_proxy(
+    distogram_logits: torch.Tensor,
+    target_length: int,
+    binder_sequence: str,
+    is_antibody: bool,
+) -> dict[str, float]:
+    """Algorithm 15 Distogram ipTM Proxy.
+
+    Distogram iPTM proxy for a target|binder complex (binder at suffix).
+
+    Returns `distogram_iptm_proxy` for all designs and
+    `cdr_distogram_iptm_proxy` when the binder can be annotated as an
+    antibody; otherwise the CDR score is NaN.
+    """
+    if distogram_logits.ndim == 4:
+        distogram_logits = distogram_logits[0]
+
+    binder_length = len(binder_sequence)
+    assert distogram_logits.shape[0] == target_length + binder_length
+
+    bin_distance = get_mid_points().to(distogram_logits.device)
+    binder_start = target_length
+
+    def _mean_lowest_k(entropies: torch.Tensor, k: int) -> float:
+        sorted_entropies, _ = torch.sort(entropies.reshape(-1))
+        k = min(k, sorted_entropies.numel())
+        return float(sorted_entropies[:k].mean())
+
+    binder_to_target_entropy = _binding_confidence_entropy(
+        distogram_logits[binder_start:, :target_length, :], bin_distance, cutoff=22.0
+    )
+    distogram_iptm_proxy = _entropy_to_confidence(
+        _mean_lowest_k(binder_to_target_entropy, k=binder_length)
+    )
+
+    if not is_antibody:
+        cdr_distogram_iptm_proxy = float("nan")
+    else:
+        cdr_indices = _cdr_indices(binder_sequence)
+        cdr_rows = [binder_start + i for i in cdr_indices]
+        cdr_to_target_entropy = _binding_confidence_entropy(
+            distogram_logits[cdr_rows, :target_length, :], bin_distance, cutoff=22.0
+        )
+        cdr_distogram_iptm_proxy = _entropy_to_confidence(
+            _mean_lowest_k(cdr_to_target_entropy, k=len(cdr_indices))
+        )
+
+    return {
+        "distogram_iptm_proxy": distogram_iptm_proxy,
+        "cdr_distogram_iptm_proxy": cdr_distogram_iptm_proxy,
+    }
+
+
+# ---- ESMC pseudoperplexity NLL (sequence prior regulariser) ----
+
+
+@cache
+def _folding_trunk_to_lm_aa_vocab_matrix(device: torch.device) -> torch.Tensor:
+    """Build a [ft_aas=20, lm_aas=20] permutation matrix between vocabularies."""
+    three_to_one_map = {v: k for k, v in PROTEIN_1TO3.items()}
+    ft_aas = [three_to_one_map[tok_3letter] for tok_3letter in TOKENS[2:22]]
+
+    lm_vocab = sorted(ESMCTokenizer().vocab.items(), key=lambda x: x[1])
+    lm_aas = [lm_vocab[i][0] for i in range(4, 24)]
+
+    ft_to_lm_aa_matrix = torch.zeros(20, 20)
+    for ft_idx, ft_aa in enumerate(ft_aas):
+        lm_idx = lm_aas.index(ft_aa)
+        ft_to_lm_aa_matrix[ft_idx, lm_idx] = 1
+
+    return ft_to_lm_aa_matrix.to(device=device)
+
+
+def _one_hot_from_probs(probs: torch.Tensor) -> torch.Tensor:
+    return F.one_hot(torch.argmax(probs, dim=-1), num_classes=probs.size(-1)).to(
+        probs.dtype
+    )
+
+
+def _straight_through(discrete: torch.Tensor, continuous: torch.Tensor) -> torch.Tensor:
+    return continuous + (discrete - continuous).detach()
+
+
+def compute_esmc_pseudoperplexity_nll(
+    esmc_model: ESMCForMaskedLM,
+    binder_design: torch.Tensor,
+    score_mask: torch.Tensor,
+    batch_size: int = 4,
+    n_passes: int = 4,
+) -> torch.Tensor:
+    """Algorithm 14 ESMC Pseudo-perplexity Sequence Regularization.
+
+    Approximate pseudoperplexity NLL via multiple sampled masks."""
+    device = binder_design.device
+    lm_vocab_size = esmc_model.config.vocab_size
+    model_dtype = esmc_model.esmc.embed.weight.dtype
+
+    target_esm = binder_design @ _folding_trunk_to_lm_aa_vocab_matrix(device)
+    input_esm = _straight_through(_one_hot_from_probs(target_esm), target_esm)
+    input_ids = torch.zeros(
+        (binder_design.size(0), binder_design.size(1) + 2, lm_vocab_size),
+        dtype=model_dtype,
+        device=device,
+    )
+    tokenizer = ESMCTokenizer()
+    input_ids[:, 0, tokenizer.cls_token_id] = 1
+    input_ids[:, -1, tokenizer.eos_token_id] = 1
+    input_ids[:, 1:-1, 4:24] = input_esm.to(model_dtype)
+
+    if score_mask.ndim == 1:
+        score_mask = score_mask.unsqueeze(0).expand(binder_design.size(0), -1)
+    elif score_mask.shape != binder_design.shape[:2]:
+        raise ValueError(
+            f"Expected score_mask with shape {(binder_design.size(0), binder_design.size(1))}, "
+            f"got {tuple(score_mask.shape)}"
+        )
+    score_mask = score_mask.to(device=device, dtype=torch.bool)
+
+    mask_token = torch.zeros(lm_vocab_size, dtype=model_dtype, device=device)
+    mask_token[esmc_model.config.mask_token_id] = 1
+    esmc = esmc_model.esmc
+
+    losses = []
+    for batch_idx in range(binder_design.size(0)):
+        position_indices = score_mask[batch_idx].nonzero(as_tuple=False).flatten()
+        num_positions = int(position_indices.numel())
+        if num_positions == 0:
+            raise ValueError(
+                "ESMC pseudoperplexity score mask selected zero positions."
+            )
+
+        num_masked = max(1, math.ceil(ESMC_MASK_FRACTION * num_positions))
+        random_scores = torch.rand((n_passes, num_positions), device=device)
+        masked_offsets = random_scores.topk(num_masked, dim=-1, largest=False).indices
+        pass_masks = torch.zeros(
+            (n_passes, binder_design.size(1)), dtype=torch.bool, device=device
+        )
+        pass_masks[
+            torch.arange(n_passes, device=device)[:, None],
+            position_indices[masked_offsets],
+        ] = True
+
+        masked_sequences = input_ids[batch_idx : batch_idx + 1].repeat(n_passes, 1, 1)
+        mask_rows, mask_cols = pass_masks.nonzero(as_tuple=True)
+        masked_sequences[mask_rows, mask_cols + 1] = mask_token
+
+        target_weights = target_esm[batch_idx]
+        masked_nlls = []
+        for start in range(0, n_passes, batch_size):
+            stop = min(start + batch_size, n_passes)
+            chunk = masked_sequences[start:stop]
+            with torch.autocast(
+                device_type="cuda", dtype=torch.bfloat16, enabled=device.type == "cuda"
+            ):
+                hidden, *_ = esmc.transformer(
+                    chunk @ esmc.embed.weight.to(chunk.dtype),
+                    sequence_id=None,
+                    layers_to_collect=[],
+                    output_attentions=False,
+                )
+                logits = esmc_model.lm_head(hidden)
+            log_probs = logits.log_softmax(dim=-1)[:, 1:-1, 4:24]
+            nlls = -(log_probs * target_weights.to(log_probs.dtype).unsqueeze(0)).sum(
+                dim=-1
+            )
+            masked_nlls.append(nlls[pass_masks[start:stop]])
+
+        losses.append(torch.cat(masked_nlls, dim=0).mean())
+
+    return torch.stack(losses, dim=0)

--- a/06_gpu_and_ml/binder-design/binder_design/models.py
+++ b/06_gpu_and_ml/binder-design/binder_design/models.py
@@ -1,0 +1,158 @@
+"""Model loading and the `ESMFold2Designer` orchestrator.
+
+`ESMFold2Designer.load` pulls down the inversion + critic ESMFold2 checkpoints and
+the ESMC LM from Hugging Face, optionally adds the scaling critics, and
+wires them into the gradient-descent loop in `binder_design.design.design_binder`.
+
+`ESMFold2Designer.design` is the public entry point that the example's Modal
+class calls into; it just forwards to `design_binder` with the loaded models.
+"""
+
+from functools import partial
+from typing import Any
+
+import torch
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    CheckpointImpl,
+    apply_activation_checkpointing,
+    checkpoint_wrapper,
+)
+from transformers.models.esmc.modeling_esmc import (
+    ESMCForMaskedLM,
+    UnifiedTransformerBlock as TransformerBlock,
+)
+from transformers.models.esmfold2.modeling_esmfold2_common import (
+    CUE_AVAILABLE,
+    PairUpdateBlock,
+)
+from transformers.models.esmfold2.modeling_esmfold2_experimental import (
+    ESMFold2ExperimentalModel,
+    MSAEncoder as ESMFold2MSAEncoder,
+)
+
+from .constants import CHECKPOINT_LM, COMPILE, REUSE_ESMC
+from .design import design_binder
+
+_ESMC = None
+
+
+def _load_hf_model(
+    critic_name: str, lm_dropout: float, cache_esmc: bool, device: str
+) -> Any:
+    """Load an ESMFold2 critic from Hugging Face.
+
+    Caches the ESMC-6B encoder across non-scaling checkpoints to save VRAM
+    and load time."""
+    global _ESMC
+    repo_id = f"biohub/{critic_name}"
+    model = ESMFold2ExperimentalModel.from_pretrained(repo_id, load_esmc=not cache_esmc)
+    if cache_esmc:
+        if _ESMC is None:
+            model.load_esmc(model.config.esmc_id)
+            _ESMC = model._esmc
+        else:
+            model._esmc = _ESMC
+    model.configure_lm_dropout(lm_dropout, force_lm_dropout_during_inference=True)
+    model.set_kernel_backend("cuequivariance" if CUE_AVAILABLE else None)
+    return model.to(device=device).eval().requires_grad_(False)
+
+
+def _apply_torch_compile(model: torch.nn.Module) -> None:
+    """`torch.compile` the heavy submodules of an ESMFold2 model."""
+    torch._dynamo.config.cache_size_limit = 512
+    torch._dynamo.config.accumulated_cache_size_limit = 512
+
+    compile_targets = (ESMFold2MSAEncoder, PairUpdateBlock, TransformerBlock)
+
+    def _maybe_compile_module(module: torch.nn.Module) -> None:
+        if not isinstance(module, compile_targets):
+            return
+        module.forward = torch.compile(module.forward)  # pyright: ignore
+
+    model.apply(_maybe_compile_module)
+
+
+class ESMFold2Designer:
+    lm_name = "biohub/ESMC-6B"
+    inversion_model_names: list[str] = [
+        "ESMFold2-Experimental-Fast",
+        "ESMFold2-Experimental-Fast-Cutoff2025",
+    ]
+    hero_critic_hf_paths: list[str] = [
+        "ESMFold2-Experimental-Fast",
+        "ESMFold2-Experimental-Fast-Cutoff2025",
+        "ESMFold2-Experimental",
+        "ESMFold2-Experimental-Cutoff2025",
+    ]
+    scaling_critic_hf_paths: list[str] = []
+
+    def load(self, use_scaling_critics: bool):
+        if use_scaling_critics:
+            self.scaling_critic_hf_paths = [
+                f"ESMFold2-Experimental-Fast-base{size}-step{step}k"
+                for size in ("300M", "600M", "6B")
+                for step in ("250", "500", "750", "1000", "1500")
+            ]
+
+        self.inversion_models = {
+            model_name: _load_hf_model(
+                model_name, lm_dropout=0.5, cache_esmc=True, device="cuda"
+            )
+            for model_name in self.inversion_model_names
+        }
+        if COMPILE:
+            for model in self.inversion_models.values():
+                _apply_torch_compile(model)
+
+        self.hf_critic_models: dict[str, Any] = {}
+        for name in self.hero_critic_hf_paths:
+            self.hf_critic_models[name] = _load_hf_model(
+                name, lm_dropout=0.25, cache_esmc=True, device="cuda"
+            )
+        for name in self.scaling_critic_hf_paths:
+            self.hf_critic_models[name] = _load_hf_model(
+                name, lm_dropout=0.25, cache_esmc=False, device="cpu"
+            )
+
+        self.esmc_model = ESMCForMaskedLM.from_pretrained(
+            self.lm_name, torch_dtype=torch.float32
+        )
+        if REUSE_ESMC:
+            del self.esmc_model.esmc
+            torch.cuda.empty_cache()
+            self.esmc_model.esmc = self.inversion_models[
+                "ESMFold2-Experimental-Fast"
+            ]._esmc
+        self.esmc_model = self.esmc_model.cuda().eval().requires_grad_(False)
+
+        if CHECKPOINT_LM:
+            apply_activation_checkpointing(
+                self.esmc_model,
+                checkpoint_wrapper_fn=partial(
+                    checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT
+                ),
+                check_fn=lambda module: isinstance(module, TransformerBlock),
+            )
+
+    def design(
+        self,
+        target_name: str | None = None,
+        target_sequence: str | None = None,
+        binder_name: str | None = None,
+        binder_sequence: str | None = None,
+        is_antibody: bool | None = None,
+        seed: int = 0,
+        batch_size: int = 1,
+    ) -> tuple[list[str], dict[int, dict[str, torch.Tensor]], list[dict]]:
+        return design_binder(
+            self.inversion_models,
+            self.hf_critic_models,
+            self.esmc_model,
+            target_name=target_name,
+            target_sequence=target_sequence,
+            binder_name=binder_name,
+            binder_sequence=binder_sequence,
+            is_antibody=is_antibody,
+            seed=seed,
+            batch_size=batch_size,
+        )

--- a/06_gpu_and_ml/binder-design/binder_design/models.py
+++ b/06_gpu_and_ml/binder-design/binder_design/models.py
@@ -143,8 +143,8 @@ class ESMFold2Designer:
         is_antibody: bool | None = None,
         seed: int = 0,
         batch_size: int = 1,
-    ) -> tuple[list[str], dict[int, dict[str, torch.Tensor]], list[dict]]:
-        return design_binder(
+    ) -> tuple[list[str], dict[int, dict[str, list[float]]], list[dict]]:
+        best_sequences, trajectory, critic_results = design_binder(
             self.inversion_models,
             self.hf_critic_models,
             self.esmc_model,
@@ -156,3 +156,13 @@ class ESMFold2Designer:
             seed=seed,
             batch_size=batch_size,
         )
+        trajectory = {
+            step: {k: v.tolist() for k, v in losses.items()}
+            for step, losses in trajectory.items()
+        }
+        for r in critic_results:
+            if "logits" in r:
+                r["logits"] = r["logits"].tolist()
+            if "complex" in r:
+                r["complex"] = r["complex"].to_pdb_string()
+        return best_sequences, trajectory, critic_results

--- a/06_gpu_and_ml/binder-design/binder_design/prompts.py
+++ b/06_gpu_and_ml/binder-design/binder_design/prompts.py
@@ -1,0 +1,73 @@
+"""Binder prompt templates and target sequences used by the design loop.
+
+`PromptFactory` builds a binder prompt string by stamping random-length runs of
+the mutable token (`#`) into the named slots of `template`. The binder design
+loop then drives those mutable positions with gradient descent against the
+folding-derived structure losses.
+"""
+
+import random
+from dataclasses import dataclass
+
+from .constants import MUTABLE_TOKEN
+
+# A binder prompt: AA chars at fixed positions and `MUTABLE_TOKEN` at mutable ones.
+BinderPromptStr = str
+
+
+@dataclass(frozen=True)
+class PromptFactory:
+    """A simple factory for making binder prompt strings."""
+
+    name: str
+    template: str  # string with format fields
+    length_ranges: dict[str, tuple[int, int]]  # map from field name to length range
+    is_antibody: bool  # used to set LM loss weight for antibodies
+
+    def sample(self, seed: int) -> BinderPromptStr:
+        random.seed(seed)
+        return self.template.format(
+            **{
+                key: MUTABLE_TOKEN * random.randint(low, high)
+                for key, (low, high) in self.length_ranges.items()
+            }
+        )
+
+
+# fmt: off
+BINDER_PROMPT_FACTORIES = {
+    "minibinder": PromptFactory(name="minibinder", template="{seq}", length_ranges={"seq": (60, 200)}, is_antibody=False),
+    "trastuzumab_framework_vhvl": PromptFactory(
+        name="trastuzumab_framework_vhvl",
+        template="EVQLVESGGGLVQPGGSLRLSCAAS{hcdr1}YIHWVRQAPGKGLEWVARI{hcdr2}TRYADSVKGRFTISADTSKNTAYLQMNSLRAEDTAVYYCSR{hcdr3}WGQGTLVTVSSGGGSGGGSGGGSGGGSDIQMTQSPSSLSASVGDRVTITC{lcdr1}WYQQKPGKAPKLLIY{lcdr2}GVPSRFSGSRSGTDFTLTISSLQPEDFATYYC{lcdr3}FGQGTKVEIK",
+        length_ranges = {"hcdr1": (7, 9), "hcdr2": (5, 6), "hcdr3": (9, 15), "lcdr1": (11, 16), "lcdr2": (7, 7), "lcdr3": (9, 9)},
+        is_antibody=True,
+    ),
+    "atezolizumab_framework_vhvl": PromptFactory(
+        name="atezolizumab_framework_vhvl",
+        template="EVQLVESGGGLVQPGGSLRLSCAAS{hcdr1}WIHWVRQAPGKGLEWVAWI{hcdr2}TYYADSVKGRFTISADTSKNTAYLQMNSLRAEDTAVYYCAR{hcdr3}WGQGTLVTVSSGGGSGGGSGGGSGGGSDIQMTQSPSSLSASVGDRVTITC{lcdr1}WYQQKPGKAPKLLIY{lcdr2}GVPSRFSGSGSGTDFTLTISSLQPEDFATYYC{lcdr3}FGQGTKVEIK",
+        length_ranges = {"hcdr1": (7, 9), "hcdr2": (5, 6), "hcdr3": (9, 15), "lcdr1": (11, 16), "lcdr2": (7, 7), "lcdr3": (9, 9)},
+        is_antibody=True,
+    ),
+    "ocankitug_framework_vhvl": PromptFactory(
+        name="ocankitug_framework_vhvl",
+        template="QVQLVQSGAEVKKPGSSVKVSCKAS{hcdr1}WMHWVRQAPGQGLEWMGII{hcdr2}TSLNQKFQGRVTITADTSTSTAYMELSSLRSEDTAVYYCAR{hcdr3}WGQGTLVTVSSGGGSGGGSGGGSGGGSDIQMTQSPSSLSASVGDRVTITC{lcdr1}WYQQKPGKAPKLLIY{lcdr2}GVPSRFSGSGSGTDFTLTISSLQPEDFATYYC{lcdr3}FGQGTKVEIK",
+        length_ranges = {"hcdr1": (7, 9), "hcdr2": (5, 6), "hcdr3": (8, 14), "lcdr1": (11, 16), "lcdr2": (7, 7), "lcdr3": (9, 9)},
+        is_antibody=True,
+    ),
+}
+
+
+TARGET_SEQUENCES = {
+    # https://www.uniprot.org/uniprotkb/P08575  389-574
+    "cd45": "GSPGEPQIIFCRSEAAHQGVITWNPPQRSFHNFTLCYIKETEKDCLNLDKNLIKYDLQNLKPYTKYVLSLHAYIIAKVQRNGSAAMCHFTTKSAPPSQVWNMTVSMTSDNSMHVKCRPPRDRNGPHERYHLEVEAGNTLVRNESHKNCDFRVKDLQYSTDYTFKAYFHNGDYPGEPFILHHSTSY",
+    # https://www.uniprot.org/uniprotkb/P16410  37-155
+    "ctla4": "MHVAQPAVVLASSRGIASFVCEYASPGKATEVRVTVLRQADSQVTEVCAATYMMGNELTFLDDSICTGTSSGNQVNLTIQGLRAMDTGLYICKVELMYPPPYYLGIGNGTQIYVIDPE",
+    # https://www.uniprot.org/uniprotkb/P00533  333-524
+    "egfr": "RKVCNGIGIGEFKDSLSINATNIKHFKNCTSISGDLHILPVAFRGDSFTHTPPLDPQELDILKTVKEITGFLLIQAWPENRTDLHAFENLEIIRGRTKQHGQFSLAVVSLNITSLGLRSLKEISDGDVIISGNKNLCYANTINWKKLFGTSGQKTKIISNRGENSCKATGQVCHALCSPEGCWGPEPRDCV",
+    # https://www.uniprot.org/uniprotkb/Q9NZQ7  17-132
+    "pd-l1": "AFTVTVPKDLYVVEYGSNMTIECKFPVEKQLDLAALIVYWEMEDKNIIQFVHGEEDLKVQHSSYRQRARLLKDQLSLGNAALQITDVKLQDAGVYRCMISYGGADYKRITVKVNA",
+    # https://www.uniprot.org/uniprotkb/P09619  125-312
+    "pdgfr": "GFLPNDAEELFIFLTEITEITIPCRVTDPQLVVTLHEKKGDVALPVPYDHQRGFSGIFEDRSYICKTTIGDREVDSDAYYVYRLQVSSINVSVNAVQTVVRQGENITLMCIVIGNEVVNFEWTYPRKESGRLVEPVTDFLLDMPYHIRSILHIPSAELEDSGTYTCNVTESVNDHQDEKAINITVVE",
+}
+# fmt: on

--- a/06_gpu_and_ml/binder-design/binder_design/sweep.py
+++ b/06_gpu_and_ml/binder-design/binder_design/sweep.py
@@ -6,8 +6,8 @@ Two pure functions plus their selection knobs:
   config dicts -- one per Modal job in the sweep.
 - `select_designs` joins the per-job result frames returned by `design_binder`,
   annotates each design with isoelectric point, drops non-acidic minibinders,
-  and keeps the top `top_n` per `(target, binder)` group ranked by combined
-  ipTM / distogram-iPTM-proxy score.
+  and keeps the top `top_n` per `(target, binder)` group ranked by an equal-
+  weighted blend of hero-critic ipTM and scaling-critic distogram-iPTM-proxy.
 
 Both functions are deliberately Modal-agnostic: the example's `run_sweep`
 function calls them inside the orchestrating container, but they are equally
@@ -18,6 +18,10 @@ usable from a notebook or a one-off script.
 TOP_N = 84
 # Minibinders are filtered to acidic designs; antibodies are kept regardless.
 ISOELECTRIC_POINT_MAX = 6.0
+# Critic names containing this substring are the smaller "scaling" critics that
+# only expose distogram proxies; everything else is treated as a hero critic
+# whose calibrated ipTM we use directly.
+SCALING_CHECKPOINT_SUBSTRING = "ESMFold2-Experimental-Fast-base"
 
 
 def expand_sweep(line_sweeps: dict[str, list]) -> list[dict]:
@@ -35,6 +39,15 @@ def select_designs(
     isoelectric_point_max: float = ISOELECTRIC_POINT_MAX,
 ):
     """Join per-job result frames, filter to plausible designs, and keep the top per group.
+
+    Each design's score is the average of two terms:
+
+    - `iptm_score` -- mean ipTM across hero critics (calibrated by Biohub).
+    - `iptm_proxy_score` -- mean distogram-iPTM-proxy across scaling critics
+      (uncalibrated but cheap, so we run a larger ensemble of them).
+
+    Antibodies use the CDR-restricted distogram proxy; minibinders use the full
+    one. With no scaling critics in the sweep, only `iptm_score` is non-zero.
 
     Returns a `pandas.DataFrame` of selected designs with `target_name` and
     `binder_name` as columns (suitable for parquet round-trips).
@@ -61,17 +74,29 @@ def select_designs(
     ]
 
     def _rank_group(group):
-        # Use the cdr-specific iptm proxy when available (antibodies), else
-        # the full distogram proxy. Without scaling critics, neither exists
-        # and this term contributes 0.
-        group["iptm_proxy"] = group.cdr_distogram_iptm_proxy.combine_first(
-            group.distogram_iptm_proxy
-        ).fillna(0)
-        group = group.groupby("designed_sequence", as_index=False).agg(
-            dict(iptm="mean", iptm_proxy="mean")
+        is_scaling = group.critic_name.str.contains(
+            SCALING_CHECKPOINT_SUBSTRING, regex=False, na=False
         )
-        group["selection_score"] = 0.5 * group.iptm + 0.5 * group.iptm_proxy
-        return group.nlargest(min(len(group), top_n), "selection_score")
+        iptm_proxy = group.distogram_iptm_proxy.where(
+            ~group.is_antibody, group.cdr_distogram_iptm_proxy
+        )
+        # Hero critics contribute calibrated ipTM; scaling critics contribute
+        # the distogram proxy. Mask each into its own column so the per-sequence
+        # mean below pulls only from the right subset of critics.
+        group = group.assign(
+            iptm_score=group.iptm.where(~is_scaling),
+            iptm_proxy_score=iptm_proxy.where(is_scaling),
+        )
+        scores = group.groupby("designed_sequence", as_index=False).agg(
+            iptm_score=("iptm_score", "mean"),
+            iptm_proxy_score=("iptm_proxy_score", "mean"),
+        )
+        # Designs missing one side (e.g., no scaling critics in the sweep) get
+        # 0 for that term rather than dropping out of the ranking entirely.
+        scores["selection_score"] = 0.5 * scores.iptm_score.fillna(
+            0
+        ) + 0.5 * scores.iptm_proxy_score.fillna(0)
+        return scores.nlargest(min(len(scores), top_n), "selection_score")
 
     # `reset_index` so `target_name` / `binder_name` survive the parquet
     # round-trip as columns rather than living on a MultiIndex.

--- a/06_gpu_and_ml/binder-design/binder_design/sweep.py
+++ b/06_gpu_and_ml/binder-design/binder_design/sweep.py
@@ -1,0 +1,83 @@
+"""Grid-sweep helpers used by the example's `run_sweep` Modal function.
+
+Two pure functions plus their selection knobs:
+
+- `expand_sweep` turns a dict of axes into a list of `(target, binder, seed, ...)`
+  config dicts -- one per Modal job in the sweep.
+- `select_designs` joins the per-job result frames returned by `design_binder`,
+  annotates each design with isoelectric point, drops non-acidic minibinders,
+  and keeps the top `top_n` per `(target, binder)` group ranked by combined
+  ipTM / distogram-iPTM-proxy score.
+
+Both functions are deliberately Modal-agnostic: the example's `run_sweep`
+function calls them inside the orchestrating container, but they are equally
+usable from a notebook or a one-off script.
+"""
+
+# Selection keeps the top designs per (target, binder) by selection_score.
+TOP_N = 84
+# Minibinders are filtered to acidic designs; antibodies are kept regardless.
+ISOELECTRIC_POINT_MAX = 6.0
+
+
+def expand_sweep(line_sweeps: dict[str, list]) -> list[dict]:
+    """Expand a dict of sweep axes into one config dict per grid point."""
+    from itertools import product
+
+    keys = list(line_sweeps)
+    return [dict(zip(keys, vals)) for vals in product(*line_sweeps.values())]
+
+
+def select_designs(
+    configs: list[dict],
+    raw_results: list,
+    top_n: int = TOP_N,
+    isoelectric_point_max: float = ISOELECTRIC_POINT_MAX,
+):
+    """Join per-job result frames, filter to plausible designs, and keep the top per group.
+
+    Returns a `pandas.DataFrame` of selected designs with `target_name` and
+    `binder_name` as columns (suitable for parquet round-trips).
+    """
+    import pandas as pd
+    from Bio.SeqUtils.ProtParam import ProteinAnalysis
+    from tqdm.auto import tqdm
+
+    # Each `design` call returns (best_sequences, trajectory, critic_results);
+    # we only need critic_results for selection, broadcast with config metadata.
+    df_result = pd.concat(
+        [pd.DataFrame(r[2]).assign(**cfg) for cfg, r in zip(configs, raw_results)],
+        ignore_index=True,
+    )
+    df_result["binder_sequence"] = df_result.designed_sequence.str.split(r"\|").str[1]
+    df_result["isoelectric_point"] = [
+        ProteinAnalysis(seq).isoelectric_point()
+        for seq in tqdm(df_result.binder_sequence.values)
+    ]
+
+    # Antibodies aren't acid-filtered; minibinders are.
+    df_filter = df_result[
+        df_result.is_antibody | df_result.isoelectric_point.lt(isoelectric_point_max)
+    ]
+
+    def _rank_group(group):
+        # Use the cdr-specific iptm proxy when available (antibodies), else
+        # the full distogram proxy. Without scaling critics, neither exists
+        # and this term contributes 0.
+        group["iptm_proxy"] = group.cdr_distogram_iptm_proxy.combine_first(
+            group.distogram_iptm_proxy
+        ).fillna(0)
+        group = group.groupby("designed_sequence", as_index=False).agg(
+            dict(iptm="mean", iptm_proxy="mean")
+        )
+        group["selection_score"] = 0.5 * group.iptm + 0.5 * group.iptm_proxy
+        return group.nlargest(min(len(group), top_n), "selection_score")
+
+    # `reset_index` so `target_name` / `binder_name` survive the parquet
+    # round-trip as columns rather than living on a MultiIndex.
+    return (
+        df_filter.groupby(["target_name", "binder_name"])
+        .apply(_rank_group, include_groups=False)
+        .reset_index(level=["target_name", "binder_name"])
+        .reset_index(drop=True)
+    )

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -1,5 +1,5 @@
 # ---
-# cmd: ["modal", "run", "-m", "06_gpu_and_ml.binder-design.esmfold2_binder_design"]
+# cmd: ["modal", "run", "-m", "06_gpu_and_ml.binder-design.esmfold2_binder_design::main"]
 # ---
 
 # # Design protein binders at scale with ESMFold2 and ESMC

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -1,0 +1,348 @@
+# ---
+# cmd: ["modal", "run", "-m", "06_gpu_and_ml.binder-design.esmfold2_binder_design"]
+# ---
+
+# # Design protein binders at scale with ESMFold2
+
+# The ability to accurately "fold" proteins, that is, infer their 3D structures from their
+# sequence of amino acids was the landmark breakthrough that brought computational
+# biology into the AI conversation. But folding _per se_ is not the problem
+# biologists want to solve. What we want really want to do is design new molecules which
+# can be used as drugs, sensors, or other biomedecial applications.
+
+# The key idea is to generate proteins or peptides (smaller molecules made of amino acids)
+# that bind to a protein of interest at target site. These "binders" alter how the
+# protein works, either by blocking it from binding to other proteins or by acting as a bridge
+# that helps other proteins or small molecules interact with the target protein. The former
+# can shut down diseased pathways. The latter can be used to deliver drugs or biosensors.
+
+# Traditionally, binder design has been a slow and manual process, requiring
+# months or years of directed evolution or rational design.
+# But if you had a a model that could not only go from sequence to structure for single molecules ("folding"),
+# but also understand how multiple folded proteins interact, you could
+# explore the sequence space _in silico_ at a much larger scale.
+
+# At a high-level, the algorithm looks something like this:
+# - Fold a candidate binder together with the target.
+# - Score the resulting structure on how well the binder folds and binds.
+# - Take a step in sequence space that improves the score.
+# - Repeat for a fixed number of steps.
+
+# This recipe -- running a forward folding model in service of searching the
+# sequence space for a structure we want, rather than to predict a structure
+# from a sequence -- is sometimes called "inverse folding". For it to work,
+# every step of the loop has to be _differentiable_, so that the score
+# computed from the predicted structure can be back-propagated through the
+# folding model into the candidate sequence.
+
+# This is where [ESMFold2](https://biohub.ai/esm/protein/about) comes in. It's a state-of-the-art model
+# for biomolecular complex structure prediction, developed by [Biohub](https://biohub.ai/) and released
+# under an open license. Built on ESMC representations, it produces leading accuracy
+# for protein-protein and antibody-antigen interactions at any given compute budget.
+
+# ESMFold2 is available in two configurations:
+
+# - [ESMFold2](https://huggingface.co/biohub/ESMFold2): the larger model for
+#   maximum accuracy. It can be run either from a single sequence or with MSA
+#   context, with MSAs improving performance on difficult complexes.
+# - [ESMFold2-Fast](https://huggingface.co/biohub/ESMFold2-Fast): a smaller
+#   model optimized for very fast single-sequence folding. It is well suited for
+#   high-throughput folding, designed sequences, metagenomic proteins, and
+#   targets with limited homologous sequence information.
+
+# In this example, we'll demonstrate how to run a single binder design call using
+# ESMFold2 on Modal's serverless infrastructure. Then with only
+# a few more lines of code, we'll write an orchestrator function
+# that executes a large-scale search powered by Modal's autoscaling and global GPU capacity.
+
+# ## Setup
+
+from pathlib import Path
+from typing import Optional
+
+import modal
+
+MINUTES = 60  # seconds
+HOURS = 60 * MINUTES
+
+app = modal.App(
+    name="example-esmfold2-binder-design",
+)
+
+# ## A bioconda-flavored Modal Image
+
+# Binder design needs a few specialized libraries on top of the usual
+# `transformers` / `torch` stack: the [`esm`](https://github.com/Biohub/esm)
+# library from CZ Biohub (which pulls in a custom fork of `transformers`),
+# plus [`abnumber`](https://github.com/prihoda/AbNumber)
+# and the [`anarci`](https://github.com/oxpig/ANARCI) /
+# [`hmmer`](http://hmmer.org/) tools it shells out to for CDR annotation of
+# antibodies.
+
+# `CUBLAS_WORKSPACE_CONFIG` is required for
+# `torch.use_deterministic_algorithms(True)` -- which we'll set when we run
+# our design search to ensure reproducibility.
+
+ESM_REVISION = "main"  # see https://github.com/Biohub/esm
+
+image = (
+    modal.Image.micromamba(python_version="3.12")
+    .run_commands("apt update && apt install -y git build-essential")
+    .micromamba_install(
+        "anarci>=2020.04.03",
+        "hmmer=3.4",
+        channels=["conda-forge", "bioconda"],
+    )
+    .pip_install(
+        "abnumber==0.4.4",
+        f"esm @ git+https://github.com/Biohub/esm.git@{ESM_REVISION}",
+        "pyarrow==18.1.0",
+    )
+    .env(
+        {
+            "HF_HOME": "/models",
+            "HF_XET_HIGH_PERFORMANCE": "1",  # speed up Hugging Face downloads
+            "XFORMERS_IGNORE_FLASH_VERSION_CHECK": "1",
+            # required for torch.use_deterministic_algorithms(True)
+            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        }
+    )
+)
+
+# ## Caching weights and persisting results on Modal Volumes
+
+# ESMFold2 builds on the 6B-parameter ESMC encoder; together with the four
+# critic models used for final scoring, the model weights come in around ~50 GB.
+# We cache them on a [Modal Volume](https://modal.com/docs/guide/volumes)
+# which delivers much better performance at cold-start time than re-downloading
+# from Hugging Face each time.
+
+models_volume = modal.Volume.from_name("esmfold2-models", create_if_missing=True)
+models_dir = Path("/models")
+
+# A second Volume will store our results.
+
+results_volume = modal.Volume.from_name(
+    "esmfold2-binder-design-results", create_if_missing=True
+)
+results_dir = Path("/results")
+
+
+# ## Designing a binder on Modal
+
+# To run binder design on Modal, we define a `BinderDesignService` class and
+# wrap it with the `@app.cls` decorator. The decorator takes arguments that
+# describe the infrastructure our code needs: the Image and both Volumes we
+# defined, plus an H100 GPU sized for the 6B-parameter ESMC encoder and the
+# four ESMFold2 "hero" critic models.
+
+# Inside the class, the [`@modal.enter()` lifecycle hook](https://modal.com/docs/guide/lifecycle-functions#modalenter)
+# downloads and initializes those models once per container start, so subsequent
+# `design` calls on the same container reuse the loaded weights.
+
+# We decorate our `design` method with `@modal.method()` to enable remote
+# execution. We'll see it called both via `.remote()` (single design) and via
+# `.spawn()` + [`modal.FunctionCall.gather`](https://modal.com/docs/reference/modal.FunctionCall)
+# (parallel sweep) further below. The class itself is a thin wrapper around
+# [`ESMFold2Designer`](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/binder-design/binder_design/models.py)
+# from the helper package, which handles the actual model loading and the
+# gradient-guided optimization loop (`design_binder` in
+# [`binder_design.design`](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/binder-design/binder_design/design.py)).
+
+
+@app.cls(
+    image=image,
+    volumes={models_dir: models_volume},
+    gpu="H100",
+    timeout=1 * HOURS,
+)
+class BinderDesignService:
+    """Modal entry point for ESMFold2-driven binder design.
+
+    Set ``use_scaling_critics=True`` to also load the 15-checkpoint
+    scaling-experiment ensemble (distogram binding confidence only).
+    """
+
+    use_scaling_critics: bool = modal.parameter(default=False)
+
+    @modal.enter()
+    def load(self):
+        from .binder_design import ESMFold2Designer
+
+        self._designer = ESMFold2Designer()
+        self._designer.load(self.use_scaling_critics)
+
+    @modal.method()
+    def design(
+        self,
+        target_name: Optional[str] = None,
+        target_sequence: Optional[str] = None,
+        binder_name: Optional[str] = None,
+        binder_sequence: Optional[str] = None,
+        is_antibody: Optional[bool] = None,
+        seed: int = 0,
+        batch_size: int = 1,
+    ):
+        return self._designer.design(
+            target_name=target_name,
+            target_sequence=target_sequence,
+            binder_name=binder_name,
+            binder_sequence=binder_sequence,
+            is_antibody=is_antibody,
+            seed=seed,
+            batch_size=batch_size,
+        )
+
+
+# ## Fanning out a sweep with selection
+
+# A single design run gives you one candidate per batch slot. To recover the
+# kind of hit rates reported in the paper, you want many seeds, several binder
+# templates, and several targets, then a selection pass that ranks designs by
+# a combined ipTM / distogram-ipTM-proxy score.
+
+# We orchestrate from inside a Modal Function so you don't have to worry about
+# keeping a long-running process alive locally or installing any local dependencies.
+
+
+@app.function(
+    image=image,
+    volumes={results_dir: results_volume},
+    gpu="H100",
+    timeout=2 * HOURS,
+)
+def run_sweep(
+    line_sweeps: dict[str, list],
+    use_scaling_critics: bool = False,
+    save_filename: str = "selection.parquet",
+) -> bytes:
+    """Fan a grid sweep across GPUs, gather results, select top designs, ave results + return parquet."""
+    import io
+
+    from .binder_design.sweep import expand_sweep, select_designs
+
+    designer = BinderDesignService(use_scaling_critics=use_scaling_critics)
+    configs = expand_sweep(line_sweeps)
+
+    print(f"🧬 spawning {len(configs)} design jobs")
+    calls = [designer.design.spawn(**cfg) for cfg in configs]
+    raw_results = modal.FunctionCall.gather(*calls)
+
+    df_select = select_designs(configs, raw_results)
+
+    buf = io.BytesIO()
+    df_select.to_parquet(buf, index=False)
+    parquet_bytes = buf.getvalue()
+
+    save_path = results_dir / save_filename
+    save_path.write_bytes(parquet_bytes)
+    results_volume.commit()
+    print(f"🧬 saved {len(df_select)} selected designs to volume:{save_path}")
+
+    return parquet_bytes
+
+
+# ## From the command line
+
+# `main` runs a single design. Override the
+# `target_name` / `binder_name` to try one of the
+# [bundled targets](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/binder-design/binder_design/prompts.py)
+# (`cd45`, `ctla4`, `egfr`, `pd-l1`, `pdgfr`) and binder templates
+# (`minibinder`, `trastuzumab_framework_vhvl`, `atezolizumab_framework_vhvl`,
+# `ocankitug_framework_vhvl`), or pass an arbitrary `target_sequence` /
+# `binder_sequence` directly.
+
+# ```shell
+# modal run -m 06_gpu_and_ml.binder-design.esmfold2_binder_design \
+#     --target-name pd-l1 --binder-name minibinder
+# ```
+
+
+@app.local_entrypoint()
+def main(
+    target_name: Optional[str] = "pd-l1",
+    target_sequence: Optional[str] = None,
+    binder_name: Optional[str] = "minibinder",
+    binder_sequence: Optional[str] = None,
+    is_antibody: Optional[bool] = None,
+    use_scaling_critics: bool = False,
+    seed: int = 0,
+    batch_size: int = 1,
+):
+    designer = BinderDesignService(use_scaling_critics=use_scaling_critics)
+    seq, trajectory, results = designer.design.remote(
+        target_name=target_name,
+        target_sequence=target_sequence,
+        binder_name=binder_name,
+        binder_sequence=binder_sequence,
+        is_antibody=is_antibody,
+        seed=seed,
+        batch_size=batch_size,
+    )
+
+    avg_final_loss = sum(r["final_loss"] for r in results) / len(results)
+    print(f"🧬 designed sequence: {seq}")
+    print(f"🧬 trajectory length: {len(trajectory)} steps")
+    print(f"🧬 average final loss: {avg_final_loss:.4f}")
+
+
+# `sweep` runs a grid sweep across every `(target, binder, seed)` combination
+# of the targets and binders you pass in, scaling design horizontally with Modal's
+# [asynchronous job processing](https://modal.com/docs/guide/job-queue).
+# The selection pass runs server-side and the resulting parquet is
+# written to both the `esmfold2-binder-design-results` Volume and to a local
+# file for inspection.
+
+# `target_names` and `binder_names` are passed as comma-separated strings
+# because Modal's local-entrypoint CLI doesn't accept lists directly. The
+# defaults sweep one target across two binder modalities -- a `minibinder`
+# and the `trastuzumab_framework_vhvl` antibody template -- so a single
+# command fans out across both at once:
+
+# ```shell
+# modal run -m 06_gpu_and_ml.binder-design.esmfold2_binder_design::sweep \
+#     --target-names pd-l1,ctla4 \
+#     --binder-names minibinder,trastuzumab_framework_vhvl \
+#     --n-seeds 8
+# ```
+
+
+@app.local_entrypoint()
+def sweep(
+    target_names: str = "pd-l1",
+    binder_names: str = "minibinder,trastuzumab_framework_vhvl",
+    use_scaling_critics: bool = False,
+    n_seeds: int = 8,
+    output_path: Optional[str] = None,
+):
+    target_name_list = [
+        name.strip() for name in target_names.split(",") if name.strip()
+    ]
+    binder_name_list = [
+        name.strip() for name in binder_names.split(",") if name.strip()
+    ]
+
+    line_sweeps = {
+        "target_name": target_name_list,
+        "target_sequence": [None],
+        "binder_name": binder_name_list,
+        "binder_sequence": [None],
+        "seed": list(range(n_seeds)),
+        "batch_size": [1],
+    }
+
+    print(
+        f"🧬 launching sweep: targets={target_name_list}, binders={binder_name_list}, "
+        f"n_seeds={n_seeds}, use_scaling_critics={use_scaling_critics}"
+    )
+    parquet_bytes = run_sweep.remote(
+        line_sweeps, use_scaling_critics=use_scaling_critics
+    )
+
+    if output_path is None:
+        output_path = Path("/tmp") / "esmfold2_binder_design" / "selection.parquet"
+    else:
+        output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(parquet_bytes)
+    print(f"🧬 wrote selection parquet to {output_path}")

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -45,13 +45,13 @@ app = modal.App(
 
 # ## Defining our Modal Image
 
-# We'll use `Image.micromamba` as our base image because a few of the packages we needd
-# are only available via Conda. We'll also instaall the [`esm`](https://github.com/Biohub/esm)
+# We'll use `Image.micromamba` as our base image because a few of the packages we need
+# are only available via Conda. We'll also install the [`esm`](https://github.com/Biohub/esm)
 # library from CZ Biohub (which pulls in a custom fork of `transformers`) and a few other helpful libraries
 # for working with protein sequences.
 
 # We set `CUBLAS_WORKSPACE_CONFIG` which allows us to ensure reproducibility by calling
-# `torch.use_deterministic_algorithms(True)`.
+# `torch.use_deterministic_algorithms(True)` at the top of our remote code.
 
 ESM_REVISION = (
     "f652b471d29da828b31e9b7a9cf7d0a7803240f5"  # see https://github.com/Biohub/esm

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -43,29 +43,30 @@ app = modal.App(
     name="example-esmfold2-binder-design",
 )
 
-# ## A bioconda-flavored Modal Image
+# ## Defining our Modal Image
 
 # We'll use `Image.micromamba` as our base image because a few of the packages we needd
 # are only available via Conda. We'll also instaall the [`esm`](https://github.com/Biohub/esm)
 # library from CZ Biohub (which pulls in a custom fork of `transformers`) and a few other helpful libraries
 # for working with protein sequences.
 
-# We also set `CUBLAS_WORKSPACE_CONFIG` which allows us to ensure reproducibility by calling
-# `torch.use_deterministic_algorithms(True)` at the top of our code.
+# We set `CUBLAS_WORKSPACE_CONFIG` which allows us to ensure reproducibility by calling
+# `torch.use_deterministic_algorithms(True)`.
 
-ESM_REVISION = "f652b471d29da828b31e9b7a9cf7d0a7803240f5"  # see https://github.com/Biohub/esm
+ESM_REVISION = (
+    "f652b471d29da828b31e9b7a9cf7d0a7803240f5"  # see https://github.com/Biohub/esm
+)
 
 image = (
     modal.Image.micromamba(python_version="3.12")
     .run_commands("apt update && apt install -y git build-essential")
     .micromamba_install(
-        "anarci=2.0.6",
+        "anarci=2024.05.21-0",
         channels=["conda-forge", "bioconda"],
     )
     .pip_install(
         f"esm @ git+https://github.com/Biohub/esm.git@{ESM_REVISION}",
         "abnumber==0.4.4",
-        "hmmer=3.4.0",
         "pyarrow==18.1.0",
     )
     .env(
@@ -92,7 +93,9 @@ models_dir = Path("/models")
 
 # A second Volume will store our results.
 
-results_volume = modal.Volume.from_name("esmfold2-binder-design-results", create_if_missing=True)
+results_volume = modal.Volume.from_name(
+    "esmfold2-binder-design-results", create_if_missing=True
+)
 results_dir = Path("/results")
 
 
@@ -101,7 +104,7 @@ results_dir = Path("/results")
 # To run binder design on Modal, we define a `BinderDesignService` class and
 # wrap it with the `@app.cls` decorator. The decorator takes arguments that
 # describe the infrastructure our code needs: the Image and both Volumes we
-# defined, plus an H100 GPU sized for the 6B-parameter ESMC encoder and the
+# defined, plus an H100 GPU which has enough memory for the 6B-parameter ESMC encoder and the
 # four ESMFold2 "hero" critic models.
 
 # Inside the class, the [`@modal.enter()` lifecycle hook](https://modal.com/docs/guide/lifecycle-functions#modalenter)
@@ -221,7 +224,7 @@ def run_sweep(
 # `binder_sequence` directly.
 
 # ```shell
-# modal run -m 06_gpu_and_ml.binder-design.esmfold2_binder_design \
+# modal run -m 06_gpu_and_ml.binder-design.esmfold2_binder_design::main \
 #     --target-name pd-l1 --binder-name minibinder
 # ```
 
@@ -283,8 +286,12 @@ def sweep(
     n_seeds: int = 8,
     output_path: Optional[str] = None,
 ):
-    target_name_list = [name.strip() for name in target_names.split(",") if name.strip()]
-    binder_name_list = [name.strip() for name in binder_names.split(",") if name.strip()]
+    target_name_list = [
+        name.strip() for name in target_names.split(",") if name.strip()
+    ]
+    binder_name_list = [
+        name.strip() for name in binder_names.split(",") if name.strip()
+    ]
 
     line_sweeps = {
         "target_name": target_name_list,
@@ -299,7 +306,9 @@ def sweep(
         f"🧬 launching sweep: targets={target_name_list}, binders={binder_name_list}, "
         f"n_seeds={n_seeds}, use_scaling_critics={use_scaling_critics}"
     )
-    parquet_bytes = run_sweep.remote(line_sweeps, use_scaling_critics=use_scaling_critics)
+    parquet_bytes = run_sweep.remote(
+        line_sweeps, use_scaling_critics=use_scaling_critics
+    )
 
     if output_path is None:
         output_path = Path("/tmp") / "esmfold2_binder_design" / "selection.parquet"

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -5,14 +5,13 @@
 # # Design protein binders at scale with ESMFold2 and ESMC
 
 # Protein folding was a landmark breakthrough in computational biology.
-# But for many applications, we do not just want to predict the structures of existing proteins —
+# But for many applications, we don't just want to predict the structures of existing proteins —
 # we want to design new proteins that can modulate biology.
 
 # One of the most important ways to do that is through binding.
 # Protein-protein interactions drive much of biological function,
 # and the ability to design molecules that bind specific targets
 # opens the door to new research tools and therapeutics.
-
 # Recent AI approaches have tackled binder design by inverting
 # structure prediction models via an iterative optimization process:
 # 1. Fold a candidate binder together with the target protein.
@@ -22,10 +21,9 @@
 
 # In this example, we'll demonstrate how implement this process on Modal
 # using [ESMFold2 and ESMC](https://biohub.ai/esm/protein/about), state-of-the-art models
-# developed by [Biohub](https://biohub.ai/) that can predict the stucture of biomolecular complexes.
-# In their [technical report](https://bhp-papers-prod.s3.us-west-2.amazonaws.com/esm_protein.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAU6GD3FYNPNY5VQML%2F20260601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260601T211329Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEE0aCXVzLXdlc3QtMiJHMEUCIQCo7iFVdbR8PdDuUKXkftQzwb17YIokN8eqsU4GVNLfXwIgHiY8F9BRKFhS52xYV8vva0yAJMDVBBqr%2BSVWTbnKmu4qqQUIFhAAGgwzMzk3MTMxNDIyOTgiDMbnfvOsb0AlGC9GIiqGBfl271MAE4q1YvlP0gVJcR0GQGmNLzYLOFZlKZuAl%2B2f10e9ff6O%2Fvq5OJvVoVFZPeFRAMFZnVpu7qmjZdTsDEkr9Kb2RUrItMI1ycrMkO%2FpdRXfLEZVCQ9l1frm93b3arhbJrA2QS0l7h7Kvqgn3vdh3sfkxP1oeOEf5H2noCepBdJdNozmQ9Mb%2FBU5BnVN02SzQ4W0HgY00XTNbIqdOcW2cQ%2B21zcFwMeoxxzDnLcNuIG6pAD2fJ7IJBmijW9aSLOhqR42e%2F0ZsJiRHIINIYC1x1z1OiPLIQM6ILV9Wxevn761h1zCONepQvxsSQ%2Byha7ztQ7%2BGL4dQskSiXA84IZa%2F0oUWSPPPJjwoIynM0dqONngLtjV3yX9uZ7o6NhesV0zEJgfgR1uuibPX3hmtd0uSTT1b%2FzqWwWqnVVpw8pXOPUaYO1uoD8kgud45U%2F2fKZYyHDkG9oL%2F3CQO7C%2B5okYLMBFDKQGJb4yb75uTCot0IYQC%2FlQbwrBkLiwCFvElX0%2FZ%2BpYOAiaeUFMiiJp6jCItrXPpvxKrHZnpOpRaXdaAkm%2F64Kwj2SW0mjok02hHW3PH39iY5dJ0DghclJBOEE1qFniEC5gFtzfEq4%2Bpm7J6gklIjIPdIbZT2vCKZBDeD1QjY9zdM8m%2B9sLAQokhqVyI4OJijDwzMoEA6vIrjjST8yy6dHq4oLrWAXBwt2dDJPRxNLOPKsbRRPfHbkwqxEu%2BPEfwkUchp5VchYrPlODlOWr6%2FdttlF%2FIwrFbMbCRJqLNQjCMpSaZJdZy1wWjMIWrsNx2KKoPIcs%2FaV26fN0lY%2BQ5DXESYLTCR1zBkCVXJirIK7o7xIEt715r0FlsAJDQqDAGVAw%2Bev30AY6mQFHzylgearF%2BJ1Qw4tnwpmoig%2FIAhz5LidTy1nyBTemeT2O0Pr8U9dU%2BkDaAGdvNL0Rkxs2SWvh0BQvQA6OKy9gILvE2ZXDqY2JnjaCyEKyrzigIL7sW2UFZUQwV86rVCEosqsY1fIvFRtKI3NRDkDhk%2Bqg7BfmA94bkXcp0PG863YrF76%2BtzXHNJa1vVmRv0CSrKWSX0bfAoY%3D&X-Amz-Signature=e478c493d9cbaa2d48de8a100b4e93182b00b064c0c07b6809d0dc79c136ed74&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) ,
-# researchers used this approach to design binders against five therapeutically relevant targets
-# and experimentally validated their afficinity, selectivity, and acitivity in the lab.
+# developed at [Biohub](https://biohub.ai/) that can predict the stucture of biomolecular complexes.
+# Check out their [technical report](https://bhp-papers-prod.s3.us-west-2.amazonaws.com/esm_protein.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAU6GD3FYNPNY5VQML%2F20260601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260601T211329Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEE0aCXVzLXdlc3QtMiJHMEUCIQCo7iFVdbR8PdDuUKXkftQzwb17YIokN8eqsU4GVNLfXwIgHiY8F9BRKFhS52xYV8vva0yAJMDVBBqr%2BSVWTbnKmu4qqQUIFhAAGgwzMzk3MTMxNDIyOTgiDMbnfvOsb0AlGC9GIiqGBfl271MAE4q1YvlP0gVJcR0GQGmNLzYLOFZlKZuAl%2B2f10e9ff6O%2Fvq5OJvVoVFZPeFRAMFZnVpu7qmjZdTsDEkr9Kb2RUrItMI1ycrMkO%2FpdRXfLEZVCQ9l1frm93b3arhbJrA2QS0l7h7Kvqgn3vdh3sfkxP1oeOEf5H2noCepBdJdNozmQ9Mb%2FBU5BnVN02SzQ4W0HgY00XTNbIqdOcW2cQ%2B21zcFwMeoxxzDnLcNuIG6pAD2fJ7IJBmijW9aSLOhqR42e%2F0ZsJiRHIINIYC1x1z1OiPLIQM6ILV9Wxevn761h1zCONepQvxsSQ%2Byha7ztQ7%2BGL4dQskSiXA84IZa%2F0oUWSPPPJjwoIynM0dqONngLtjV3yX9uZ7o6NhesV0zEJgfgR1uuibPX3hmtd0uSTT1b%2FzqWwWqnVVpw8pXOPUaYO1uoD8kgud45U%2F2fKZYyHDkG9oL%2F3CQO7C%2B5okYLMBFDKQGJb4yb75uTCot0IYQC%2FlQbwrBkLiwCFvElX0%2FZ%2BpYOAiaeUFMiiJp6jCItrXPpvxKrHZnpOpRaXdaAkm%2F64Kwj2SW0mjok02hHW3PH39iY5dJ0DghclJBOEE1qFniEC5gFtzfEq4%2Bpm7J6gklIjIPdIbZT2vCKZBDeD1QjY9zdM8m%2B9sLAQokhqVyI4OJijDwzMoEA6vIrjjST8yy6dHq4oLrWAXBwt2dDJPRxNLOPKsbRRPfHbkwqxEu%2BPEfwkUchp5VchYrPlODlOWr6%2FdttlF%2FIwrFbMbCRJqLNQjCMpSaZJdZy1wWjMIWrsNx2KKoPIcs%2FaV26fN0lY%2BQ5DXESYLTCR1zBkCVXJirIK7o7xIEt715r0FlsAJDQqDAGVAw%2Bev30AY6mQFHzylgearF%2BJ1Qw4tnwpmoig%2FIAhz5LidTy1nyBTemeT2O0Pr8U9dU%2BkDaAGdvNL0Rkxs2SWvh0BQvQA6OKy9gILvE2ZXDqY2JnjaCyEKyrzigIL7sW2UFZUQwV86rVCEosqsY1fIvFRtKI3NRDkDhk%2Bqg7BfmA94bkXcp0PG863YrF76%2BtzXHNJa1vVmRv0CSrKWSX0bfAoY%3D&X-Amz-Signature=e478c493d9cbaa2d48de8a100b4e93182b00b064c0c07b6809d0dc79c136ed74&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)
+# to see how the models were developed and used to design and experimentally validate binders against therapeutically relevant targets.
 
 # We'll start by building a Modal Function that designs a single binder; then with only
 # a few more lines of code, we'll write an orchestrator function
@@ -47,31 +45,27 @@ app = modal.App(
 
 # ## A bioconda-flavored Modal Image
 
-# Binder design needs a few specialized libraries on top of the usual
-# `transformers` / `torch` stack: the [`esm`](https://github.com/Biohub/esm)
-# library from CZ Biohub (which pulls in a custom fork of `transformers`),
-# plus [`abnumber`](https://github.com/prihoda/AbNumber)
-# and the [`anarci`](https://github.com/oxpig/ANARCI) /
-# [`hmmer`](http://hmmer.org/) tools it shells out to for CDR annotation of
-# antibodies.
+# We'll use `Image.micromamba` as our base image because a few of the packages we needd
+# are only available via Conda. We'll also instaall the [`esm`](https://github.com/Biohub/esm)
+# library from CZ Biohub (which pulls in a custom fork of `transformers`) and a few other helpful libraries
+# for working with protein sequences.
 
-# `CUBLAS_WORKSPACE_CONFIG` is required for
-# `torch.use_deterministic_algorithms(True)` -- which we'll set when we run
-# our design search to ensure reproducibility.
+# We also set `CUBLAS_WORKSPACE_CONFIG` which allows us to ensure reproducibility by calling
+# `torch.use_deterministic_algorithms(True)` at the top of our code.
 
-ESM_REVISION = "main"  # see https://github.com/Biohub/esm
+ESM_REVISION = "f652b471d29da828b31e9b7a9cf7d0a7803240f5"  # see https://github.com/Biohub/esm
 
 image = (
     modal.Image.micromamba(python_version="3.12")
     .run_commands("apt update && apt install -y git build-essential")
     .micromamba_install(
-        "anarci>=2020.04.03",
-        "hmmer=3.4",
+        "anarci=2.0.6",
         channels=["conda-forge", "bioconda"],
     )
     .pip_install(
-        "abnumber==0.4.4",
         f"esm @ git+https://github.com/Biohub/esm.git@{ESM_REVISION}",
+        "abnumber==0.4.4",
+        "hmmer=3.4.0",
         "pyarrow==18.1.0",
     )
     .env(
@@ -98,9 +92,7 @@ models_dir = Path("/models")
 
 # A second Volume will store our results.
 
-results_volume = modal.Volume.from_name(
-    "esmfold2-binder-design-results", create_if_missing=True
-)
+results_volume = modal.Volume.from_name("esmfold2-binder-design-results", create_if_missing=True)
 results_dir = Path("/results")
 
 
@@ -291,12 +283,8 @@ def sweep(
     n_seeds: int = 8,
     output_path: Optional[str] = None,
 ):
-    target_name_list = [
-        name.strip() for name in target_names.split(",") if name.strip()
-    ]
-    binder_name_list = [
-        name.strip() for name in binder_names.split(",") if name.strip()
-    ]
+    target_name_list = [name.strip() for name in target_names.split(",") if name.strip()]
+    binder_name_list = [name.strip() for name in binder_names.split(",") if name.strip()]
 
     line_sweeps = {
         "target_name": target_name_list,
@@ -311,9 +299,7 @@ def sweep(
         f"🧬 launching sweep: targets={target_name_list}, binders={binder_name_list}, "
         f"n_seeds={n_seeds}, use_scaling_critics={use_scaling_critics}"
     )
-    parquet_bytes = run_sweep.remote(
-        line_sweeps, use_scaling_critics=use_scaling_critics
-    )
+    parquet_bytes = run_sweep.remote(line_sweeps, use_scaling_critics=use_scaling_critics)
 
     if output_path is None:
         output_path = Path("/tmp") / "esmfold2_binder_design" / "selection.parquet"

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -2,58 +2,34 @@
 # cmd: ["modal", "run", "-m", "06_gpu_and_ml.binder-design.esmfold2_binder_design"]
 # ---
 
-# # Design protein binders at scale with ESMFold2
+# # Design protein binders at scale with ESMFold2 and ESMC
 
-# The ability to accurately "fold" proteins, that is, infer their 3D structures from their
-# sequence of amino acids was the landmark breakthrough that brought computational
-# biology into the AI conversation. But folding _per se_ is not the problem
-# biologists want to solve. What we want really want to do is design new molecules which
-# can be used as drugs, sensors, or other biomedecial applications.
+# Protein folding was a landmark breakthrough in computational biology.
+# But for many applications, we do not just want to predict the structures of existing proteins —
+# we want to design new proteins that can modulate biology.
 
-# The key idea is to generate proteins or peptides (smaller molecules made of amino acids)
-# that bind to a protein of interest at target site. These "binders" alter how the
-# protein works, either by blocking it from binding to other proteins or by acting as a bridge
-# that helps other proteins or small molecules interact with the target protein. The former
-# can shut down diseased pathways. The latter can be used to deliver drugs or biosensors.
+# One of the most important ways to do that is through binding.
+# Protein-protein interactions drive much of biological function,
+# and the ability to design molecules that bind specific targets
+# opens the door to new research tools and therapeutics.
 
-# Traditionally, binder design has been a slow and manual process, requiring
-# months or years of directed evolution or rational design.
-# But if you had a a model that could not only go from sequence to structure for single molecules ("folding"),
-# but also understand how multiple folded proteins interact, you could
-# explore the sequence space _in silico_ at a much larger scale.
+# Recent AI approaches have tackled binder design by inverting
+# structure prediction models via an iterative optimization process:
+# 1. Fold a candidate binder together with the target protein.
+# 2. Score the resulting structure based on how well the binder folds and binds.
+# 3. Take a step in sequence space that improves the score.
+# 4. Repeat.
 
-# At a high-level, the algorithm looks something like this:
-# - Fold a candidate binder together with the target.
-# - Score the resulting structure on how well the binder folds and binds.
-# - Take a step in sequence space that improves the score.
-# - Repeat for a fixed number of steps.
+# In this example, we'll demonstrate how implement this process on Modal
+# using [ESMFold2 and ESMC](https://biohub.ai/esm/protein/about), state-of-the-art models
+# developed by [Biohub](https://biohub.ai/) that can predict the stucture of biomolecular complexes.
+# In their [technical report](https://bhp-papers-prod.s3.us-west-2.amazonaws.com/esm_protein.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAU6GD3FYNPNY5VQML%2F20260601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260601T211329Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEE0aCXVzLXdlc3QtMiJHMEUCIQCo7iFVdbR8PdDuUKXkftQzwb17YIokN8eqsU4GVNLfXwIgHiY8F9BRKFhS52xYV8vva0yAJMDVBBqr%2BSVWTbnKmu4qqQUIFhAAGgwzMzk3MTMxNDIyOTgiDMbnfvOsb0AlGC9GIiqGBfl271MAE4q1YvlP0gVJcR0GQGmNLzYLOFZlKZuAl%2B2f10e9ff6O%2Fvq5OJvVoVFZPeFRAMFZnVpu7qmjZdTsDEkr9Kb2RUrItMI1ycrMkO%2FpdRXfLEZVCQ9l1frm93b3arhbJrA2QS0l7h7Kvqgn3vdh3sfkxP1oeOEf5H2noCepBdJdNozmQ9Mb%2FBU5BnVN02SzQ4W0HgY00XTNbIqdOcW2cQ%2B21zcFwMeoxxzDnLcNuIG6pAD2fJ7IJBmijW9aSLOhqR42e%2F0ZsJiRHIINIYC1x1z1OiPLIQM6ILV9Wxevn761h1zCONepQvxsSQ%2Byha7ztQ7%2BGL4dQskSiXA84IZa%2F0oUWSPPPJjwoIynM0dqONngLtjV3yX9uZ7o6NhesV0zEJgfgR1uuibPX3hmtd0uSTT1b%2FzqWwWqnVVpw8pXOPUaYO1uoD8kgud45U%2F2fKZYyHDkG9oL%2F3CQO7C%2B5okYLMBFDKQGJb4yb75uTCot0IYQC%2FlQbwrBkLiwCFvElX0%2FZ%2BpYOAiaeUFMiiJp6jCItrXPpvxKrHZnpOpRaXdaAkm%2F64Kwj2SW0mjok02hHW3PH39iY5dJ0DghclJBOEE1qFniEC5gFtzfEq4%2Bpm7J6gklIjIPdIbZT2vCKZBDeD1QjY9zdM8m%2B9sLAQokhqVyI4OJijDwzMoEA6vIrjjST8yy6dHq4oLrWAXBwt2dDJPRxNLOPKsbRRPfHbkwqxEu%2BPEfwkUchp5VchYrPlODlOWr6%2FdttlF%2FIwrFbMbCRJqLNQjCMpSaZJdZy1wWjMIWrsNx2KKoPIcs%2FaV26fN0lY%2BQ5DXESYLTCR1zBkCVXJirIK7o7xIEt715r0FlsAJDQqDAGVAw%2Bev30AY6mQFHzylgearF%2BJ1Qw4tnwpmoig%2FIAhz5LidTy1nyBTemeT2O0Pr8U9dU%2BkDaAGdvNL0Rkxs2SWvh0BQvQA6OKy9gILvE2ZXDqY2JnjaCyEKyrzigIL7sW2UFZUQwV86rVCEosqsY1fIvFRtKI3NRDkDhk%2Bqg7BfmA94bkXcp0PG863YrF76%2BtzXHNJa1vVmRv0CSrKWSX0bfAoY%3D&X-Amz-Signature=e478c493d9cbaa2d48de8a100b4e93182b00b064c0c07b6809d0dc79c136ed74&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) ,
+# researchers used this approach to design binders against five therapeutically relevant targets
+# and experimentally validated their afficinity, selectivity, and acitivity in the lab.
 
-# This recipe -- running a forward folding model in service of searching the
-# sequence space for a structure we want, rather than to predict a structure
-# from a sequence -- is sometimes called "inverse folding". For it to work,
-# every step of the loop has to be _differentiable_, so that the score
-# computed from the predicted structure can be back-propagated through the
-# folding model into the candidate sequence.
-
-# This is where [ESMFold2](https://biohub.ai/esm/protein/about) comes in. It's a state-of-the-art model
-# for biomolecular complex structure prediction, developed by [Biohub](https://biohub.ai/) and released
-# under an open license. Built on ESMC representations, it produces leading accuracy
-# for protein-protein and antibody-antigen interactions at any given compute budget.
-
-# ESMFold2 is available in two configurations:
-
-# - [ESMFold2](https://huggingface.co/biohub/ESMFold2): the larger model for
-#   maximum accuracy. It can be run either from a single sequence or with MSA
-#   context, with MSAs improving performance on difficult complexes.
-# - [ESMFold2-Fast](https://huggingface.co/biohub/ESMFold2-Fast): a smaller
-#   model optimized for very fast single-sequence folding. It is well suited for
-#   high-throughput folding, designed sequences, metagenomic proteins, and
-#   targets with limited homologous sequence information.
-
-# In this example, we'll demonstrate how to run a single binder design call using
-# ESMFold2 on Modal's serverless infrastructure. Then with only
+# We'll start by building a Modal Function that designs a single binder; then with only
 # a few more lines of code, we'll write an orchestrator function
-# that executes a large-scale search powered by Modal's autoscaling and global GPU capacity.
+# that executes a large-scale search powered by Modal's autoscaling infrastructure and global GPU capacity.
 
 # ## Setup
 

--- a/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
+++ b/06_gpu_and_ml/binder-design/esmfold2_binder_design.py
@@ -5,7 +5,7 @@
 # # Design protein binders at scale with ESMFold2 and ESMC
 
 # Protein folding was a landmark breakthrough in computational biology.
-# But for many applications, we do not just want to predict the structures of existing proteins —
+# But for many applications, we don't just want to predict the structures of existing proteins —
 # we want to design new proteins that can modulate biology.
 
 # One of the most important ways to do that is through binding.


### PR DESCRIPTION
Adds a follow-up example for the ESMFold2 release that runs binder design and demonstrates how to scale this horizontally with Modal.

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [x] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [x] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [x] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [x] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [x] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [x] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [x] Example pins all dependencies in container images
    - [ ] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [x] Example specifies a `python_version` for the base image, if it is used 
    - [x] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->