### PR TITLE
migrate modal-examples repo's synmon from lambda to modal

### DIFF
--- a/internal/readme.md
+++ b/internal/readme.md
@@ -30,8 +30,7 @@ Fields include:
 - `args`: Arguments to pass to the command. Default is `[]`.
 - `lambda-test`: If `true`, the example is tested with the cli command provided
   in `cmd`. If `false`, it is not. Default is `true`. Note that this controls
-  execution in the CI/CD of this repo _and_ in the internal AWS Lambda monitor
-  as part of `synthetic_monitoring`.
+  execution in the CI/CD of this repo _and_ in the internal Modal monitor as part of `synthetic_monitoring`.
 - `env`: A dictionary of environment variables to include when testing.
   Default is `{}`, but note that the environment can be modified in the CI/CD of
   this repo or in the monitor-based testing.

--- a/internal/run_example.py
+++ b/internal/run_example.py
@@ -8,9 +8,7 @@ import time
 from . import utils
 
 MINUTES = 60
-# NB: Max runtime for AWS Lambda is 15 minutes.
-# Asynchronous monitoring is managed by Lambda, so max timeout here is limited.
-# ref: https://docs.aws.amazon.com/lambda/latest/dg/configuration-timeout.html
+# NB: Max runtime was originally set to match AWS Lambda timeout of 15 minutes.
 DEFAULT_TIMEOUT = 14 * MINUTES
 
 


### PR DESCRIPTION
follow up to https://github.com/modal-labs/modal/pull/45848.

## Type of Change

- [☑️] Other (Changes to the codebase, but not to examples)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->