### PR TITLE
Fix Algolia crawler start/stop URLs for restructured SDK reference routes

### DIFF
--- a/10_integrations/algolia_indexer.py
+++ b/10_integrations/algolia_indexer.py
@@ -46,7 +46,9 @@ CONFIG = {
         "synonyms": [["cls", "class"]],
     },
     "stop_urls": [
+        "https://modal.com/docs/reference/modal.Stub",
         "https://modal.com/gpu-glossary",
+        "https://modal.com/docs/reference/changelog",
     ],
     "start_urls": [
         {

--- a/10_integrations/algolia_indexer.py
+++ b/10_integrations/algolia_indexer.py
@@ -47,7 +47,6 @@ CONFIG = {
     },
     "stop_urls": [
         "https://modal.com/gpu-glossary",
-        "https://modal.com/docs/sdk/py/changelog",
     ],
     "start_urls": [
         {

--- a/10_integrations/algolia_indexer.py
+++ b/10_integrations/algolia_indexer.py
@@ -46,9 +46,8 @@ CONFIG = {
         "synonyms": [["cls", "class"]],
     },
     "stop_urls": [
-        "https://modal.com/docs/reference/modal.Stub",
         "https://modal.com/gpu-glossary",
-        "https://modal.com/docs/reference/changelog",
+        "https://modal.com/docs/sdk/py/changelog",
     ],
     "start_urls": [
         {
@@ -62,7 +61,7 @@ CONFIG = {
             "page_rank": 1,
         },
         {
-            "url": "https://modal.com/docs/reference",
+            "url": "https://modal.com/docs/sdk/py/latest",
             "selectors_key": "reference",
             "page_rank": 1,
         },


### PR DESCRIPTION
Update Algolia crawler `start_url` from `/docs/reference` to `/docs/sdk/py/latest`.

The reference doc routes were restructured in modal-labs/modal@74c8b9ec60 but the crawler config wasn't updated, so search for symbols like `Image.uv_pip_install` stopped returning results.

After merging, the crawler needs to be triggered to re-index: `modal run 10_integrations/algolia_indexer.py`