### PR TITLE
Add unauthenticated=True to nemotron http_server to fix 401 in CI

### DIFF
--- a/06_gpu_and_ml/llm-serving/nemotron_inference.py
+++ b/06_gpu_and_ml/llm-serving/nemotron_inference.py
@@ -236,6 +236,7 @@ PORT = 8000
     port=PORT,  # wrapped code must listen on this port
     proxy_regions=[PROXY_REGION],  # location of proxies, should overlap with Cls region
     exit_grace_period=15,  # seconds, time to finish up requests when closing down
+    unauthenticated=True,  # allow public access without a Modal-Authorization token
 )
 @modal.concurrent(target_inputs=TARGET_INPUTS)
 class Server:


### PR DESCRIPTION
## Summary

- Adds `unauthenticated=True` to the `@modal.experimental.http_server` decorator in the nemotron example so the service is publicly accessible without a `Modal-Authorization` header.

modal-labs/modal@0a7389485d changed `http_server` services (those with `is_server=True`) to require proxy auth by default when `http_config.unauthenticated=False`. The nemotron example is a public demo and the test code makes unauthenticated requests, which started returning 401 after that change.

This also requires modal-labs/modal#XXXXX to expose `unauthenticated` as a parameter on `modal.experimental.http_server()` — the two changes should land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->