### PR TITLE
Add lychee link checking to CI

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,106 @@
+name: Links
+
+on:
+  pull_request:
+    paths:
+      - "**.py"
+      - "**.md"
+      - "**.ipynb"
+      - "lychee.toml"
+      - ".github/workflows/links.yml"
+  schedule:
+    - cron: "0 4 * * 1,4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  changed-files:
+    name: Check links in changed files
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Find changed files
+        id: changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          changed=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate \
+            --jq '.[] | select(.status != "removed") | .filename')
+          if echo "$changed" | grep -qxE 'lychee\.toml|\.github/workflows/links\.yml'; then
+            files="./**/*.py ./**/*.md ./**/*.ipynb"
+          else
+            files=$(echo "$changed" \
+              | grep -E '\.(py|md|ipynb)$' \
+              | grep -E '^[A-Za-z0-9._/-]+$' \
+              | tr '\n' ' ' || true)
+          fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Restore lychee cache
+        if: steps.changed.outputs.files != ''
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .lycheecache
+          key: lychee-cache
+          restore-keys: lychee-cache-
+
+      - name: Check links
+        if: steps.changed.outputs.files != ''
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --config lychee.toml --root-dir ${{ github.workspace }} --no-progress ${{ steps.changed.outputs.files }}
+          token: ${{ github.token }}
+
+  all-files:
+    name: Check all links
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --config lychee.toml --root-dir ${{ github.workspace }} --no-progress --format markdown './**/*.py' './**/*.md' './**/*.ipynb'
+          output: lychee-report.md
+          fail: false
+          token: ${{ github.token }}
+
+      - name: Save lychee cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .lycheecache
+          key: lychee-cache-${{ github.run_id }}
+
+      - name: Update tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list --label broken-links --state open --json number --jq '.[0].number')
+          if [ "${{ steps.lychee.outputs.exit_code }}" != "0" ]; then
+            if [ -n "$existing" ]; then
+              gh issue edit "$existing" --body-file lychee-report.md
+              gh issue comment "$existing" --body "Updated with the latest scheduled run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            else
+              gh label create broken-links --description "Broken links found by the scheduled lychee run" --color D93F0B --force
+              gh issue create --title "Broken links in examples" --body-file lychee-report.md --label broken-links
+            fi
+            exit 1
+          elif [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "All links are passing again as of ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ venv
 # secrets file for act, tool for local GitHub Actions testing
 .secrets
 
+# lychee link-checker result cache
+.lycheecache
+
 # agent configuration
 **/opencode.json

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,32 @@
+cache = true
+max_cache_age = "10d"
+cache_exclude_status = ["429", "500..=599"]
+
+max_retries = 3
+timeout = 30
+max_concurrency = 32
+
+scheme = ["http", "https"]
+exclude_all_private = true
+accept = ["200..=299", "401", "405", "429"]
+
+user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+exclude = [
+    # placeholders and templated URLs
+    "%7B",
+    "\\{",
+    "\\.\\.\\.",
+    "example\\.com",
+    "https?://your-",
+    "https?://my-",
+    "APP_ID",
+    "\\.modal\\.host",
+    # lychee mis-parses `https://oauth2:{token}@github.com/...` into a check of the literal host `oauth2`
+    "^https?://oauth2",
+    # login-redirect walls that fail with redirect loops, not status codes
+    "www\\.tensorflow\\.org",
+    # base URLs that code appends a file path to
+    "chaiassets\\.com",
+    "github\\.com/.+/releases/download/.+/$",
+]


### PR DESCRIPTION
On PRs, checks links only in changed `.py`/`.md`/`.ipynb` files (full sweep if `lychee.toml` or the workflow itself changed). Twice a week, sweeps everything, opens or updates a `broken-links` tracking issue with the report, closes it when clean, and refreshes the result cache that PR runs restore. Successes are cached for 10 days; 429s and 5xx are never cached, so transient failures can't stick.

Every exclusion in `lychee.toml` is there for a reason:

- `{` / `%7B` / `...` / `your-` / `my-` / `APP_ID` / `example.com` / `.modal.host` — templated and placeholder URLs
- `oauth2` — lychee mis-parses `https://oauth2:{token}@github.com/...` into a check of the literal host `oauth2`
- `tensorflow.org` — anonymous requests loop forever through a `prompt=none` OAuth redirect
- `chaiassets.com`, `github.com/*/releases/download/*/` — base URLs that code appends filenames to

The full sweep currently finds 31 genuinely broken links, so this PR's own check run is red. Fixing those is a separate change; once this merges, the scheduled job will track them in the issue.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->