### PR TITLE
update the webrtc code to use async everywhere

### DIFF
--- a/07_web/webrtc/modal_webrtc.py
+++ b/07_web/webrtc/modal_webrtc.py
@@ -104,7 +104,7 @@ class ModalWebRtcPeer(ABC):
                     in ["connected", "closed", "failed"]
                 ):
                     print(f"{self.id}: Closing connection to {peer_id} over queue...")
-                    q.put("close", partition="server")
+                    await q.put.aio("close", partition="server")
                     break
 
                 # read and parse websocket message passed over queue
@@ -284,10 +284,10 @@ class ModalWebRtcSignalingServer:
                 "Modal peer class must be an implementation of `ModalWebRtcPeer`"
             )
 
-        with modal.Queue.ephemeral() as q:
+        async with modal.Queue.ephemeral() as q:
             print(f"Server: Spawning modal peer instance for client peer {peer_id}...")
             modal_peer = modal_peer_class()
-            modal_peer.run.spawn(q, peer_id)
+            await modal_peer.run.spawn.aio(q, peer_id)
 
             await asyncio.gather(
                 relay_websocket_to_queue(websocket, q, peer_id),

--- a/07_web/webrtc/webrtc_yolo_test.py
+++ b/07_web/webrtc/webrtc_yolo_test.py
@@ -154,9 +154,9 @@ class TestPeer(ModalWebRtcPeer):
 
         peer_id = None
         # connect to server via websocket
-        ws_uri = (
-            (await WebcamObjDet().web.get_web_url.aio()).replace("http", "ws") + f"/ws/{self.id}"
-        )
+        ws_uri = (await WebcamObjDet().web.get_web_url.aio()).replace(
+            "http", "ws"
+        ) + f"/ws/{self.id}"
         async with websockets.connect(
             ws_uri, open_timeout=self.WS_OPEN_TIMEOUT
         ) as websocket:

--- a/07_web/webrtc/webrtc_yolo_test.py
+++ b/07_web/webrtc/webrtc_yolo_test.py
@@ -155,7 +155,7 @@ class TestPeer(ModalWebRtcPeer):
         peer_id = None
         # connect to server via websocket
         ws_uri = (
-            WebcamObjDet().web.get_web_url().replace("http", "ws") + f"/ws/{self.id}"
+            (await WebcamObjDet().web.get_web_url.aio()).replace("http", "ws") + f"/ws/{self.id}"
         )
         async with websockets.connect(
             ws_uri, open_timeout=self.WS_OPEN_TIMEOUT


### PR DESCRIPTION
This PR adds async/await and `.aio` to the WebRTC example in all places where we warn about using sync interfaces inside an async context.

Tests pass still and the demo worked for me.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->