### PR TITLE
sleep for longer before starting test

### DIFF
--- a/07_web/server_sticky.py
+++ b/07_web/server_sticky.py
@@ -132,7 +132,7 @@ async def test(n_clients: int = 4, sticky: bool = True, seconds: float = 10.0):
     # allow generous time for all replicas to spin up based on rough heuristic;
     # remove this sleep and increase CONTAINERS
     # to observe session routing changes during autoscaling
-    await asyncio.sleep(5 + max((CONTAINERS - 10) // 2, 0))
+    await asyncio.sleep(10 + max((CONTAINERS - 10) // 2, 0))
 
     # run the test
     results = await run_clients(url, n_clients, seconds, sticky)


### PR DESCRIPTION
The sticky routing test in `server_sticky` is less flaky than it was in `http_server` -- not sure exactly why! but good news.

However, it was still flaking a bit, so I am increasing the sleep time to allow both target containers to scale up.

We are still short of a really excellent test here -- kind of annoying that this feature's behavior is so hard to crisply define. To be rock-solid, the test would need to be statistical and/or based on container counts.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->