### PR TITLE
use a string cache path in flux kontext example to fix Windows builds

### DIFF
--- a/06_gpu_and_ml/stable_diffusion/image_to_image.py
+++ b/06_gpu_and_ml/stable_diffusion/image_to_image.py
@@ -73,7 +73,7 @@ MODEL_REVISION = "f9fdd1a95e0dfd7653cb0966cda2486745122695"
 # Modal Volumes act like a shared disk that all Modal Functions can access.
 # For more on storing model weights on Modal, see [this guide](https://modal.com/docs/guide/model-weights).
 
-CACHE_DIR = Path("/cache")
+CACHE_DIR = "/cache"
 cache_volume = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 volumes = {CACHE_DIR: cache_volume}
 
@@ -84,7 +84,7 @@ secrets = [modal.Secret.from_name("huggingface-secret")]
 # We configure environment variables to enable faster downloads from Hugging Face
 # and point the Hugging Face cache to our Modal Volume.
 
-image = image.env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HOME": str(CACHE_DIR)})
+image = image.env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HOME": CACHE_DIR})
 
 # Finally, we import packages we'll be using in our inference function,
 # but not locally.


### PR DESCRIPTION
On Windows, building the image for the Flux Kontext example fails with `error unescaping string: UnrecognizedEscape: unrecognized escape sequence` ([#1264](https://github.com/modal-labs/modal-examples/issues/1264)).

The cause is [`image_to_image.py`](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/stable_diffusion/image_to_image.py) defining `CACHE_DIR = Path("/cache")` and baking `str(CACHE_DIR)` into the image env. On Windows that is a `WindowsPath`, and `str()` of it is `\cache`, so the client emits the Dockerfile directive `ENV HF_HOME='\cache'` (`Image.env` in [`modal/_image.py`](https://github.com/modal-labs/modal-client/blob/main/modal/_image.py) builds `ENV {key}={shlex.quote(val)}`), and the build server's Dockerfile parser rejects `\c` as an unrecognized escape. The volume mount key (`volumes={CACHE_DIR: cache_volume}`) is not the live problem: the client normalizes mount keys with `PurePath(path).as_posix()` in [`modal/_utils/mount_utils.py`](https://github.com/modal-labs/modal-client/blob/main/modal/_utils/mount_utils.py), which turns `WindowsPath('/cache')` back into `/cache`. Only the env var carries the backslash through.

One-line repro on any Windows machine: `python -c "from pathlib import Path; print(str(Path('/cache')))"` prints `\cache`.

The fix makes `CACHE_DIR` a plain string, matching the sibling [`text_to_image.py`](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/stable_diffusion/text_to_image.py), which already uses `CACHE_DIR = "/cache"`. I verified on Windows 11 with modal 1.5.2 by importing the example and capturing what reaches `Image.env`:

```
# before (current main)
dict passed to .env()  = {'HF_XET_HIGH_PERFORMANCE': '1', 'HF_HOME': '\\cache'}
baked directive        = ENV HF_HOME='\cache'

# after (this PR)
dict passed to .env()  = {'HF_XET_HIGH_PERFORMANCE': '1', 'HF_HOME': '/cache'}
baked directive        = ENV HF_HOME=/cache
```

I did not run a full `modal run` build for this change; the evidence above is the captured env directive. victor-numair [confirmed in the thread](https://github.com/modal-labs/modal-examples/issues/1264#issuecomment-3663674146) that switching `CACHE_DIR` to a plain string fixes the build on Windows 11 (his writeup points at the volume key, but the variable he changed is the same one that feeds the env var). [Dragoy](https://github.com/modal-labs/modal-examples/issues/1264#issuecomment-3129091244) and [skfrost19](https://github.com/modal-labs/modal-examples/issues/1264#issuecomment-3218161725) hit the same failure.

A few other examples bake `str(Path("/..."))` into `.env` the same way and will fail the same way on Windows: [`misc/flux_endpoint.py`](https://github.com/modal-labs/modal-examples/blob/main/misc/flux_endpoint.py), [`06_gpu_and_ml/protein-folding/esmfold2.py`](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/protein-folding/esmfold2.py), and [`06_gpu_and_ml/protein-folding/chai1.py`](https://github.com/modal-labs/modal-examples/blob/main/06_gpu_and_ml/protein-folding/chai1.py). I left those for a follow-up to keep this diff small.

The docs page https://modal.com/docs/examples/image_to_image is generated from this file, so it picks up the fix too.

`ruff check` and `ruff format --check` pass on the changed file (ruff 0.9.6, the version pinned in CI).

Fixes [#1264](https://github.com/modal-labs/modal-examples/issues/1264).

## Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

## Outside Contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->