### PR TITLE
fix: GPU snapshot volume reload in LFM and vLLM examples

### DIFF
--- a/06_gpu_and_ml/llm-serving/lfm_snapshot.py
+++ b/06_gpu_and_ml/llm-serving/lfm_snapshot.py
@@ -334,6 +334,7 @@ class LfmVllmInference:
         # Persist cached weights and vLLM compilation artifacts before GPU snapshot.
         hf_cache_vol.commit()
         vllm_cache_vol.commit()
+        hf_cache_vol.commit()
 
     @modal.enter(snap=False)
     def restore(self):

--- a/06_gpu_and_ml/llm-serving/lfm_snapshot.py
+++ b/06_gpu_and_ml/llm-serving/lfm_snapshot.py
@@ -334,7 +334,6 @@ class LfmVllmInference:
         # Persist cached weights and vLLM compilation artifacts before GPU snapshot.
         hf_cache_vol.commit()
         vllm_cache_vol.commit()
-        hf_cache_vol.commit()
 
     @modal.enter(snap=False)
     def restore(self):

--- a/06_gpu_and_ml/llm-serving/lfm_snapshot.py
+++ b/06_gpu_and_ml/llm-serving/lfm_snapshot.py
@@ -71,6 +71,9 @@ vllm_image = (
             "VLLM_SERVER_DEV_MODE": "1",
             "TORCH_CPP_LOG_LEVEL": "FATAL",
             "MODEL_NAME": MODEL_NAME,
+            # Stabilize NCCL after GPU snapshot restore (modal-examples#1558).
+            "NCCL_ASYNC_ERROR_HANDLING": "1",
+            "TORCH_NCCL_BLOCKING_WAIT": "1",
         }
     )
 )
@@ -328,10 +331,17 @@ class LfmVllmInference:
         warmup()
         sleep(level=1)
 
+        # Persist vLLM compilation artifacts before GPU snapshot (modal-examples#1558).
+        vllm_cache_vol.commit()
+
     @modal.enter(snap=False)
     def restore(self):
         """Wake vLLM from sleep mode after restoring from a memory snapshot."""
+        # Refresh 9p Volume metadata after GPU memory snapshot restore.
+        hf_cache_vol.reload()
+        vllm_cache_vol.reload()
         wake_up()
+        wait_ready(self.process)
 
     @modal.exit()
     def stop(self):

--- a/06_gpu_and_ml/llm-serving/lfm_snapshot.py
+++ b/06_gpu_and_ml/llm-serving/lfm_snapshot.py
@@ -331,7 +331,8 @@ class LfmVllmInference:
         warmup()
         sleep(level=1)
 
-        # Persist vLLM compilation artifacts before GPU snapshot (modal-examples#1558).
+        # Persist cached weights and vLLM compilation artifacts before GPU snapshot.
+        hf_cache_vol.commit()
         vllm_cache_vol.commit()
 
     @modal.enter(snap=False)

--- a/06_gpu_and_ml/llm-serving/vllm_low_latency.py
+++ b/06_gpu_and_ml/llm-serving/vllm_low_latency.py
@@ -87,7 +87,13 @@ MODEL_PATH = f"{HF_CACHE_PATH}/{MODEL_NAME}"
 # which can fully saturate our network bandwidth.
 
 vllm_image = vllm_image.env(
-    {"HF_HUB_CACHE": HF_CACHE_PATH, "HF_XET_HIGH_PERFORMANCE": "1"}
+    {
+        "HF_HUB_CACHE": HF_CACHE_PATH,
+        "HF_XET_HIGH_PERFORMANCE": "1",
+        # Stabilize NCCL after GPU snapshot restore (modal-examples#1558).
+        "NCCL_ASYNC_ERROR_HANDLING": "1",
+        "TORCH_NCCL_BLOCKING_WAIT": "1",
+    }
 )
 
 # ## Define the inference server and infrastructure
@@ -287,10 +293,15 @@ class VLLM:
         warmup()
         sleep(1)
 
+        # Persist cached model weights before GPU snapshot (modal-examples#1558).
+        HF_CACHE_VOL.commit()
+
     @modal.enter(snap=False)
     def restore(self):
         """Wake vLLM from sleep mode after restoring from a memory snapshot."""
+        HF_CACHE_VOL.reload()
         wake_up()
+        wait_ready(self.process)
 
     @modal.exit()
     def stop(self):


### PR DESCRIPTION
## Summary
Apply the #1558 GPU snapshot guardrails to two more vLLM snapshot examples:

- **`lfm_snapshot.py`**: NCCL env vars, `vllm_cache_vol.commit()` before snapshot, `hf_cache_vol.reload()` + `vllm_cache_vol.reload()` + `wait_ready()` after wake
- **`vllm_low_latency.py`**: same pattern for HF cache volume

Related to #1558.

## Test plan
- [ ] `modal deploy lfm_snapshot.py` — cold start + snapshot restore
- [ ] `modal deploy vllm_low_latency.py` — cold start + snapshot restore
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->