### PR TITLE
load the LoRA from the mounted bucket instead of re-downloading it from the hub

### DIFF
--- a/10_integrations/cloud_bucket_mount_loras.py
+++ b/10_integrations/cloud_bucket_mount_loras.py
@@ -193,7 +193,7 @@ class StableDiffusionLoRA:
         self, lora_id: str, prompt: str, seed: int = 8888
     ) -> bytes:
         for file in (LORAS_PATH / lora_id).rglob("*.safetensors"):
-            self.pipe.load_lora_weights(lora_id, weight_name=file.name)
+            self.pipe.load_lora_weights(file, weight_name=file.name)
             break
 
         lora_scale = 0.9


### PR DESCRIPTION
The cloud bucket mount LoRAs example downloads each LoRA into the S3 bucket, then at inference time loads it with `self.pipe.load_lora_weights(lora_id, weight_name=file.name)`. The first argument is `lora_id`, the Hugging Face repo id, so diffusers resolves the weights from the Hub and downloads them a second time into `HF_HUB_CACHE` instead of using the copy already sitting in the mounted bucket. That defeats the point of the example, which is to serve LoRAs from S3 ("we load whichever LoRA the user specifies from the S3 bucket").

`file` is the local path to the `.safetensors` file inside the mount, found by the `rglob` on the line above. Passing it as the first argument makes diffusers load straight from disk. Traced through the pinned `diffusers==0.26.3`: `load_lora_weights` calls `lora_state_dict` calls `_get_model_file`, where `os.path.isfile(path)` is true for the mount file and the path is returned directly (`hub_utils.py`), so no Hub download happens. `weight_name=file.name` is redundant in that branch but harmless, so I kept the change to the single argument.

Fixes #1106.

`ruff check` and `ruff format --check` pass on the file (ruff 0.9.6, the version pinned in CI).

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->