### PR TITLE
Add DPO alignment example (dpo_trl.py)

### DIFF
--- a/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
@@ -1,0 +1,144 @@
+# ---
+# cmd: ["modal", "run", "06_gpu_and_ml/reinforcement-learning/dpo_trl.py::train"]
+# ---
+
+# # Align a model with human preferences using DPO and TRL
+
+# This example demonstrates how to align a language model with
+# [Direct Preference Optimization](https://arxiv.org/abs/2305.18290) (DPO) on
+# Modal using the TRL [`DPOTrainer`](https://huggingface.co/docs/trl/main/en/dpo_trainer).
+
+# DPO is an alternative to reinforcement learning algorithms like
+# [GRPO](https://arxiv.org/pdf/2402.03300) and PPO for aligning models with human
+# preferences. Rather than sampling rollouts, scoring them with a reward function,
+# and updating the policy through an RL loop (as in the
+# [GRPO example](https://modal.com/docs/examples/grpo_trl)), DPO optimizes directly
+# on a static dataset of `(prompt, chosen, rejected)` triples using a closed-form
+# loss derived from the same RLHF objective. This makes DPO simpler to implement,
+# cheaper to train, and a good fit for cases where you already have — or can
+# collect — pairwise preference data instead of a programmatic reward function.
+
+# ## Setup
+
+# Import the necessary modules for Modal deployment.
+from pathlib import Path
+
+import modal
+
+MINUTES = 60  # seconds
+
+# ## Defining the image and app
+
+app = modal.App("example-dpo-trl")
+
+# We define an image with TRL, a LoRA-compatible `peft`, and their dependencies.
+# Following the [pinning conventions](https://modal.com/docs/guide/images) for this
+# repo, every container dependency is pinned to at least a SemVer minor version.
+
+image = modal.Image.debian_slim(python_version="3.11").uv_pip_install(
+    "torch==2.7.0",
+    "transformers==4.57",
+    "trl==0.28.0",
+    "peft==0.15.2",
+    "datasets==3.5.1",
+    "accelerate==1.6.0",
+    "huggingface-hub==0.36.0",
+)
+
+with image.imports():
+    from datasets import load_dataset
+    from peft import LoraConfig
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from trl import DPOConfig, DPOTrainer
+
+# ## Caching weights and checkpoints
+
+# We use [Modal Volumes](https://modal.com/docs/guide/volumes) to cache downloaded
+# base model weights and to persist the trained LoRA checkpoints, so that repeat
+# runs don't need to redownload or lose progress.
+
+MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
+MODEL_REVISION = "7ae557604adf67be50417f59c2c2f167def9a775"  # pin to avoid surprises!
+
+MODELS_DIR = Path("/models")
+hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
+checkpoints_volume = modal.Volume.from_name(
+    "example-dpo-trl-checkpoints", create_if_missing=True
+)
+
+# ## Preference dataset
+
+# We use [`trl-lib/ultrafeedback_binarized`](https://huggingface.co/datasets/trl-lib/ultrafeedback_binarized),
+# a preprocessed, ready-to-train version of the UltraFeedback preference dataset.
+# It has `chosen` and `rejected` columns, each a full conversation (a list of
+# `{role, content}` turns) that share the same leading user turn but end with a
+# different assistant response. `DPOTrainer` accepts this "implicit prompt" format
+# directly, automatically splitting off the shared prefix as the prompt, so no
+# further preprocessing is required.
+
+
+def load_preference_dataset(max_examples: int):
+    dataset = load_dataset("trl-lib/ultrafeedback_binarized", split="train")
+    if max_examples > 0:
+        dataset = dataset.select(range(min(max_examples, len(dataset))))
+    return dataset
+
+
+# ## Kicking off a training run
+
+# We attach a LoRA adapter rather than fine-tuning the full model, following the
+# same efficiency motivation as the
+# [Unsloth finetuning example](https://modal.com/docs/examples/unsloth_finetune):
+# only a small fraction of parameters need gradients, which keeps this example
+# runnable on a single GPU.
+
+
+@app.function(
+    image=image,
+    gpu="L40S",
+    timeout=60 * MINUTES,
+    volumes={"/root/.cache/huggingface": hf_cache_vol, MODELS_DIR: checkpoints_volume},
+)
+def train(max_steps: int = 5, max_examples: int = 256) -> None:  # increase both!
+    model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, revision=MODEL_REVISION)
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, revision=MODEL_REVISION)
+
+    train_dataset = load_preference_dataset(max_examples)
+
+    peft_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        lora_dropout=0.05,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        task_type="CAUSAL_LM",
+    )
+
+    training_args = DPOConfig(
+        output_dir=str(MODELS_DIR / "dpo-qwen2.5-0.5b"),
+        max_steps=max_steps,  # to simplify testing; remove for production use cases
+        per_device_train_batch_size=4,
+        gradient_accumulation_steps=4,
+        learning_rate=5e-5,
+        beta=0.1,  # controls how far the trained model may drift from the reference
+        save_steps=max_steps,
+        logging_steps=1,
+        bf16=True,
+    )
+
+    trainer = DPOTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        processing_class=tokenizer,
+        peft_config=peft_config,
+    )
+    trainer.train()
+    trainer.save_model()
+    checkpoints_volume.commit()
+
+
+# To run: `modal run --detach dpo_trl.py::train --max-steps 500 --max-examples 0`
+# (`--max-examples 0` uses the full dataset). The saved LoRA adapter can then be
+# loaded for inference the same way as in the
+# [Unsloth finetuning example](https://modal.com/docs/examples/unsloth_finetune), or
+# served with a [vLLM inference endpoint](https://modal.com/docs/examples/vllm_inference).

--- a/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
@@ -35,15 +35,19 @@ app = modal.App("example-dpo-trl")
 # Following the [pinning conventions](https://modal.com/docs/guide/images) for this
 # repo, every container dependency is pinned to at least a SemVer minor version.
 
-image = modal.Image.debian_slim(python_version="3.11").uv_pip_install(
-    "torch==2.7.0",
-    "transformers==4.57.1",  # 4.57.0 is yanked from PyPI
-    "trl==0.28.0",
-    "peft==0.15.2",
-    "datasets==3.5.1",
-    "accelerate==1.6.0",
-    "huggingface-hub==0.36.0",
-).env({"HF_XET_HIGH_PERFORMANCE": "1"})  # faster downloads
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .uv_pip_install(
+        "torch==2.7.0",
+        "transformers==4.57.1",  # 4.57.0 is yanked from PyPI
+        "trl==0.28.0",
+        "peft==0.15.2",
+        "datasets==3.5.1",
+        "accelerate==1.6.0",
+        "huggingface-hub==0.36.0",
+    )
+    .env({"HF_XET_HIGH_PERFORMANCE": "1"})  # faster downloads
+)
 
 with image.imports():
     from datasets import load_dataset

--- a/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
@@ -37,7 +37,7 @@ app = modal.App("example-dpo-trl")
 
 image = modal.Image.debian_slim(python_version="3.11").uv_pip_install(
     "torch==2.7.0",
-    "transformers==4.57",
+    "transformers==4.57.1",  # 4.57.0 is yanked from PyPI
     "trl==0.28.0",
     "peft==0.15.2",
     "datasets==3.5.1",

--- a/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
+++ b/06_gpu_and_ml/reinforcement-learning/dpo_trl.py
@@ -43,7 +43,7 @@ image = modal.Image.debian_slim(python_version="3.11").uv_pip_install(
     "datasets==3.5.1",
     "accelerate==1.6.0",
     "huggingface-hub==0.36.0",
-)
+).env({"HF_XET_HIGH_PERFORMANCE": "1"})  # faster downloads
 
 with image.imports():
     from datasets import load_dataset


### PR DESCRIPTION
## Summary

Adds `06_gpu_and_ml/reinforcement-learning/dpo_trl.py`, a new example that fills a gap in the existing reinforcement-learning coverage: the folder currently has `grpo_trl.py` (code, TRL), `grpo_verl.py` (math, verl), and `learn_math.py` (math, `verifiers` + sandboxed execution) — all GRPO-based rollout/reward-function training. There's no example for **Direct Preference Optimization** (DPO), which trains directly on static `(chosen, rejected)` preference pairs instead of sampling rollouts through an RL loop — simpler, cheaper, and a good fit when you already have preference data rather than a programmatic reward function.

- Trains a LoRA adapter on `Qwen/Qwen2.5-0.5B-Instruct` against [`trl-lib/ultrafeedback_binarized`](https://huggingface.co/datasets/trl-lib/ultrafeedback_binarized) using TRL's `DPOTrainer`.
- Follows the existing `grpo_trl.py` conventions in this folder: pinned container deps, an HF cache Volume + checkpoint Volume, `max_steps=5` default to keep CI fast (`args`/`cmd` frontmatter unnecessary since the function default is already CI-sized), literate-programming prose.
- The model revision hash was pulled from the live HF API rather than guessed. The dataset's actual schema (`chosen`/`rejected` as full conversations sharing a prefix — the "implicit prompt" format, no separate `prompt` column) was verified against `datasets-server` rather than assumed from memory, and the prose was written to describe that accurately.
- `DPOConfig`/`DPOTrainer` keyword arguments (`beta`, `processing_class`, `peft_config`, etc.) were verified against a real `trl==0.28.0` install rather than assumed.

## Monitoring Checklist

- [x] Example is tested by executing with `modal run` (`cmd` in frontmatter targets `::train`)
- [x] Example runs with no arguments (defaults to `max_steps=5`, `max_examples=256` — small enough for CI)
- [x] No third-party local dependencies beyond `modal` (all deps installed inside the container image only)

## Build Stability Checklist

- [x] All container dependencies pinned to at least SemVer minor (`torch==2.7.0`, `trl==0.28.0`, etc.)
- [x] No `latest` tags used
- [x] `python_version="3.11"` specified on the base image
- [x] `ruff check` and `ruff format` pass

## Test plan

- [x] `ruff check` / `ruff format --check` — pass
- [x] `python -m py_compile` — passes
- [x] `DPOConfig`/`DPOTrainer`/dataset-schema assumptions verified against real `trl==0.28.0` install + live HF API (not just written from memory)
- [ ] Full `modal run` execution (requires Modal auth I don't have configured locally — this repo's CI runs changed examples automatically on PRs, so happy to have that be the live verification, or for a maintainer to run it)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->