### PR TITLE
Add pipeline orchestrator example

### DIFF
--- a/09_job_queues/pipeline_orchestration.py
+++ b/09_job_queues/pipeline_orchestration.py
@@ -43,6 +43,7 @@ import modal
 
 APP_NAME = "example-pipeline-orchestration"
 DATA_DIR = Path("/data")
+MINUTES = 60  # seconds
 
 app = modal.App(APP_NAME)
 image = modal.Image.debian_slim(python_version="3.12").pip_install("numpy==2.2.6")
@@ -251,7 +252,7 @@ def trigger(n: int) -> str:
     return pipeline.run_id
 
 
-def wait(run_id: str, timeout: int = 60) -> Pipeline:
+def wait(run_id: str, timeout: int = 5 * MINUTES) -> Pipeline:
     """Poll `state` until the last step marks the run done."""
     deadline = time.time() + timeout
     while time.time() < deadline:

--- a/09_job_queues/pipeline_orchestration.py
+++ b/09_job_queues/pipeline_orchestration.py
@@ -1,0 +1,266 @@
+# # Orchestrate a multi-step pipeline with Modal Functions
+
+# Every step of this pipeline is a Modal Function that hands off to the next one,
+# so no external orchestrator is needed. A step looks up its successor by name
+# with [`Function.from_name`](https://modal.com/docs/guide/trigger-deployed-functions)
+# and starts it with `Function.spawn`.
+
+# The toy computation is: build a range of numbers, square them, sum them. Each
+# step caches its output on a Volume, so a rerun skips work already done.
+
+# First, deploy the App:
+
+# ```bash
+# modal deploy pipeline_orchestration.py
+# ```
+
+# Then trigger a run and see its trace:
+
+# ```bash
+# modal run pipeline_orchestration.py --n 10
+# ```
+
+# Run that again with the same `n` and every step hits the cache. Edit a step and
+# deploy again and they all recompute.
+
+import hashlib
+import io
+import json
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import NamedTuple
+
+import modal
+
+APP_NAME = "example-pipeline-orchestration"
+DATA_DIR = Path("/data")
+
+app = modal.App(APP_NAME)
+image = modal.Image.debian_slim().pip_install("numpy")
+
+with image.imports():
+    import numpy as np
+
+# A [Dict](https://modal.com/docs/guide/dicts-and-queues) holds each run's trace and a
+# [Volume](https://modal.com/docs/guide/volumes) holds the input and the artifacts
+# steps pass along.
+
+state = modal.Dict.from_name(f"{APP_NAME}-state", create_if_missing=True)
+data = modal.Volume.from_name(f"{APP_NAME}-data", create_if_missing=True)
+
+# Each step is a Function and its outputted artifact.
+
+
+class Step(NamedTuple):
+    name: str  # the Function that runs it
+    output: str  # the artifact it leaves under its key
+
+
+STEPS = [
+    Step("build", "numbers.npy"),
+    Step("square", "squared.npy"),
+    Step("total", "total.json"),
+]
+
+
+@dataclass
+class Pipeline:
+    run_id: str  # unique per execution
+    app_version: int  # deployed code version this run is pinned to
+    input_id: str  # identifies the input, names its directory on the Volume
+    function_call_ids: list[str] = field(default_factory=list)  # `fc-`, per step
+    done: bool = False  # set by the last step; `wait` polls for it
+
+
+# ## Key each artifact by the code and inputs that made it
+
+# A step skips work whose output is already on the Volume, so the key naming that
+# output has to move whenever the output would. Two ingredients move it:
+
+# - The App version, which a deploy bumps whenever the code changes. Keying on the
+# pipeline's input alone would serve a stale artifact after you edit a step.
+# - The step's own inputs, folded in as its predecessor's key rather than as the
+# pipeline's input. Two pipelines that both run `square` on different arrays would
+# otherwise share a key like `n-10` and read each other's work.
+
+# Both enter once, at the seed: every link folds in a predecessor key that already
+# carries them, so a new source step would have to seed the version itself.
+
+
+def cache_key(pipeline: Pipeline, step_num: int) -> str:
+    """Content-address a step's output: same code and inputs, same key."""
+    key = f"{pipeline.input_id}@v{pipeline.app_version}"  # the version seeds the chain
+    for step in STEPS[: step_num + 1]:
+        digest = hashlib.sha256(f"{step.name}/{key}".encode()).hexdigest()
+        key = f"{step.name}-{digest[:16]}"
+    return key
+
+
+def artifact(pipeline: Pipeline, step_num: int) -> Path:
+    """Where the given step keeps its output, under its key on the Volume."""
+    return DATA_DIR / cache_key(pipeline, step_num) / STEPS[step_num].output
+
+
+# ## Hand off from one step to the next
+
+# Each step stamps its call id onto the run so the trace builds up as the pipeline
+# moves, then hands off. Every hand-off, including the driver's, goes through the
+# one pinned lookup below.
+
+
+def start_step(pipeline: Pipeline, step_num: int) -> Path:
+    """Record the running step on the pipeline and return its output path."""
+    data.reload()  # a container only sees the Volume as of when it started
+    pipeline.function_call_ids.append(modal.current_function_call_id())
+    state[pipeline.run_id] = pipeline
+
+    out = artifact(pipeline, step_num)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    status = "cached" if out.exists() else "computing"
+    print(f"[{STEPS[step_num].name}] {status} {out.name}")
+    return out
+
+
+def spawn_step(pipeline: Pipeline, step_num: int) -> modal.FunctionCall:
+    """Start a step on the App version this run is pinned to."""
+    step = modal.Function.from_name(
+        APP_NAME, STEPS[step_num].name, version=pipeline.app_version
+    )
+    return step.spawn(pipeline, step_num)
+
+
+def spawn_next(pipeline: Pipeline, step_num: int) -> None:
+    """Hand off to the following step, or mark the pipeline finished."""
+    if step_num + 1 >= len(STEPS):
+        pipeline.done = True
+        state[pipeline.run_id] = pipeline
+        print("[done]")
+        return
+
+    spawn_step(pipeline, step_num + 1)
+
+
+# ## Write the steps
+
+# Every step has the same shape: start the step, do the work, spawn the next. The
+# commit has to land before the hand-off, since the next step starts before this
+# container shuts down and triggers Modal's automatic commit.
+
+# Note that [background commits](https://modal.com/docs/guide/volumes#background-commits)
+# land every few seconds, so a step that dies mid-write leaves a partial artifact
+# that a later run would read as a hit. Production pipelines switch on a temporary
+# path or a marker file so a key only appears once its artifact is whole.
+
+
+@app.function(image=image, volumes={DATA_DIR: data})
+def build(pipeline: Pipeline, step_num: int) -> None:
+    """Materialize the input range from the input staged on the Volume."""
+    out = start_step(pipeline, step_num)
+    if not out.exists():
+        with open(DATA_DIR / pipeline.input_id / "input.json") as f:
+            n = json.load(f)["n"]
+        np.save(out, np.arange(1, n + 1))
+        data.commit()
+    spawn_next(pipeline, step_num)
+
+
+@app.function(image=image, volumes={DATA_DIR: data})
+def square(pipeline: Pipeline, step_num: int) -> None:
+    """Square every element of the previous step's array."""
+    out = start_step(pipeline, step_num)
+    if not out.exists():
+        numbers = np.load(artifact(pipeline, step_num - 1))
+        np.save(out, numbers**2)
+        data.commit()
+    spawn_next(pipeline, step_num)
+
+
+@app.function(image=image, volumes={DATA_DIR: data})
+def total(pipeline: Pipeline, step_num: int) -> None:
+    """Reduce to the final result, small enough to hand back as JSON."""
+    out = start_step(pipeline, step_num)
+    if not out.exists():
+        # Reaches back past `square` to also read what `build` wrote, by key.
+        squared = np.load(artifact(pipeline, step_num - 1))
+        numbers = np.load(artifact(pipeline, 0))
+        with open(out, "w") as f:
+            json.dump({"total": int(squared.sum()), "count": numbers.size}, f)
+        data.commit()
+    spawn_next(pipeline, step_num)
+
+
+# ## Trigger a run from a local driver
+
+# The driver reads the app version off the CLI and hands it to the run.
+# Pinning lookups to a version is a [Team and Enterprise feature](https://modal.com/docs/guide/trigger-deployed-functions#version-pinned-lookups).
+
+
+def deployed_version() -> int:
+    """Read the App's live version, the code version this run pins to."""
+    history = subprocess.run(
+        ["modal", "app", "history", APP_NAME, "--json"], capture_output=True, text=True
+    )
+    if history.returncode != 0:
+        raise RuntimeError(f"deploy the app first: modal deploy {Path(__file__).name}")
+    versions = json.loads(history.stdout)
+    return max(int(v["version"].removeprefix("v")) for v in versions)
+
+
+def stage_input(n: int) -> str:
+    """Put the input on the Volume under an id, unless it's already staged."""
+    input_id = f"n-{n}"
+    try:
+        data.listdir(f"{input_id}/input.json")
+    except modal.exception.NotFoundError:
+        with data.batch_upload() as batch:
+            blob = io.BytesIO(json.dumps({"n": n}).encode())
+            batch.put_file(blob, f"{input_id}/input.json")
+    return input_id
+
+
+def trigger(n: int) -> str:
+    """Stage the input, then start the first step on a pinned App version."""
+    pipeline = Pipeline(
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        app_version=deployed_version(),
+        input_id=stage_input(n),
+    )
+    state[pipeline.run_id] = pipeline
+
+    call = spawn_step(pipeline, 0)
+    print(f"Started {pipeline.run_id} on v{pipeline.app_version}: {call.object_id}")
+    return pipeline.run_id
+
+
+def wait(run_id: str, timeout: int = 60) -> Pipeline:
+    """Poll `state` until the last step marks the run done."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        pipeline = state.get(run_id)
+        if pipeline is not None and pipeline.done:
+            return pipeline
+        time.sleep(1)
+    raise TimeoutError(f"{run_id} did not finish in {timeout}s")
+
+
+# The trace prints each step's key, so a rerun of the same input on the same code
+# shows the same keys — those are the artifacts it reused.
+
+
+def report(pipeline: Pipeline) -> None:
+    """Print the run's trace, then pull just the final result off the Volume."""
+    print(f"\n{pipeline.run_id} finished on v{pipeline.app_version}:")
+    for step_num, call_id in enumerate(pipeline.function_call_ids):
+        print(f"  {cache_key(pipeline, step_num)}  function_call={call_id}")
+    final_key = cache_key(pipeline, len(STEPS) - 1)
+    result = json.loads(b"".join(data.read_file(f"{final_key}/{STEPS[-1].output}")))
+    print(f"  result: sum of {result['count']} squares = {result['total']}\n")
+
+
+@app.local_entrypoint()
+def run(n: int = 10) -> None:
+    """Run the pipeline end to end against the deployed App."""
+    report(wait(trigger(n)))

--- a/09_job_queues/pipeline_orchestration.py
+++ b/09_job_queues/pipeline_orchestration.py
@@ -1,3 +1,7 @@
+# ---
+# deploy: true
+# ---
+
 # # Orchestrate a multi-step pipeline with Modal Functions
 
 # Every step of this pipeline is a Modal Function that hands off to the next one,
@@ -8,16 +12,18 @@
 # The toy computation is: build a range of numbers, square them, sum them. Each
 # step caches its output on a Volume, so a rerun skips work already done.
 
-# First, deploy the App:
-
-# ```bash
-# modal deploy pipeline_orchestration.py
-# ```
-
-# Then trigger a run and see its trace:
+# Run it and see its trace:
 
 # ```bash
 # modal run pipeline_orchestration.py --n 10
+# ```
+
+# Because the steps hand off by name against a pinned version, the App has to be
+# deployed before it runs. The entrypoint deploys it for you if it isn't already,
+# but you can also deploy explicitly:
+
+# ```bash
+# modal deploy pipeline_orchestration.py
 # ```
 
 # Run that again with the same `n` and every step hits the cache. Edit a step and
@@ -39,7 +45,7 @@ APP_NAME = "example-pipeline-orchestration"
 DATA_DIR = Path("/data")
 
 app = modal.App(APP_NAME)
-image = modal.Image.debian_slim().pip_install("numpy")
+image = modal.Image.debian_slim(python_version="3.12").pip_install("numpy==2.2.6")
 
 with image.imports():
     import numpy as np
@@ -194,8 +200,8 @@ def total(pipeline: Pipeline, step_num: int) -> None:
 
 # ## Trigger a run from a local driver
 
-# The driver reads the app version off the CLI and hands it to the run.
-# Pinning lookups to a version is a [Team and Enterprise feature](https://modal.com/docs/guide/trigger-deployed-functions#version-pinned-lookups).
+# The driver deploys the App if needed, reads its live version, and pins the run
+# to it. Pinning lookups to a version is a [Team and Enterprise feature](https://modal.com/docs/guide/trigger-deployed-functions#version-pinned-lookups).
 
 
 def deployed_version() -> int:
@@ -203,18 +209,28 @@ def deployed_version() -> int:
     history = subprocess.run(
         ["modal", "app", "history", APP_NAME, "--json"], capture_output=True, text=True
     )
-    if history.returncode != 0:
+    versions = json.loads(history.stdout) if history.returncode == 0 else []
+    if not versions:
         raise RuntimeError(f"deploy the app first: modal deploy {Path(__file__).name}")
-    versions = json.loads(history.stdout)
     return max(int(v["version"].removeprefix("v")) for v in versions)
+
+
+def ensure_deployed() -> None:
+    """Deploy the App if it isn't already, so a bare `modal run` works."""
+    try:
+        deployed_version()
+    except RuntimeError:
+        subprocess.run(["modal", "deploy", __file__], check=True)
 
 
 def stage_input(n: int) -> str:
     """Put the input on the Volume under an id, unless it's already staged."""
     input_id = f"n-{n}"
     try:
-        data.listdir(f"{input_id}/input.json")
-    except modal.exception.NotFoundError:
+        staged = bool(data.listdir(f"{input_id}/input.json"))
+    except (FileNotFoundError, modal.exception.NotFoundError):
+        staged = False
+    if not staged:
         with data.batch_upload() as batch:
             blob = io.BytesIO(json.dumps({"n": n}).encode())
             batch.put_file(blob, f"{input_id}/input.json")
@@ -263,4 +279,5 @@ def report(pipeline: Pipeline) -> None:
 @app.local_entrypoint()
 def run(n: int = 10) -> None:
     """Run the pipeline end to end against the deployed App."""
+    ensure_deployed()
     report(wait(trigger(n)))


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Modal-native orchestration of pipeline steps by chaining Function calls. Each Modal Function spawns the next step with `Function.from_name` + `Function.spawn`. The steps in this example are 1. build a range, 2. square it, 3. sum it.

Includes caching, keyed by the input id, the App version, and the ordered step names up to and including that step.

Notes this example uses [versioned functions](https://modal.com/docs/guide/trigger-deployed-functions#version-pinned-lookups), which is a Team/Enterprise feature. The purpose is to invalidate the hash if the function was updated.

Output:
```
Started run-ab8a09954149 on v15: fc-01KYSS57036V530RMX4Z1ZB6EX

run-ab8a09954149 finished on v15:
  build-3b88a031b74b5d8d  function_call=fc-01KYSS57036V530RMX4Z1ZB6EX task=ta-01KYSS4NAJJ806HVFAS0HNDZ6R
  square-05950c933efe9d1a  function_call=fc-01KYSS57K1AP1GMX32PW6DYDBW task=ta-01KYSS4SN1V2HDWC4D6JHRDGNR
  total-c7c7de5dbaa6aa72  function_call=fc-01KYSS582PJ5FTV270AY8878P2 task=ta-01KYSS4XQ56ZP1G65ZHVT0A0GR
  result: sum of 10 squares = 385
```

## Type of Change

<!--
  ☑️ Check one of the top-level boxes and delete the others.
-->

- [X] New example for the GitHub repo
  - [ ] New example for the documentation site (Linked from a discoverable page, e.g. via the sidebar in `/docs/examples`)
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (Changes to the codebase, but not to examples)

## Monitoring Checklist

<!--
  ☑️ All examples added to numbered folders in the repo should pass this checklist.
  Otherwise, move the file into `misc/` and delete the checklist.

  See `internal/README.md` for details on the CI.
-->

  - [X] Example is configured for testing in the synthetic monitoring system, or `lambda-test: false` is provided in the example frontmatter and I have gotten approval from a maintainer
    - [X] Example is tested by executing with `modal run`, or an alternative `cmd` is provided in the example frontmatter (e.g. `cmd: ["modal", "serve"]`)
    - [X] Example is tested by running the `cmd` with no arguments, or the `args` are provided in the example frontmatter (e.g. `args: ["--prompt", "Formula for room temperature superconductor:"]`
    - [X] Example does _not_ require third-party dependencies besides `fastapi` to be installed locally (e.g. does not import `requests` or `torch` in the global scope or other code executed locally)

## Documentation Site Checklist

<!--
  ☑️ Review the checklist below if the example is intended for the documentation site.
  All boxes should be checked!
-->

### Content
  - [X] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style
  - [X] All media assets for the example that are rendered in the documentation site page are retrieved from `modal-cdn.com`

### Build Stability
  - [X] Example pins all dependencies in container images
    - [X] Example pins container images to a stable tag like `v1`, not a dynamic tag like `latest`
    - [X] Example specifies a `python_version` for the base image, if it is used 
    - [X] Example pins all dependencies to at least [SemVer](https://semver.org/) minor version, `~=x.y.z` or `==x.y`, or we expect this example to work across major versions of the dependency and are committed to maintenance across those versions
      - [X] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

## Outside Contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/modal-examples/pull/1624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->